### PR TITLE
Generate appendix anchors consistent with URL fragments generated for references

### DIFF
--- a/cli/tests/valid/docfile.py36.html
+++ b/cli/tests/valid/docfile.py36.html
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">May 2021</td>
+<td class="right">June 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>

--- a/cli/tests/valid/docfile.py36.html
+++ b/cli/tests/valid/docfile.py36.html
@@ -302,51 +302,51 @@
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-references-2" class="xref">References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-relax-ng-schema" class="xref">RELAX NG Schema</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-relax-ng-schema" class="xref">RELAX NG Schema</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-xml2rfc-command-line-option" class="xref"><code>xml2rfc</code> Command-line Options</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-xml2rfc-command-line-option" class="xref"><code>xml2rfc</code> Command-line Options</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-positional-arguments" class="xref">Positional arguments</a></p>
+                <p id="section-toc.1-1.6.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-positional-arguments" class="xref">Positional arguments</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-documentation-options" class="xref">Documentation options</a></p>
+                <p id="section-toc.1-1.6.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-documentation-options" class="xref">Documentation options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.3">
-                <p id="section-toc.1-1.6.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-format-selection" class="xref">Format selection</a></p>
+                <p id="section-toc.1-1.6.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-format-selection" class="xref">Format selection</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.4">
-                <p id="section-toc.1-1.6.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-generic-switch-options" class="xref">Generic Switch Options</a></p>
+                <p id="section-toc.1-1.6.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-generic-switch-options" class="xref">Generic Switch Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.5">
-                <p id="section-toc.1-1.6.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-generic-options-with-values" class="xref">Generic Options with Values</a></p>
+                <p id="section-toc.1-1.6.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-generic-options-with-values" class="xref">Generic Options with Values</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.6">
-                <p id="section-toc.1-1.6.2.6.1"><a href="#section-b.6" class="xref">B.6</a>.  <a href="#name-generic-format-options" class="xref">Generic Format Options</a></p>
+                <p id="section-toc.1-1.6.2.6.1"><a href="#appendix-B.6" class="xref">B.6</a>.  <a href="#name-generic-format-options" class="xref">Generic Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.7">
-                <p id="section-toc.1-1.6.2.7.1"><a href="#section-b.7" class="xref">B.7</a>.  <a href="#name-text-format-options" class="xref">Text Format Options</a></p>
+                <p id="section-toc.1-1.6.2.7.1"><a href="#appendix-B.7" class="xref">B.7</a>.  <a href="#name-text-format-options" class="xref">Text Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.8">
-                <p id="section-toc.1-1.6.2.8.1"><a href="#section-b.8" class="xref">B.8</a>.  <a href="#name-html-format-options" class="xref">Html Format Options</a></p>
+                <p id="section-toc.1-1.6.2.8.1"><a href="#appendix-B.8" class="xref">B.8</a>.  <a href="#name-html-format-options" class="xref">Html Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.9">
-                <p id="section-toc.1-1.6.2.9.1"><a href="#section-b.9" class="xref">B.9</a>.  <a href="#name-v2-v3-converter-options" class="xref">V2-V3 Converter Options</a></p>
+                <p id="section-toc.1-1.6.2.9.1"><a href="#appendix-B.9" class="xref">B.9</a>.  <a href="#name-v2-v3-converter-options" class="xref">V2-V3 Converter Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.10">
-                <p id="section-toc.1-1.6.2.10.1"><a href="#section-b.10" class="xref">B.10</a>. <a href="#name-preptool-options" class="xref">Preptool Options</a></p>
+                <p id="section-toc.1-1.6.2.10.1"><a href="#appendix-B.10" class="xref">B.10</a>. <a href="#name-preptool-options" class="xref">Preptool Options</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-xml2rfc-configuration-files" class="xref"><code>xml2rfc</code> Configuration Files</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-xml2rfc-configuration-files" class="xref"><code>xml2rfc</code> Configuration Files</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-appendix.d" class="xref">Appendix D</a>.  <a href="#name-xml2rfc-documentation-templ" class="xref"><code>xml2rfc</code> Documentation Template Variables</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#appendix-D" class="xref">Appendix D</a>.  <a href="#name-xml2rfc-documentation-templ" class="xref"><code>xml2rfc</code> Documentation Template Variables</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#appendix-E" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -4306,11 +4306,11 @@ src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww..."&gt;
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-relax-ng-schema">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-relax-ng-schema" class="section-name selfRef">RELAX NG Schema</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-relax-ng-schema" class="section-name selfRef">RELAX NG Schema</a>
       </h2>
-<div id="section-appendix.a-1">
+<div id="appendix-A-1">
 <pre class="sourcecode lang-relax-ng-compact">&lt;CODE BEGINS&gt; file "v3.rnc"
 
 
@@ -5458,570 +5458,570 @@ u =
 start |= rfc
 
 
-&lt;CODE ENDS&gt;</pre><a href="#section-appendix.a-1" class="pilcrow">¶</a>
+&lt;CODE ENDS&gt;</pre><a href="#appendix-A-1" class="pilcrow">¶</a>
 </div>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-xml2rfc-command-line-option">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-xml2rfc-command-line-option" class="section-name selfRef"><code>xml2rfc</code> Command-line Options</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-xml2rfc-command-line-option" class="section-name selfRef"><code>xml2rfc</code> Command-line Options</a>
       </h2>
-<p id="section-appendix.b-1">
-       The following command-line options are available.  Long options may be shortened to the shortest substring that still makes the option string unique, when given on the command line.  In config files, the full long option string must be used.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
-<section id="section-b.1">
-        <h2 id="name-positional-arguments">
-<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-positional-arguments" class="section-name selfRef">Positional arguments</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.1-1">
-          <dt id="section-b.1-1.1"><code>source</code></dt>
-          <dd style="margin-left: 1.5em" id="section-b.1-1.2">Input XML file to render to one or more of the available formats.<a href="#section-b.1-1.2" class="pilcrow">¶</a>
+<p id="appendix-B-1">
+       The following command-line options are available.  Long options may be shortened to the shortest substring that still makes the option string unique, when given on the command line.  In config files, the full long option string must be used.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<section id="appendix-B.1">
+        <h3 id="name-positional-arguments">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-positional-arguments" class="section-name selfRef">Positional arguments</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.1-1">
+          <dt id="appendix-B.1-1.1"><code>source</code></dt>
+          <dd style="margin-left: 1.5em" id="appendix-B.1-1.2">Input XML file to render to one or more of the available formats.<a href="#appendix-B.1-1.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.2">
-        <h2 id="name-documentation-options">
-<a href="#section-b.2" class="section-number selfRef">B.2. </a><a href="#name-documentation-options" class="section-name selfRef">Documentation options</a>
-        </h2>
-<p id="section-b.2-1">
+<section id="appendix-B.2">
+        <h3 id="name-documentation-options">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-documentation-options" class="section-name selfRef">Documentation options</a>
+        </h3>
+<p id="appendix-B.2-1">
                Some options to generate built-in documentation.
-               The group has 8 options.<a href="#section-b.2-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.2-2">
-          <dt id="section-b.2-2.1">
+               The group has 8 options.<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.2-2">
+          <dt id="appendix-B.2-2.1">
 <div id="option--help">
 <code>--help</code>, <code>-h</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.2">
-            <p id="section-b.2-2.2.1">
-                          Show a help message and exit.<a href="#section-b.2-2.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.2">
+            <p id="appendix-B.2-2.2.1">
+                          Show a help message and exit.<a href="#appendix-B.2-2.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.3">
+<dt id="appendix-B.2-2.3">
 <div id="option--docfile">
 <code>--docfile</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.4">
-            <p id="section-b.2-2.4.1">
-                          Generate a documentation XML file ready for formatting.<a href="#section-b.2-2.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.4.2">
-       The <code>--docfile</code> and <code>--manpage</code> switches takes input from 5 places:<a href="#section-b.2-2.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.4">
+            <p id="appendix-B.2-2.4.1">
+                          Generate a documentation XML file ready for formatting.<a href="#appendix-B.2-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.4.2">
+       The <code>--docfile</code> and <code>--manpage</code> switches takes input from 5 places:<a href="#appendix-B.2-2.4.2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-b.2-2.4.3.1">The <code>v3.rng</code> file distributed as part of the xml2rfc package, which is also used to validate and process v3 XML input.<a href="#section-b.2-2.4.3.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-B.2-2.4.3.1">The <code>v3.rng</code> file distributed as part of the xml2rfc package, which is also used to validate and process v3 XML input.<a href="#appendix-B.2-2.4.3.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.2">A <code>rfc7991.rng</code> file distributed as part of the xml2rfc package, which holds the schema defined in <span>[<a href="#RFC7991" class="xref">RFC7991</a>]</span>.  This is used in determining elements and attributes that are new in the current <code>v3.rng</code> schema, compared to the RFC7991 schema.<a href="#section-b.2-2.4.3.2" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.2">A <code>rfc7991.rng</code> file distributed as part of the xml2rfc package, which holds the schema defined in <span>[<a href="#RFC7991" class="xref">RFC7991</a>]</span>.  This is used in determining elements and attributes that are new in the current <code>v3.rng</code> schema, compared to the RFC7991 schema.<a href="#appendix-B.2-2.4.3.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.3">Lists of deprecated elements and attributes, which are part of the xml2rfc source.<a href="#section-b.2-2.4.3.3" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.3">Lists of deprecated elements and attributes, which are part of the xml2rfc source.<a href="#appendix-B.2-2.4.3.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.4">A YAML file <code>doc.yaml</code> that contains XML snippets with descriptions of elements, attributes, attribute values, and switches, from the same directory as <code>doc.xml</code>.<a href="#section-b.2-2.4.3.4" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.4">A YAML file <code>doc.yaml</code> that contains XML snippets with descriptions of elements, attributes, attribute values, and switches, from the same directory as <code>doc.xml</code>.<a href="#appendix-B.2-2.4.3.4" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.5">An XML template file <code>doc.xml</code>, by default taken from the <code>templates</code> directory of the xml2rfc package (but this can be changed with the <code>--templates-dir</code> switch).  The 4 preceding sources provide content that is used to expand the template file when generating the <code>--⁠docfile</code> and <code>--⁠manpage</code> output.<a href="#section-b.2-2.4.3.5" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.5">An XML template file <code>doc.xml</code>, by default taken from the <code>templates</code> directory of the xml2rfc package (but this can be changed with the <code>--templates-dir</code> switch).  The 4 preceding sources provide content that is used to expand the template file when generating the <code>--⁠docfile</code> and <code>--⁠manpage</code> output.<a href="#appendix-B.2-2.4.3.5" class="pilcrow">¶</a>
 </li>
             </ul>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.5">
+<dt id="appendix-B.2-2.5">
 <div id="option--manpage">
 <code>--manpage</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.6">
-            <p id="section-b.2-2.6.1">
-                          Show paged text documentation.<a href="#section-b.2-2.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.6.2">
-       Generates on-the-fly paged text documentation for the v3 schema elements and attributes from the v3 RelaxNG schema file which is part of the xml2rfc distribution, and YAML and XML files that provide the text content and formatting.  See the <code>--docfile</code> switch for more details.<a href="#section-b.2-2.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.6">
+            <p id="appendix-B.2-2.6.1">
+                          Show paged text documentation.<a href="#appendix-B.2-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.6.2">
+       Generates on-the-fly paged text documentation for the v3 schema elements and attributes from the v3 RelaxNG schema file which is part of the xml2rfc distribution, and YAML and XML files that provide the text content and formatting.  See the <code>--docfile</code> switch for more details.<a href="#appendix-B.2-2.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.7">
+<dt id="appendix-B.2-2.7">
 <div id="option--country-help">
 <code>--country-help</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.8">
-            <p id="section-b.2-2.8.1">
-                          Show the recognized &lt;country&gt; strings.<a href="#section-b.2-2.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.8">
+            <p id="appendix-B.2-2.8.1">
+                          Show the recognized &lt;country&gt; strings.<a href="#appendix-B.2-2.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.9">
+<dt id="appendix-B.2-2.9">
 <div id="option--pdf-help">
 <code>--pdf-help</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.10">
-            <p id="section-b.2-2.10.1">
-                          Show pdf generation requirements.<a href="#section-b.2-2.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.10">
+            <p id="appendix-B.2-2.10.1">
+                          Show pdf generation requirements.<a href="#appendix-B.2-2.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.11">
+<dt id="appendix-B.2-2.11">
 <div id="option--template-dir">
 <code>--template-dir</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.12">
-            <p id="section-b.2-2.12.1">
-                          Directory to pull the doc.xml and doc.yaml templates from.  The default is the "templates" directory of the xml2rfc package.<a href="#section-b.2-2.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.12.2">
-       This is used to find the templates used by the <code>--⁠docfile</code> and <code>--⁠manpage</code> commands and for legacy .html template and .dtd files.<a href="#section-b.2-2.12.2" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.12.3">
-       A consequence of being able to specify a different template directory than the default is that it's possible to use the <code>--⁠docfile</code> command to generate additional documentation XML files based on the current V3 grammar file.  The default template and snippets file does not include documentation for deprecated elements and attributes, for instance; but if it is desired to generate such documentation from the distributed V3 RelaxNg schema, it should be straightforward.  The templating system used is Jinja2; the snippens file is YAML with extra support for some escape sequences: '\ &lt;' and '\ &gt;'.<a href="#section-b.2-2.12.3" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.12">
+            <p id="appendix-B.2-2.12.1">
+                          Directory to pull the doc.xml and doc.yaml templates from.  The default is the "templates" directory of the xml2rfc package.<a href="#appendix-B.2-2.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.12.2">
+       This is used to find the templates used by the <code>--⁠docfile</code> and <code>--⁠manpage</code> commands and for legacy .html template and .dtd files.<a href="#appendix-B.2-2.12.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.12.3">
+       A consequence of being able to specify a different template directory than the default is that it's possible to use the <code>--⁠docfile</code> command to generate additional documentation XML files based on the current V3 grammar file.  The default template and snippets file does not include documentation for deprecated elements and attributes, for instance; but if it is desired to generate such documentation from the distributed V3 RelaxNg schema, it should be straightforward.  The templating system used is Jinja2; the snippens file is YAML with extra support for some escape sequences: '\ &lt;' and '\ &gt;'.<a href="#appendix-B.2-2.12.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.13">
+<dt id="appendix-B.2-2.13">
 <div id="option--values">
 <code>--values</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.14">
-            <p id="section-b.2-2.14.1">
-                          Show option values and from where they come.<a href="#section-b.2-2.14.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.14.2">
-       This shows (in order):<a href="#section-b.2-2.14.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.14">
+            <p id="appendix-B.2-2.14.1">
+                          Show option values and from where they come.<a href="#appendix-B.2-2.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.14.2">
+       This shows (in order):<a href="#appendix-B.2-2.14.2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-b.2-2.14.3.1">Command line arguments<a href="#section-b.2-2.14.3.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-B.2-2.14.3.1">Command line arguments<a href="#appendix-B.2-2.14.3.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.2">Config file settings, per config file<a href="#section-b.2-2.14.3.2" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.2">Config file settings, per config file<a href="#appendix-B.2-2.14.3.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.3">Default values<a href="#section-b.2-2.14.3.3" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.3">Default values<a href="#appendix-B.2-2.14.3.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.4">Config file search path<a href="#section-b.2-2.14.3.4" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.4">Config file search path<a href="#appendix-B.2-2.14.3.4" class="pilcrow">¶</a>
 </li>
             </ul>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.15">
+<dt id="appendix-B.2-2.15">
 <div id="option--version">
 <code>--version</code>, <code>-V</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.16">
-            <p id="section-b.2-2.16.1">
-                          Display the version number and exit.<a href="#section-b.2-2.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.16.2">
-       With the <code>--verbose</code> switch, the versions of the external python modules used will also be shown.<a href="#section-b.2-2.16.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.16">
+            <p id="appendix-B.2-2.16.1">
+                          Display the version number and exit.<a href="#appendix-B.2-2.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.16.2">
+       With the <code>--verbose</code> switch, the versions of the external python modules used will also be shown.<a href="#appendix-B.2-2.16.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.3">
-        <h2 id="name-format-selection">
-<a href="#section-b.3" class="section-number selfRef">B.3. </a><a href="#name-format-selection" class="section-name selfRef">Format selection</a>
-        </h2>
-<p id="section-b.3-1">
+<section id="appendix-B.3">
+        <h3 id="name-format-selection">
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-format-selection" class="section-name selfRef">Format selection</a>
+        </h3>
+<p id="appendix-B.3-1">
                One or more of the following output formats may be specified. The default is --text. The destination filename will be based on the input filename, unless --out=FILE or --basename=BASE is used.
-               The group has 10 options.<a href="#section-b.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.3-2">
-          <dt id="section-b.3-2.1">
+               The group has 10 options.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.3-2">
+          <dt id="appendix-B.3-2.1">
 <div id="option--text">
 <code>--text</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.2">
-            <p id="section-b.3-2.2.1">
-                          Outputs formatted text to file, with proper page breaks.<a href="#section-b.3-2.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.2">
+            <p id="appendix-B.3-2.2.1">
+                          Outputs formatted text to file, with proper page breaks.<a href="#appendix-B.3-2.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.3">
+<dt id="appendix-B.3-2.3">
 <div id="option--html">
 <code>--html</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.4">
-            <p id="section-b.3-2.4.1">
-                          Outputs formatted HTML to file.<a href="#section-b.3-2.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.4">
+            <p id="appendix-B.3-2.4.1">
+                          Outputs formatted HTML to file.<a href="#appendix-B.3-2.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.5">
+<dt id="appendix-B.3-2.5">
 <div id="option--nroff">
 <code>--nroff</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.6">
-            <p id="section-b.3-2.6.1">
-                          Outputs formatted nroff to file (only v2 input).<a href="#section-b.3-2.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.6">
+            <p id="appendix-B.3-2.6.1">
+                          Outputs formatted nroff to file (only v2 input).<a href="#appendix-B.3-2.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.7">
+<dt id="appendix-B.3-2.7">
 <div id="option--pdf">
 <code>--pdf</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.8">
-            <p id="section-b.3-2.8.1">
-                          Outputs formatted PDF to file.<a href="#section-b.3-2.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.8">
+            <p id="appendix-B.3-2.8.1">
+                          Outputs formatted PDF to file.<a href="#appendix-B.3-2.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.9">
+<dt id="appendix-B.3-2.9">
 <div id="option--raw">
 <code>--raw</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.10">
-            <p id="section-b.3-2.10.1">
-                          Outputs formatted text to file, unpaginated (only v2 input).<a href="#section-b.3-2.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.10">
+            <p id="appendix-B.3-2.10.1">
+                          Outputs formatted text to file, unpaginated (only v2 input).<a href="#appendix-B.3-2.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.11">
+<dt id="appendix-B.3-2.11">
 <div id="option--expand">
 <code>--expand</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.12">
-            <p id="section-b.3-2.12.1">
-                          Outputs XML to file with all references expanded.<a href="#section-b.3-2.12.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.12">
+            <p id="appendix-B.3-2.12.1">
+                          Outputs XML to file with all references expanded.<a href="#appendix-B.3-2.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.13">
+<dt id="appendix-B.3-2.13">
 <div id="option--v2v3">
 <code>--v2v3</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.14">
-            <p id="section-b.3-2.14.1">
-                          Convert vocabulary version 2 XML to version 3.<a href="#section-b.3-2.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.14">
+            <p id="appendix-B.3-2.14.1">
+                          Convert vocabulary version 2 XML to version 3.<a href="#appendix-B.3-2.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.15">
+<dt id="appendix-B.3-2.15">
 <div id="option--preptool">
 <code>--preptool</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.16">
-            <p id="section-b.3-2.16.1">
-                          Run preptool on the input.<a href="#section-b.3-2.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.16">
+            <p id="appendix-B.3-2.16.1">
+                          Run preptool on the input.<a href="#appendix-B.3-2.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.17">
+<dt id="appendix-B.3-2.17">
 <div id="option--unprep">
 <code>--unprep</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.18">
-            <p id="section-b.3-2.18.1">
-                          Reduce prepped xml to unprepped.<a href="#section-b.3-2.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.18">
+            <p id="appendix-B.3-2.18.1">
+                          Reduce prepped xml to unprepped.<a href="#appendix-B.3-2.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.19">
+<dt id="appendix-B.3-2.19">
 <div id="option--info">
 <code>--info</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.20">
-            <p id="section-b.3-2.20.1">
-                          Generate a JSON file with anchor to section lookup information.<a href="#section-b.3-2.20.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.20">
+            <p id="appendix-B.3-2.20.1">
+                          Generate a JSON file with anchor to section lookup information.<a href="#appendix-B.3-2.20.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.4">
-        <h2 id="name-generic-switch-options">
-<a href="#section-b.4" class="section-number selfRef">B.4. </a><a href="#name-generic-switch-options" class="section-name selfRef">Generic Switch Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.4-1">
-          <dt id="section-b.4-1.1">
+<section id="appendix-B.4">
+        <h3 id="name-generic-switch-options">
+<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-generic-switch-options" class="section-name selfRef">Generic Switch Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.4-1">
+          <dt id="appendix-B.4-1.1">
 <div id="option--clear-cache">
 <code>--clear-cache</code>, <code>-C</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.2">
-            <p id="section-b.4-1.2.1">
-                          Purge the cache and exit.<a href="#section-b.4-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.2">
+            <p id="appendix-B.4-1.2.1">
+                          Purge the cache and exit.<a href="#appendix-B.4-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.3">
+<dt id="appendix-B.4-1.3">
 <div id="option--debug">
 <code>--debug</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.4">
-            <p id="section-b.4-1.4.1">
-                          Show debugging output.<a href="#section-b.4-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.4">
+            <p id="appendix-B.4-1.4.1">
+                          Show debugging output.<a href="#appendix-B.4-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.5">
+<dt id="appendix-B.4-1.5">
 <div id="option--no-network">
 <code>--no-network</code>, <code>-N</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.6">
-            <p id="section-b.4-1.6.1">
-                          Don't use the network to resolve references.<a href="#section-b.4-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.6">
+            <p id="appendix-B.4-1.6.1">
+                          Don't use the network to resolve references.<a href="#appendix-B.4-1.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.7">
+<dt id="appendix-B.4-1.7">
 <div id="option--no-org-info">
 <code>--no-org-info</code>, <code>-O</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.8">
-            <p id="section-b.4-1.8.1">
-                          Don't show author orgainzation info on page one (legacy only).<a href="#section-b.4-1.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.8">
+            <p id="appendix-B.4-1.8.1">
+                          Don't show author orgainzation info on page one (legacy only).<a href="#appendix-B.4-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.9">
+<dt id="appendix-B.4-1.9">
 <div id="option--quiet">
 <code>--quiet</code>, <code>-q</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.10">
-            <p id="section-b.4-1.10.1">
-                          Don't print anything while working.<a href="#section-b.4-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.10">
+            <p id="appendix-B.4-1.10.1">
+                          Don't print anything while working.<a href="#appendix-B.4-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.11">
+<dt id="appendix-B.4-1.11">
 <div id="option--skip-config-files">
 <code>--skip-config-files</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.12">
-            <p id="section-b.4-1.12.1">
-                          Ignore config file settings.<a href="#section-b.4-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.4-1.12.2">
-       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#section-b.4-1.12.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.12">
+            <p id="appendix-B.4-1.12.1">
+                          Ignore config file settings.<a href="#appendix-B.4-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-1.12.2">
+       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#appendix-B.4-1.12.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.13">
+<dt id="appendix-B.4-1.13">
 <div id="option--remove-pis">
 <code>--remove-pis</code>, <code>-r</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.14">
-            <p id="section-b.4-1.14.1">
-                          Remove XML processing instructions.<a href="#section-b.4-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.14">
+            <p id="appendix-B.4-1.14.1">
+                          Remove XML processing instructions.<a href="#appendix-B.4-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.15">
+<dt id="appendix-B.4-1.15">
 <div id="option--utf8">
 <code>--utf8</code>, <code>-u</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.16">
-            <p id="section-b.4-1.16.1">
-                          Generate utf8 output.<a href="#section-b.4-1.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.16">
+            <p id="appendix-B.4-1.16.1">
+                          Generate utf8 output.<a href="#appendix-B.4-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.17">
+<dt id="appendix-B.4-1.17">
 <div id="option--verbose">
 <code>--verbose</code>, <code>-v</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.18">
-            <p id="section-b.4-1.18.1">
-                          Print extra information.<a href="#section-b.4-1.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.18">
+            <p id="appendix-B.4-1.18.1">
+                          Print extra information.<a href="#appendix-B.4-1.18.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.5">
-        <h2 id="name-generic-options-with-values">
-<a href="#section-b.5" class="section-number selfRef">B.5. </a><a href="#name-generic-options-with-values" class="section-name selfRef">Generic Options with Values</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.5-1">
-          <dt id="section-b.5-1.1">
+<section id="appendix-B.5">
+        <h3 id="name-generic-options-with-values">
+<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-generic-options-with-values" class="section-name selfRef">Generic Options with Values</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.5-1">
+          <dt id="appendix-B.5-1.1">
 <div id="option--basename">
 <code>--basename</code>, <code>-b</code> = NAME                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.2">
-            <p id="section-b.5-1.2.1">
-                          Specify the base name for output files.<a href="#section-b.5-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.2">
+            <p id="appendix-B.5-1.2.1">
+                          Specify the base name for output files.<a href="#appendix-B.5-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.3">
+<dt id="appendix-B.5-1.3">
 <div id="option--cache">
 <code>--cache</code>, <code>-c</code> = PATH                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.4">
-            <p id="section-b.5-1.4.1">
-                          Specify a primary cache directory to write to; default: try [ /var/cache/xml2rfc, ~/.cache/xml2rfc ].<a href="#section-b.5-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.4">
+            <p id="appendix-B.5-1.4.1">
+                          Specify a primary cache directory to write to; default: try [ /var/cache/xml2rfc, ~/.cache/xml2rfc ].<a href="#appendix-B.5-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.5">
+<dt id="appendix-B.5-1.5">
 <div id="option--config-file">
 <code>--config-file</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.6">
-            <p id="section-b.5-1.6.1">
-                          Specify a configuration file.<a href="#section-b.5-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.6.2">
-       This argument can be repeated, to read multiple explicitly specified config files.  They will be read after any config files found in 'standard' locations have been read.  Run <code>xml2rfc --values</code> to see the default search path for config files.<a href="#section-b.5-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.6">
+            <p id="appendix-B.5-1.6.1">
+                          Specify a configuration file.<a href="#appendix-B.5-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.6.2">
+       This argument can be repeated, to read multiple explicitly specified config files.  They will be read after any config files found in 'standard' locations have been read.  Run <code>xml2rfc --values</code> to see the default search path for config files.<a href="#appendix-B.5-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.7">
+<dt id="appendix-B.5-1.7">
 <div id="option--dtd">
 <code>--dtd</code>, <code>-d</code> = DTDFILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.8">
-            <p id="section-b.5-1.8.1">
-                          Specify an alternate dtd file.<a href="#section-b.5-1.8.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.8.2">
-                          This option can be negated with --no-dtd.<a href="#section-b.5-1.8.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.8">
+            <p id="appendix-B.5-1.8.1">
+                          Specify an alternate dtd file.<a href="#appendix-B.5-1.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.8.2">
+                          This option can be negated with --no-dtd.<a href="#appendix-B.5-1.8.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.9">
+<dt id="appendix-B.5-1.9">
 <div id="option--date">
 <code>--date</code>, <code>-D</code> = DATE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.10">
-            <p id="section-b.5-1.10.1">
-                          Run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date.<a href="#section-b.5-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.10">
+            <p id="appendix-B.5-1.10.1">
+                          Run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date.<a href="#appendix-B.5-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.11">
+<dt id="appendix-B.5-1.11">
 <div id="option--filename">
 <code>--filename</code>, <code>-f</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.12">
-            <p id="section-b.5-1.12.1">
-                          Deprecated.  The same as -o.<a href="#section-b.5-1.12.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.12">
+            <p id="appendix-B.5-1.12.1">
+                          Deprecated.  The same as -o.<a href="#appendix-B.5-1.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.13">
+<dt id="appendix-B.5-1.13">
 <div id="option--indent">
 <code>--indent</code>, <code>-i</code> = INDENT                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.14">
-            <p id="section-b.5-1.14.1">
-                          With some v3 formatters: Indentation to use when pretty-printing XML.<a href="#section-b.5-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.14">
+            <p id="appendix-B.5-1.14.1">
+                          With some v3 formatters: Indentation to use when pretty-printing XML.<a href="#appendix-B.5-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.15">
+<dt id="appendix-B.5-1.15">
 <div id="option--out">
 <code>--out</code>, <code>-o</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.16">
-            <p id="section-b.5-1.16.1">
-                          Specify an explicit output filename.<a href="#section-b.5-1.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.16">
+            <p id="appendix-B.5-1.16.1">
+                          Specify an explicit output filename.<a href="#appendix-B.5-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.17">
+<dt id="appendix-B.5-1.17">
 <div id="option--path">
 <code>--path</code>, <code>-p</code> = PATH                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.18">
-            <p id="section-b.5-1.18.1">
-                          Specify the directory path for output files.<a href="#section-b.5-1.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.18">
+            <p id="appendix-B.5-1.18.1">
+                          Specify the directory path for output files.<a href="#appendix-B.5-1.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.19">
+<dt id="appendix-B.5-1.19">
 <div id="option--silence">
 <code>--silence</code>, <code>-s</code> = STRING                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.20">
-            <p id="section-b.5-1.20.1">
-                          Silence any warning beginning with the given string.<a href="#section-b.5-1.20.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.20.2">
-       Specifies a string prefix or a regular expression to match against warning messages.  Any warning message that matches is silenced.  Example:<a href="#section-b.5-1.20.2" class="pilcrow">¶</a></p>
-<div id="section-b.5-1.20.3">
-<pre class="sourcecode">xml2rfc --silence='The document date' draft-foo-bar.xml</pre><a href="#section-b.5-1.20.3" class="pilcrow">¶</a>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.20">
+            <p id="appendix-B.5-1.20.1">
+                          Silence any warning beginning with the given string.<a href="#appendix-B.5-1.20.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.20.2">
+       Specifies a string prefix or a regular expression to match against warning messages.  Any warning message that matches is silenced.  Example:<a href="#appendix-B.5-1.20.2" class="pilcrow">¶</a></p>
+<div id="appendix-B.5-1.20.3">
+<pre class="sourcecode">xml2rfc --silence='The document date' draft-foo-bar.xml</pre><a href="#appendix-B.5-1.20.3" class="pilcrow">¶</a>
 </div>
-<p id="section-b.5-1.20.4">
-       This will not show any message about the document date being too far from the current date.  The option can be repeated with different prefix strings or regular expressions in order to silence multiple warning messages.<a href="#section-b.5-1.20.4" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.20.5">
-       Alternatively, instead of indicating this on the command line, an xml2rfc-specific PI (processing instruction) is available for use in XML input files. This will have the same effect as the example above, except when processing prepped drafts; running the preptool on a file will strip XML PIs before writing the prepped file:<a href="#section-b.5-1.20.5" class="pilcrow">¶</a></p>
-<div id="section-b.5-1.20.6">
-<pre class="sourcecode">&lt;?v3xml2rfc silence="The document date" ?&gt;</pre><a href="#section-b.5-1.20.6" class="pilcrow">¶</a>
+<p id="appendix-B.5-1.20.4">
+       This will not show any message about the document date being too far from the current date.  The option can be repeated with different prefix strings or regular expressions in order to silence multiple warning messages.<a href="#appendix-B.5-1.20.4" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.20.5">
+       Alternatively, instead of indicating this on the command line, an xml2rfc-specific PI (processing instruction) is available for use in XML input files. This will have the same effect as the example above, except when processing prepped drafts; running the preptool on a file will strip XML PIs before writing the prepped file:<a href="#appendix-B.5-1.20.5" class="pilcrow">¶</a></p>
+<div id="appendix-B.5-1.20.6">
+<pre class="sourcecode">&lt;?v3xml2rfc silence="The document date" ?&gt;</pre><a href="#appendix-B.5-1.20.6" class="pilcrow">¶</a>
 </div>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.6">
-        <h2 id="name-generic-format-options">
-<a href="#section-b.6" class="section-number selfRef">B.6. </a><a href="#name-generic-format-options" class="section-name selfRef">Generic Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.6-1">
-          <dt id="section-b.6-1.1">
+<section id="appendix-B.6">
+        <h3 id="name-generic-format-options">
+<a href="#appendix-B.6" class="section-number selfRef">B.6. </a><a href="#name-generic-format-options" class="section-name selfRef">Generic Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.6-1">
+          <dt id="appendix-B.6-1.1">
 <div id="option--v3">
 <code>--v3</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.2">
-            <p id="section-b.6-1.2.1">
-                          With --text and --html: use the v3 formatter, rather than the legacy one.<a href="#section-b.6-1.2.1" class="pilcrow">¶</a></p>
-<p id="section-b.6-1.2.2">
-       This is the default.  With both v2 schema and v3 schema XML input files, use the v3 output formatters.  Input with deprecated v2 elements will be converted to v3 on the fly.  This means some loss of functionality and exact control of the output, due to the intermediary conversion step.<a href="#section-b.6-1.2.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.2">
+            <p id="appendix-B.6-1.2.1">
+                          With --text and --html: use the v3 formatter, rather than the legacy one.<a href="#appendix-B.6-1.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.6-1.2.2">
+       This is the default.  With both v2 schema and v3 schema XML input files, use the v3 output formatters.  Input with deprecated v2 elements will be converted to v3 on the fly.  This means some loss of functionality and exact control of the output, due to the intermediary conversion step.<a href="#appendix-B.6-1.2.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.6-1.3">
+<dt id="appendix-B.6-1.3">
 <div id="option--v2">
 <code>--v2</code>, <code>--legacy</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.4">
-            <p id="section-b.6-1.4.1">
-                          With --text and --html: use the legacy output formatters, rather than the v3 ones.<a href="#section-b.6-1.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.6-1.4.2">
-       Invokes the legacy (schema v2) validator and output formatters, instead of the default schema v3 output formatters.  This can only be used with pure v2 input files.<a href="#section-b.6-1.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.4">
+            <p id="appendix-B.6-1.4.1">
+                          With --text and --html: use the legacy output formatters, rather than the v3 ones.<a href="#appendix-B.6-1.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.6-1.4.2">
+       Invokes the legacy (schema v2) validator and output formatters, instead of the default schema v3 output formatters.  This can only be used with pure v2 input files.<a href="#appendix-B.6-1.4.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.6-1.5">
+<dt id="appendix-B.6-1.5">
 <div id="option--id-is-work-in-progress">
 <code>--id-is-work-in-progress</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.6">
-            <p id="section-b.6-1.6.1">
-                          In references, refer to Internet-Drafts as "Work in Progress".<a href="#section-b.6-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.6">
+            <p id="appendix-B.6-1.6.1">
+                          In references, refer to Internet-Drafts as "Work in Progress".<a href="#appendix-B.6-1.6.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.7">
-        <h2 id="name-text-format-options">
-<a href="#section-b.7" class="section-number selfRef">B.7. </a><a href="#name-text-format-options" class="section-name selfRef">Text Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1">
-          <dt id="section-b.7-1.1">
+<section id="appendix-B.7">
+        <h3 id="name-text-format-options">
+<a href="#appendix-B.7" class="section-number selfRef">B.7. </a><a href="#name-text-format-options" class="section-name selfRef">Text Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1">
+          <dt id="appendix-B.7-1.1">
 <div id="option--no-headers">
 <code>--no-headers</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.2">
-            <p id="section-b.7-1.2.1">
-                          Calculate page breaks, and emit form feeds and page top spacing, but omit headers and footers from the paginated format.<a href="#section-b.7-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.2">
+            <p id="appendix-B.7-1.2.1">
+                          Calculate page breaks, and emit form feeds and page top spacing, but omit headers and footers from the paginated format.<a href="#appendix-B.7-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.3">
+<dt id="appendix-B.7-1.3">
 <div id="option--legacy-list-symbols">
 <code>--legacy-list-symbols</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.4">
-            <p id="section-b.7-1.4.1">
-                          Use the legacy list bullet symbols, rather than the new ones.<a href="#section-b.7-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.4">
+            <p id="appendix-B.7-1.4.1">
+                          Use the legacy list bullet symbols, rather than the new ones.<a href="#appendix-B.7-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.5">
+<dt id="appendix-B.7-1.5">
 <div id="option--legacy-date-format">
 <code>--legacy-date-format</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.6">
-            <p id="section-b.7-1.6.1">
-                          Use the legacy date format, rather than the new one.<a href="#section-b.7-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.6.2">
-                          This option can be negated with --no-legacy-date-format.<a href="#section-b.7-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.6">
+            <p id="appendix-B.7-1.6.1">
+                          Use the legacy date format, rather than the new one.<a href="#appendix-B.7-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.6.2">
+                          This option can be negated with --no-legacy-date-format.<a href="#appendix-B.7-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.7">
+<dt id="appendix-B.7-1.7">
 <div id="option--list-symbols">
 <code>--list-symbols</code> = 4*CHAR                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.8">
-            <p id="section-b.7-1.8.1">
-                          Use the characters given as list bullet symbols.<a href="#section-b.7-1.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.8">
+            <p id="appendix-B.7-1.8.1">
+                          Use the characters given as list bullet symbols.<a href="#appendix-B.7-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.9">
+<dt id="appendix-B.7-1.9">
 <div id="option--BOM">
 <code>--BOM</code>, <code>--bom</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.10">
-            <p id="section-b.7-1.10.1">
-                          Add a BOM (unicode byte order mark) to the start of text files.<a href="#section-b.7-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.10">
+            <p id="appendix-B.7-1.10.1">
+                          Add a BOM (unicode byte order mark) to the start of text files.<a href="#appendix-B.7-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.11">
+<dt id="appendix-B.7-1.11">
 <div id="option--pagination">
 <code>--pagination</code>, <code>--paginate</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.12">
-            <p id="section-b.7-1.12.1">
-                          Do pagination.<a href="#section-b.7-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.12.2">
-       By default, drafts are paginated, but not RFCs.  Use this switch if you want to force pagination of all text output.<a href="#section-b.7-1.12.2" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.12.3">
-                          This option can be negated with --no-pagination.<a href="#section-b.7-1.12.3" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.12">
+            <p id="appendix-B.7-1.12.1">
+                          Do pagination.<a href="#appendix-B.7-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.12.2">
+       By default, drafts are paginated, but not RFCs.  Use this switch if you want to force pagination of all text output.<a href="#appendix-B.7-1.12.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.12.3">
+                          This option can be negated with --no-pagination.<a href="#appendix-B.7-1.12.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.13">
+<dt id="appendix-B.7-1.13">
 <div id="option--table-hyphen-breaks">
 <code>--table-hyphen-breaks</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.14">
-            <p id="section-b.7-1.14.1">
-                          More easily do line breaks after hyphens in table cells to give a more compact table.<a href="#section-b.7-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.14">
+            <p id="appendix-B.7-1.14.1">
+                          More easily do line breaks after hyphens in table cells to give a more compact table.<a href="#appendix-B.7-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.15">
+<dt id="appendix-B.7-1.15">
 <div id="option--table-borders">
 <code>--table-borders</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.16">
-            <p id="section-b.7-1.16.1"><br>Default value: full<a href="#section-b.7-1.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.16.2">
-                          The style of table borders to use for text output; one of full/light/minimal.<a href="#section-b.7-1.16.2" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.16.3">
-       Examples (these will only have visible differences in text mode):<a href="#section-b.7-1.16.3" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.4">
-              <dt id="section-b.7-1.16.4.1">"full":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.4.2">
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.16">
+            <p id="appendix-B.7-1.16.1"><br>Default value: full<a href="#appendix-B.7-1.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.16.2">
+                          The style of table borders to use for text output; one of full/light/minimal.<a href="#appendix-B.7-1.16.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.16.3">
+       Examples (these will only have visible differences in text mode):<a href="#appendix-B.7-1.16.3" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.4">
+              <dt id="appendix-B.7-1.16.4.1">"full":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.4.2">
                 <table class="center" id="table-2">
                   <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
 <thead>
@@ -6063,13 +6063,13 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.4.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.4.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.5">
-              <dt id="section-b.7-1.16.5.1">"light":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.5.2">
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.5">
+              <dt id="appendix-B.7-1.16.5.1">"light":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.5.2">
                 <table class="center" id="table-3">
                   <caption><a href="#table-3" class="selfRef">Table 3</a></caption>
 <thead>
@@ -6111,13 +6111,13 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.5.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.5.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.6">
-              <dt id="section-b.7-1.16.6.1">"minimal":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.6.2">
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.6">
+              <dt id="appendix-B.7-1.16.6.1">"minimal":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.6.2">
                 <table class="center" id="table-4">
                   <caption><a href="#table-4" class="selfRef">Table 4</a></caption>
 <thead>
@@ -6159,7 +6159,7 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.6.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.6.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
@@ -6167,213 +6167,213 @@ start |= rfc
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.8">
-        <h2 id="name-html-format-options">
-<a href="#section-b.8" class="section-number selfRef">B.8. </a><a href="#name-html-format-options" class="section-name selfRef">Html Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.8-1">
-          <dt id="section-b.8-1.1">
+<section id="appendix-B.8">
+        <h3 id="name-html-format-options">
+<a href="#appendix-B.8" class="section-number selfRef">B.8. </a><a href="#name-html-format-options" class="section-name selfRef">Html Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.8-1">
+          <dt id="appendix-B.8-1.1">
 <div id="option--css">
 <code>--css</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.2">
-            <p id="section-b.8-1.2.1">
-                          Use the given CSS file instead of the builtin.<a href="#section-b.8-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.2">
+            <p id="appendix-B.8-1.2.1">
+                          Use the given CSS file instead of the builtin.<a href="#appendix-B.8-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.3">
+<dt id="appendix-B.8-1.3">
 <div id="option--external-css">
 <code>--external-css</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.4">
-            <p id="section-b.8-1.4.1">
-                          Place css in external files.<a href="#section-b.8-1.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.4.2">
-                          This option can be negated with --no-external-css.<a href="#section-b.8-1.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.4">
+            <p id="appendix-B.8-1.4.1">
+                          Place css in external files.<a href="#appendix-B.8-1.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.4.2">
+                          This option can be negated with --no-external-css.<a href="#appendix-B.8-1.4.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.5">
+<dt id="appendix-B.8-1.5">
 <div id="option--external-js">
 <code>--external-js</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.6">
-            <p id="section-b.8-1.6.1">
-                          Place js in external files.<a href="#section-b.8-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.6.2">
-                          This option can be negated with --no-external-js.<a href="#section-b.8-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.6">
+            <p id="appendix-B.8-1.6.1">
+                          Place js in external files.<a href="#appendix-B.8-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.6.2">
+                          This option can be negated with --no-external-js.<a href="#appendix-B.8-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.7">
+<dt id="appendix-B.8-1.7">
 <div id="option--rfc-base-url">
 <code>--rfc-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.8">
-            <p id="section-b.8-1.8.1"><br>Default value: https://www.rfc-editor.org/rfc/<a href="#section-b.8-1.8.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.8.2">
-                          Base URL for RFC links.<a href="#section-b.8-1.8.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.8">
+            <p id="appendix-B.8-1.8.1"><br>Default value: https://www.rfc-editor.org/rfc/<a href="#appendix-B.8-1.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.8.2">
+                          Base URL for RFC links.<a href="#appendix-B.8-1.8.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.9">
+<dt id="appendix-B.8-1.9">
 <div id="option--id-base-url">
 <code>--id-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.10">
-            <p id="section-b.8-1.10.1"><br>Default value: https://tools.ietf.org/html/<a href="#section-b.8-1.10.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.10.2">
-                          Base URL for Internet-Draft links.<a href="#section-b.8-1.10.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.10">
+            <p id="appendix-B.8-1.10.1"><br>Default value: https://tools.ietf.org/html/<a href="#appendix-B.8-1.10.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.10.2">
+                          Base URL for Internet-Draft links.<a href="#appendix-B.8-1.10.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.11">
+<dt id="appendix-B.8-1.11">
 <div id="option--rfc-reference-base-url">
 <code>--rfc-reference-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.12">
-            <p id="section-b.8-1.12.1"><br>Default value: https://rfc-editor.org/rfc/<a href="#section-b.8-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.12.2">
-                          Base URL for RFC reference targets, replacing the target="..." value given in the reference entry.<a href="#section-b.8-1.12.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.12">
+            <p id="appendix-B.8-1.12.1"><br>Default value: https://rfc-editor.org/rfc/<a href="#appendix-B.8-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.12.2">
+                          Base URL for RFC reference targets, replacing the target="..." value given in the reference entry.<a href="#appendix-B.8-1.12.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.13">
+<dt id="appendix-B.8-1.13">
 <div id="option--id-reference-base-url">
 <code>--id-reference-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.14">
-            <p id="section-b.8-1.14.1"><br>Default value: https://tools.ietf.org/html/<a href="#section-b.8-1.14.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.14.2">
-                          Base URL for I-D reference targets.<a href="#section-b.8-1.14.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.14">
+            <p id="appendix-B.8-1.14.1"><br>Default value: https://tools.ietf.org/html/<a href="#appendix-B.8-1.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.14.2">
+                          Base URL for I-D reference targets.<a href="#appendix-B.8-1.14.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.15">
+<dt id="appendix-B.8-1.15">
 <div id="option--metadata-js-url">
 <code>--metadata-js-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.16">
-            <p id="section-b.8-1.16.1"><br>Default value: metadata.min.js<a href="#section-b.8-1.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.16.2">
-                          URL for the metadata script.<a href="#section-b.8-1.16.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.16">
+            <p id="appendix-B.8-1.16.1"><br>Default value: metadata.min.js<a href="#appendix-B.8-1.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.16.2">
+                          URL for the metadata script.<a href="#appendix-B.8-1.16.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.9">
-        <h2 id="name-v2-v3-converter-options">
-<a href="#section-b.9" class="section-number selfRef">B.9. </a><a href="#name-v2-v3-converter-options" class="section-name selfRef">V2-V3 Converter Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.9-1">
-          <dt id="section-b.9-1.1">
+<section id="appendix-B.9">
+        <h3 id="name-v2-v3-converter-options">
+<a href="#appendix-B.9" class="section-number selfRef">B.9. </a><a href="#name-v2-v3-converter-options" class="section-name selfRef">V2-V3 Converter Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.9-1">
+          <dt id="appendix-B.9-1.1">
 <div id="option--add-xinclude">
 <code>--add-xinclude</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.2">
-            <p id="section-b.9-1.2.1">
-                          Replace reference elements with RFC and Internet-Draft seriesInfo with the appropriate XInclude element.<a href="#section-b.9-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.2">
+            <p id="appendix-B.9-1.2.1">
+                          Replace reference elements with RFC and Internet-Draft seriesInfo with the appropriate XInclude element.<a href="#appendix-B.9-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.9-1.3">
+<dt id="appendix-B.9-1.3">
 <div id="option--draft-revs">
 <code>--draft-revs</code>, <code>--draft-revisions</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.4">
-            <p id="section-b.9-1.4.1">
-                          Reference explicit draft revisions when inserting XIncludes for draft references.<a href="#section-b.9-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.4">
+            <p id="appendix-B.9-1.4.1">
+                          Reference explicit draft revisions when inserting XIncludes for draft references.<a href="#appendix-B.9-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.9-1.5">
+<dt id="appendix-B.9-1.5">
 <div id="option--strict">
 <code>--strict</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.6">
-            <p id="section-b.9-1.6.1">
-                          Be strict about stripping some deprecated attributes.<a href="#section-b.9-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.6">
+            <p id="appendix-B.9-1.6.1">
+                          Be strict about stripping some deprecated attributes.<a href="#appendix-B.9-1.6.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.10">
-        <h2 id="name-preptool-options">
-<a href="#section-b.10" class="section-number selfRef">B.10. </a><a href="#name-preptool-options" class="section-name selfRef">Preptool Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.10-1">
-          <dt id="section-b.10-1.1">
+<section id="appendix-B.10">
+        <h3 id="name-preptool-options">
+<a href="#appendix-B.10" class="section-number selfRef">B.10. </a><a href="#name-preptool-options" class="section-name selfRef">Preptool Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.10-1">
+          <dt id="appendix-B.10-1.1">
 <div id="option--accept-prepped">
 <code>--accept-prepped</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.10-1.2">
-            <p id="section-b.10-1.2.1">
-                          Accept already prepped input.<a href="#section-b.10-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.10-1.2">
+            <p id="appendix-B.10-1.2.1">
+                          Accept already prepped input.<a href="#appendix-B.10-1.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-xml2rfc-configuration-files">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-xml2rfc-configuration-files" class="section-name selfRef"><code>xml2rfc</code> Configuration Files</a>
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-xml2rfc-configuration-files" class="section-name selfRef"><code>xml2rfc</code> Configuration Files</a>
       </h2>
-<p id="section-appendix.c-1">
-       Most options have built-in defaults, and the command-line switches above can be used to override those.  Additionally, <code>xml2rfc</code> will look for config files in some standard file locations.  The option <code>--⁠values</code> will show the places <code>xml2rfc</code> will look for config files on your system (among other information).  Any settings in config files will override the program defaults, but will in turn be overridden by command-line options.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.c-2">
-       The config files are expected to contain lines with option value assignments. Lines with '#' as the first character are considered comments.  Here is an example:<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
-<div id="section-appendix.c-3">
+<p id="appendix-C-1">
+       Most options have built-in defaults, and the command-line switches above can be used to override those.  Additionally, <code>xml2rfc</code> will look for config files in some standard file locations.  The option <code>--⁠values</code> will show the places <code>xml2rfc</code> will look for config files on your system (among other information).  Any settings in config files will override the program defaults, but will in turn be overridden by command-line options.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">
+       The config files are expected to contain lines with option value assignments. Lines with '#' as the first character are considered comments.  Here is an example:<a href="#appendix-C-2" class="pilcrow">¶</a></p>
+<div id="appendix-C-3">
 <pre class="sourcecode">
 # ----
 legacy-date-format = true
 add-xinclude = true
 external-js = false
 # ----
-</pre><a href="#section-appendix.c-3" class="pilcrow">¶</a>
+</pre><a href="#appendix-C-3" class="pilcrow">¶</a>
 </div>
-<p id="section-appendix.c-4">
-       The complete long option names must be used in configuration files; abbreviations will not be recognised (in contrast with how abbreviations are handled during command-line option processing).<a href="#section-appendix.c-4" class="pilcrow">¶</a></p>
+<p id="appendix-C-4">
+       The complete long option names must be used in configuration files; abbreviations will not be recognised (in contrast with how abbreviations are handled during command-line option processing).<a href="#appendix-C-4" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.d">
+<section id="appendix-D">
       <h2 id="name-xml2rfc-documentation-templ">
-<a href="#section-appendix.d" class="section-number selfRef">Appendix D. </a><a href="#name-xml2rfc-documentation-templ" class="section-name selfRef"><code>xml2rfc</code> Documentation Template Variables</a>
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-xml2rfc-documentation-templ" class="section-name selfRef"><code>xml2rfc</code> Documentation Template Variables</a>
       </h2>
-<p id="section-appendix.d-1">
+<p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.8.0:<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-appendix.d-2">
-        <dt id="section-appendix.d-2.1">{{ bare_latin_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.2"></dd>
+            manpage Jinja2 template, as of xml2rfc version 3.8.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-D-2">
+        <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.3">{{ descriptions }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.4">The descriptions read from the <code>doc.yaml</code> file<a href="#section-appendix.d-2.4" class="pilcrow">¶</a>
+<dt id="appendix-D-2.3">{{ descriptions }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.4">The descriptions read from the <code>doc.yaml</code> file<a href="#appendix-D-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.5">{{ element_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.6">A list of all the element tags in the XML schema<a href="#section-appendix.d-2.6" class="pilcrow">¶</a>
+<dt id="appendix-D-2.5">{{ element_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.6">A list of all the element tags in the XML schema<a href="#appendix-D-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.7">{{ elements }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.8">A list of dictionaries, each with information about one schema element: {"attributes": ..., "children": ..., "deprecated": ..., "deprecated_attributes": ..., "description": ..., "new": ..., "parents": ..., "rnc": ..., "tag": ..., }<a href="#section-appendix.d-2.8" class="pilcrow">¶</a>
+<dt id="appendix-D-2.7">{{ elements }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.8">A list of dictionaries, each with information about one schema element: {"attributes": ..., "children": ..., "deprecated": ..., "deprecated_attributes": ..., "description": ..., "new": ..., "parents": ..., "rnc": ..., "tag": ..., }<a href="#appendix-D-2.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.9">{{ options }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.10">A list of dictionaries describing the command-line options<a href="#section-appendix.d-2.10" class="pilcrow">¶</a>
+<dt id="appendix-D-2.9">{{ options }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.10">A list of dictionaries describing the command-line options<a href="#appendix-D-2.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.11">{{ schema }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.12">The full RelaxNG Compact representation of the schema in text form<a href="#section-appendix.d-2.12" class="pilcrow">¶</a>
+<dt id="appendix-D-2.11">{{ schema }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.12">The full RelaxNG Compact representation of the schema in text form<a href="#appendix-D-2.12" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.13">{{ toc_depth }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.14">ToC depth setting; 1 when running --man, 2 otherwise<a href="#section-appendix.d-2.14" class="pilcrow">¶</a>
+<dt id="appendix-D-2.13">{{ toc_depth }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.14">ToC depth setting; 1 when running --man, 2 otherwise<a href="#appendix-D-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.15">{{ v3_element_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.16">A list of v3 element tags, excluding deprecated tags<a href="#section-appendix.d-2.16" class="pilcrow">¶</a>
+<dt id="appendix-D-2.15">{{ v3_element_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.16">A list of v3 element tags, excluding deprecated tags<a href="#appendix-D-2.16" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.17">{{ version }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.18">The xml2rfc version number<a href="#section-appendix.d-2.18" class="pilcrow">¶</a>
+<dt id="appendix-D-2.17">{{ version }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.18">The xml2rfc version number<a href="#appendix-D-2.18" class="pilcrow">¶</a>
 </dd>
       <dd class="break"></dd>
 </dl>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.e">
+<section id="appendix-E">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/docfile.py37.html
+++ b/cli/tests/valid/docfile.py37.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.7.0</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.8.0</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.7.0" name="generator">
-<meta content="xml2rfc-docs-3.7.0" name="ietf.draft">
+<meta content="xml2rfc 3.8.0" name="generator">
+<meta content="xml2rfc-docs-3.8.0" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">May 2021</td>
+<td class="right">June 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -45,7 +45,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.7.0</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.8.0</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -367,7 +367,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://xml2rfc.ietf.org/xml2rfc-doc">https://xml2rfc.ietf.org/xml2rfc-doc</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.7.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.8.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6333,7 +6333,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.7.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.8.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/cli/tests/valid/docfile.py37.html
+++ b/cli/tests/valid/docfile.py37.html
@@ -302,51 +302,51 @@
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-references-2" class="xref">References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-relax-ng-schema" class="xref">RELAX NG Schema</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-relax-ng-schema" class="xref">RELAX NG Schema</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-xml2rfc-command-line-option" class="xref"><code>xml2rfc</code> Command-line Options</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-xml2rfc-command-line-option" class="xref"><code>xml2rfc</code> Command-line Options</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-positional-arguments" class="xref">Positional arguments</a></p>
+                <p id="section-toc.1-1.6.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-positional-arguments" class="xref">Positional arguments</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-documentation-options" class="xref">Documentation options</a></p>
+                <p id="section-toc.1-1.6.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-documentation-options" class="xref">Documentation options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.3">
-                <p id="section-toc.1-1.6.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-format-selection" class="xref">Format selection</a></p>
+                <p id="section-toc.1-1.6.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-format-selection" class="xref">Format selection</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.4">
-                <p id="section-toc.1-1.6.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-generic-switch-options" class="xref">Generic Switch Options</a></p>
+                <p id="section-toc.1-1.6.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-generic-switch-options" class="xref">Generic Switch Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.5">
-                <p id="section-toc.1-1.6.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-generic-options-with-values" class="xref">Generic Options with Values</a></p>
+                <p id="section-toc.1-1.6.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-generic-options-with-values" class="xref">Generic Options with Values</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.6">
-                <p id="section-toc.1-1.6.2.6.1"><a href="#section-b.6" class="xref">B.6</a>.  <a href="#name-generic-format-options" class="xref">Generic Format Options</a></p>
+                <p id="section-toc.1-1.6.2.6.1"><a href="#appendix-B.6" class="xref">B.6</a>.  <a href="#name-generic-format-options" class="xref">Generic Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.7">
-                <p id="section-toc.1-1.6.2.7.1"><a href="#section-b.7" class="xref">B.7</a>.  <a href="#name-text-format-options" class="xref">Text Format Options</a></p>
+                <p id="section-toc.1-1.6.2.7.1"><a href="#appendix-B.7" class="xref">B.7</a>.  <a href="#name-text-format-options" class="xref">Text Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.8">
-                <p id="section-toc.1-1.6.2.8.1"><a href="#section-b.8" class="xref">B.8</a>.  <a href="#name-html-format-options" class="xref">Html Format Options</a></p>
+                <p id="section-toc.1-1.6.2.8.1"><a href="#appendix-B.8" class="xref">B.8</a>.  <a href="#name-html-format-options" class="xref">Html Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.9">
-                <p id="section-toc.1-1.6.2.9.1"><a href="#section-b.9" class="xref">B.9</a>.  <a href="#name-v2-v3-converter-options" class="xref">V2-V3 Converter Options</a></p>
+                <p id="section-toc.1-1.6.2.9.1"><a href="#appendix-B.9" class="xref">B.9</a>.  <a href="#name-v2-v3-converter-options" class="xref">V2-V3 Converter Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.10">
-                <p id="section-toc.1-1.6.2.10.1"><a href="#section-b.10" class="xref">B.10</a>. <a href="#name-preptool-options" class="xref">Preptool Options</a></p>
+                <p id="section-toc.1-1.6.2.10.1"><a href="#appendix-B.10" class="xref">B.10</a>. <a href="#name-preptool-options" class="xref">Preptool Options</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-xml2rfc-configuration-files" class="xref"><code>xml2rfc</code> Configuration Files</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-xml2rfc-configuration-files" class="xref"><code>xml2rfc</code> Configuration Files</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-appendix.d" class="xref">Appendix D</a>.  <a href="#name-xml2rfc-documentation-templ" class="xref"><code>xml2rfc</code> Documentation Template Variables</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#appendix-D" class="xref">Appendix D</a>.  <a href="#name-xml2rfc-documentation-templ" class="xref"><code>xml2rfc</code> Documentation Template Variables</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#appendix-E" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -4306,11 +4306,11 @@ src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww..."&gt;
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-relax-ng-schema">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-relax-ng-schema" class="section-name selfRef">RELAX NG Schema</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-relax-ng-schema" class="section-name selfRef">RELAX NG Schema</a>
       </h2>
-<div id="section-appendix.a-1">
+<div id="appendix-A-1">
 <pre class="sourcecode lang-relax-ng-compact">&lt;CODE BEGINS&gt; file "v3.rnc"
 
 
@@ -5458,570 +5458,570 @@ u =
 start |= rfc
 
 
-&lt;CODE ENDS&gt;</pre><a href="#section-appendix.a-1" class="pilcrow">¶</a>
+&lt;CODE ENDS&gt;</pre><a href="#appendix-A-1" class="pilcrow">¶</a>
 </div>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-xml2rfc-command-line-option">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-xml2rfc-command-line-option" class="section-name selfRef"><code>xml2rfc</code> Command-line Options</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-xml2rfc-command-line-option" class="section-name selfRef"><code>xml2rfc</code> Command-line Options</a>
       </h2>
-<p id="section-appendix.b-1">
-       The following command-line options are available.  Long options may be shortened to the shortest substring that still makes the option string unique, when given on the command line.  In config files, the full long option string must be used.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
-<section id="section-b.1">
-        <h2 id="name-positional-arguments">
-<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-positional-arguments" class="section-name selfRef">Positional arguments</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.1-1">
-          <dt id="section-b.1-1.1"><code>source</code></dt>
-          <dd style="margin-left: 1.5em" id="section-b.1-1.2">Input XML file to render to one or more of the available formats.<a href="#section-b.1-1.2" class="pilcrow">¶</a>
+<p id="appendix-B-1">
+       The following command-line options are available.  Long options may be shortened to the shortest substring that still makes the option string unique, when given on the command line.  In config files, the full long option string must be used.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<section id="appendix-B.1">
+        <h3 id="name-positional-arguments">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-positional-arguments" class="section-name selfRef">Positional arguments</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.1-1">
+          <dt id="appendix-B.1-1.1"><code>source</code></dt>
+          <dd style="margin-left: 1.5em" id="appendix-B.1-1.2">Input XML file to render to one or more of the available formats.<a href="#appendix-B.1-1.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.2">
-        <h2 id="name-documentation-options">
-<a href="#section-b.2" class="section-number selfRef">B.2. </a><a href="#name-documentation-options" class="section-name selfRef">Documentation options</a>
-        </h2>
-<p id="section-b.2-1">
+<section id="appendix-B.2">
+        <h3 id="name-documentation-options">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-documentation-options" class="section-name selfRef">Documentation options</a>
+        </h3>
+<p id="appendix-B.2-1">
                Some options to generate built-in documentation.
-               The group has 8 options.<a href="#section-b.2-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.2-2">
-          <dt id="section-b.2-2.1">
+               The group has 8 options.<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.2-2">
+          <dt id="appendix-B.2-2.1">
 <div id="option--help">
 <code>--help</code>, <code>-h</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.2">
-            <p id="section-b.2-2.2.1">
-                          Show a help message and exit.<a href="#section-b.2-2.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.2">
+            <p id="appendix-B.2-2.2.1">
+                          Show a help message and exit.<a href="#appendix-B.2-2.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.3">
+<dt id="appendix-B.2-2.3">
 <div id="option--docfile">
 <code>--docfile</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.4">
-            <p id="section-b.2-2.4.1">
-                          Generate a documentation XML file ready for formatting.<a href="#section-b.2-2.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.4.2">
-       The <code>--docfile</code> and <code>--manpage</code> switches takes input from 5 places:<a href="#section-b.2-2.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.4">
+            <p id="appendix-B.2-2.4.1">
+                          Generate a documentation XML file ready for formatting.<a href="#appendix-B.2-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.4.2">
+       The <code>--docfile</code> and <code>--manpage</code> switches takes input from 5 places:<a href="#appendix-B.2-2.4.2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-b.2-2.4.3.1">The <code>v3.rng</code> file distributed as part of the xml2rfc package, which is also used to validate and process v3 XML input.<a href="#section-b.2-2.4.3.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-B.2-2.4.3.1">The <code>v3.rng</code> file distributed as part of the xml2rfc package, which is also used to validate and process v3 XML input.<a href="#appendix-B.2-2.4.3.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.2">A <code>rfc7991.rng</code> file distributed as part of the xml2rfc package, which holds the schema defined in <span>[<a href="#RFC7991" class="xref">RFC7991</a>]</span>.  This is used in determining elements and attributes that are new in the current <code>v3.rng</code> schema, compared to the RFC7991 schema.<a href="#section-b.2-2.4.3.2" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.2">A <code>rfc7991.rng</code> file distributed as part of the xml2rfc package, which holds the schema defined in <span>[<a href="#RFC7991" class="xref">RFC7991</a>]</span>.  This is used in determining elements and attributes that are new in the current <code>v3.rng</code> schema, compared to the RFC7991 schema.<a href="#appendix-B.2-2.4.3.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.3">Lists of deprecated elements and attributes, which are part of the xml2rfc source.<a href="#section-b.2-2.4.3.3" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.3">Lists of deprecated elements and attributes, which are part of the xml2rfc source.<a href="#appendix-B.2-2.4.3.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.4">A YAML file <code>doc.yaml</code> that contains XML snippets with descriptions of elements, attributes, attribute values, and switches, from the same directory as <code>doc.xml</code>.<a href="#section-b.2-2.4.3.4" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.4">A YAML file <code>doc.yaml</code> that contains XML snippets with descriptions of elements, attributes, attribute values, and switches, from the same directory as <code>doc.xml</code>.<a href="#appendix-B.2-2.4.3.4" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.5">An XML template file <code>doc.xml</code>, by default taken from the <code>templates</code> directory of the xml2rfc package (but this can be changed with the <code>--templates-dir</code> switch).  The 4 preceding sources provide content that is used to expand the template file when generating the <code>--⁠docfile</code> and <code>--⁠manpage</code> output.<a href="#section-b.2-2.4.3.5" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.5">An XML template file <code>doc.xml</code>, by default taken from the <code>templates</code> directory of the xml2rfc package (but this can be changed with the <code>--templates-dir</code> switch).  The 4 preceding sources provide content that is used to expand the template file when generating the <code>--⁠docfile</code> and <code>--⁠manpage</code> output.<a href="#appendix-B.2-2.4.3.5" class="pilcrow">¶</a>
 </li>
             </ul>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.5">
+<dt id="appendix-B.2-2.5">
 <div id="option--manpage">
 <code>--manpage</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.6">
-            <p id="section-b.2-2.6.1">
-                          Show paged text documentation.<a href="#section-b.2-2.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.6.2">
-       Generates on-the-fly paged text documentation for the v3 schema elements and attributes from the v3 RelaxNG schema file which is part of the xml2rfc distribution, and YAML and XML files that provide the text content and formatting.  See the <code>--docfile</code> switch for more details.<a href="#section-b.2-2.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.6">
+            <p id="appendix-B.2-2.6.1">
+                          Show paged text documentation.<a href="#appendix-B.2-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.6.2">
+       Generates on-the-fly paged text documentation for the v3 schema elements and attributes from the v3 RelaxNG schema file which is part of the xml2rfc distribution, and YAML and XML files that provide the text content and formatting.  See the <code>--docfile</code> switch for more details.<a href="#appendix-B.2-2.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.7">
+<dt id="appendix-B.2-2.7">
 <div id="option--country-help">
 <code>--country-help</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.8">
-            <p id="section-b.2-2.8.1">
-                          Show the recognized &lt;country&gt; strings.<a href="#section-b.2-2.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.8">
+            <p id="appendix-B.2-2.8.1">
+                          Show the recognized &lt;country&gt; strings.<a href="#appendix-B.2-2.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.9">
+<dt id="appendix-B.2-2.9">
 <div id="option--pdf-help">
 <code>--pdf-help</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.10">
-            <p id="section-b.2-2.10.1">
-                          Show pdf generation requirements.<a href="#section-b.2-2.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.10">
+            <p id="appendix-B.2-2.10.1">
+                          Show pdf generation requirements.<a href="#appendix-B.2-2.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.11">
+<dt id="appendix-B.2-2.11">
 <div id="option--template-dir">
 <code>--template-dir</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.12">
-            <p id="section-b.2-2.12.1">
-                          Directory to pull the doc.xml and doc.yaml templates from.  The default is the "templates" directory of the xml2rfc package.<a href="#section-b.2-2.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.12.2">
-       This is used to find the templates used by the <code>--⁠docfile</code> and <code>--⁠manpage</code> commands and for legacy .html template and .dtd files.<a href="#section-b.2-2.12.2" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.12.3">
-       A consequence of being able to specify a different template directory than the default is that it's possible to use the <code>--⁠docfile</code> command to generate additional documentation XML files based on the current V3 grammar file.  The default template and snippets file does not include documentation for deprecated elements and attributes, for instance; but if it is desired to generate such documentation from the distributed V3 RelaxNg schema, it should be straightforward.  The templating system used is Jinja2; the snippens file is YAML with extra support for some escape sequences: '\ &lt;' and '\ &gt;'.<a href="#section-b.2-2.12.3" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.12">
+            <p id="appendix-B.2-2.12.1">
+                          Directory to pull the doc.xml and doc.yaml templates from.  The default is the "templates" directory of the xml2rfc package.<a href="#appendix-B.2-2.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.12.2">
+       This is used to find the templates used by the <code>--⁠docfile</code> and <code>--⁠manpage</code> commands and for legacy .html template and .dtd files.<a href="#appendix-B.2-2.12.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.12.3">
+       A consequence of being able to specify a different template directory than the default is that it's possible to use the <code>--⁠docfile</code> command to generate additional documentation XML files based on the current V3 grammar file.  The default template and snippets file does not include documentation for deprecated elements and attributes, for instance; but if it is desired to generate such documentation from the distributed V3 RelaxNg schema, it should be straightforward.  The templating system used is Jinja2; the snippens file is YAML with extra support for some escape sequences: '\ &lt;' and '\ &gt;'.<a href="#appendix-B.2-2.12.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.13">
+<dt id="appendix-B.2-2.13">
 <div id="option--values">
 <code>--values</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.14">
-            <p id="section-b.2-2.14.1">
-                          Show option values and from where they come.<a href="#section-b.2-2.14.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.14.2">
-       This shows (in order):<a href="#section-b.2-2.14.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.14">
+            <p id="appendix-B.2-2.14.1">
+                          Show option values and from where they come.<a href="#appendix-B.2-2.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.14.2">
+       This shows (in order):<a href="#appendix-B.2-2.14.2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-b.2-2.14.3.1">Command line arguments<a href="#section-b.2-2.14.3.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-B.2-2.14.3.1">Command line arguments<a href="#appendix-B.2-2.14.3.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.2">Config file settings, per config file<a href="#section-b.2-2.14.3.2" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.2">Config file settings, per config file<a href="#appendix-B.2-2.14.3.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.3">Default values<a href="#section-b.2-2.14.3.3" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.3">Default values<a href="#appendix-B.2-2.14.3.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.4">Config file search path<a href="#section-b.2-2.14.3.4" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.4">Config file search path<a href="#appendix-B.2-2.14.3.4" class="pilcrow">¶</a>
 </li>
             </ul>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.15">
+<dt id="appendix-B.2-2.15">
 <div id="option--version">
 <code>--version</code>, <code>-V</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.16">
-            <p id="section-b.2-2.16.1">
-                          Display the version number and exit.<a href="#section-b.2-2.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.16.2">
-       With the <code>--verbose</code> switch, the versions of the external python modules used will also be shown.<a href="#section-b.2-2.16.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.16">
+            <p id="appendix-B.2-2.16.1">
+                          Display the version number and exit.<a href="#appendix-B.2-2.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.16.2">
+       With the <code>--verbose</code> switch, the versions of the external python modules used will also be shown.<a href="#appendix-B.2-2.16.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.3">
-        <h2 id="name-format-selection">
-<a href="#section-b.3" class="section-number selfRef">B.3. </a><a href="#name-format-selection" class="section-name selfRef">Format selection</a>
-        </h2>
-<p id="section-b.3-1">
+<section id="appendix-B.3">
+        <h3 id="name-format-selection">
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-format-selection" class="section-name selfRef">Format selection</a>
+        </h3>
+<p id="appendix-B.3-1">
                One or more of the following output formats may be specified. The default is --text. The destination filename will be based on the input filename, unless --out=FILE or --basename=BASE is used.
-               The group has 10 options.<a href="#section-b.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.3-2">
-          <dt id="section-b.3-2.1">
+               The group has 10 options.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.3-2">
+          <dt id="appendix-B.3-2.1">
 <div id="option--text">
 <code>--text</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.2">
-            <p id="section-b.3-2.2.1">
-                          Outputs formatted text to file, with proper page breaks.<a href="#section-b.3-2.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.2">
+            <p id="appendix-B.3-2.2.1">
+                          Outputs formatted text to file, with proper page breaks.<a href="#appendix-B.3-2.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.3">
+<dt id="appendix-B.3-2.3">
 <div id="option--html">
 <code>--html</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.4">
-            <p id="section-b.3-2.4.1">
-                          Outputs formatted HTML to file.<a href="#section-b.3-2.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.4">
+            <p id="appendix-B.3-2.4.1">
+                          Outputs formatted HTML to file.<a href="#appendix-B.3-2.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.5">
+<dt id="appendix-B.3-2.5">
 <div id="option--nroff">
 <code>--nroff</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.6">
-            <p id="section-b.3-2.6.1">
-                          Outputs formatted nroff to file (only v2 input).<a href="#section-b.3-2.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.6">
+            <p id="appendix-B.3-2.6.1">
+                          Outputs formatted nroff to file (only v2 input).<a href="#appendix-B.3-2.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.7">
+<dt id="appendix-B.3-2.7">
 <div id="option--pdf">
 <code>--pdf</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.8">
-            <p id="section-b.3-2.8.1">
-                          Outputs formatted PDF to file.<a href="#section-b.3-2.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.8">
+            <p id="appendix-B.3-2.8.1">
+                          Outputs formatted PDF to file.<a href="#appendix-B.3-2.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.9">
+<dt id="appendix-B.3-2.9">
 <div id="option--raw">
 <code>--raw</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.10">
-            <p id="section-b.3-2.10.1">
-                          Outputs formatted text to file, unpaginated (only v2 input).<a href="#section-b.3-2.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.10">
+            <p id="appendix-B.3-2.10.1">
+                          Outputs formatted text to file, unpaginated (only v2 input).<a href="#appendix-B.3-2.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.11">
+<dt id="appendix-B.3-2.11">
 <div id="option--expand">
 <code>--expand</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.12">
-            <p id="section-b.3-2.12.1">
-                          Outputs XML to file with all references expanded.<a href="#section-b.3-2.12.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.12">
+            <p id="appendix-B.3-2.12.1">
+                          Outputs XML to file with all references expanded.<a href="#appendix-B.3-2.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.13">
+<dt id="appendix-B.3-2.13">
 <div id="option--v2v3">
 <code>--v2v3</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.14">
-            <p id="section-b.3-2.14.1">
-                          Convert vocabulary version 2 XML to version 3.<a href="#section-b.3-2.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.14">
+            <p id="appendix-B.3-2.14.1">
+                          Convert vocabulary version 2 XML to version 3.<a href="#appendix-B.3-2.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.15">
+<dt id="appendix-B.3-2.15">
 <div id="option--preptool">
 <code>--preptool</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.16">
-            <p id="section-b.3-2.16.1">
-                          Run preptool on the input.<a href="#section-b.3-2.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.16">
+            <p id="appendix-B.3-2.16.1">
+                          Run preptool on the input.<a href="#appendix-B.3-2.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.17">
+<dt id="appendix-B.3-2.17">
 <div id="option--unprep">
 <code>--unprep</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.18">
-            <p id="section-b.3-2.18.1">
-                          Reduce prepped xml to unprepped.<a href="#section-b.3-2.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.18">
+            <p id="appendix-B.3-2.18.1">
+                          Reduce prepped xml to unprepped.<a href="#appendix-B.3-2.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.19">
+<dt id="appendix-B.3-2.19">
 <div id="option--info">
 <code>--info</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.20">
-            <p id="section-b.3-2.20.1">
-                          Generate a JSON file with anchor to section lookup information.<a href="#section-b.3-2.20.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.20">
+            <p id="appendix-B.3-2.20.1">
+                          Generate a JSON file with anchor to section lookup information.<a href="#appendix-B.3-2.20.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.4">
-        <h2 id="name-generic-switch-options">
-<a href="#section-b.4" class="section-number selfRef">B.4. </a><a href="#name-generic-switch-options" class="section-name selfRef">Generic Switch Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.4-1">
-          <dt id="section-b.4-1.1">
+<section id="appendix-B.4">
+        <h3 id="name-generic-switch-options">
+<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-generic-switch-options" class="section-name selfRef">Generic Switch Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.4-1">
+          <dt id="appendix-B.4-1.1">
 <div id="option--clear-cache">
 <code>--clear-cache</code>, <code>-C</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.2">
-            <p id="section-b.4-1.2.1">
-                          Purge the cache and exit.<a href="#section-b.4-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.2">
+            <p id="appendix-B.4-1.2.1">
+                          Purge the cache and exit.<a href="#appendix-B.4-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.3">
+<dt id="appendix-B.4-1.3">
 <div id="option--debug">
 <code>--debug</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.4">
-            <p id="section-b.4-1.4.1">
-                          Show debugging output.<a href="#section-b.4-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.4">
+            <p id="appendix-B.4-1.4.1">
+                          Show debugging output.<a href="#appendix-B.4-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.5">
+<dt id="appendix-B.4-1.5">
 <div id="option--no-network">
 <code>--no-network</code>, <code>-N</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.6">
-            <p id="section-b.4-1.6.1">
-                          Don't use the network to resolve references.<a href="#section-b.4-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.6">
+            <p id="appendix-B.4-1.6.1">
+                          Don't use the network to resolve references.<a href="#appendix-B.4-1.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.7">
+<dt id="appendix-B.4-1.7">
 <div id="option--no-org-info">
 <code>--no-org-info</code>, <code>-O</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.8">
-            <p id="section-b.4-1.8.1">
-                          Don't show author orgainzation info on page one (legacy only).<a href="#section-b.4-1.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.8">
+            <p id="appendix-B.4-1.8.1">
+                          Don't show author orgainzation info on page one (legacy only).<a href="#appendix-B.4-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.9">
+<dt id="appendix-B.4-1.9">
 <div id="option--quiet">
 <code>--quiet</code>, <code>-q</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.10">
-            <p id="section-b.4-1.10.1">
-                          Don't print anything while working.<a href="#section-b.4-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.10">
+            <p id="appendix-B.4-1.10.1">
+                          Don't print anything while working.<a href="#appendix-B.4-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.11">
+<dt id="appendix-B.4-1.11">
 <div id="option--skip-config-files">
 <code>--skip-config-files</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.12">
-            <p id="section-b.4-1.12.1">
-                          Ignore config file settings.<a href="#section-b.4-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.4-1.12.2">
-       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#section-b.4-1.12.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.12">
+            <p id="appendix-B.4-1.12.1">
+                          Ignore config file settings.<a href="#appendix-B.4-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-1.12.2">
+       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#appendix-B.4-1.12.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.13">
+<dt id="appendix-B.4-1.13">
 <div id="option--remove-pis">
 <code>--remove-pis</code>, <code>-r</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.14">
-            <p id="section-b.4-1.14.1">
-                          Remove XML processing instructions.<a href="#section-b.4-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.14">
+            <p id="appendix-B.4-1.14.1">
+                          Remove XML processing instructions.<a href="#appendix-B.4-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.15">
+<dt id="appendix-B.4-1.15">
 <div id="option--utf8">
 <code>--utf8</code>, <code>-u</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.16">
-            <p id="section-b.4-1.16.1">
-                          Generate utf8 output.<a href="#section-b.4-1.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.16">
+            <p id="appendix-B.4-1.16.1">
+                          Generate utf8 output.<a href="#appendix-B.4-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.17">
+<dt id="appendix-B.4-1.17">
 <div id="option--verbose">
 <code>--verbose</code>, <code>-v</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.18">
-            <p id="section-b.4-1.18.1">
-                          Print extra information.<a href="#section-b.4-1.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.18">
+            <p id="appendix-B.4-1.18.1">
+                          Print extra information.<a href="#appendix-B.4-1.18.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.5">
-        <h2 id="name-generic-options-with-values">
-<a href="#section-b.5" class="section-number selfRef">B.5. </a><a href="#name-generic-options-with-values" class="section-name selfRef">Generic Options with Values</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.5-1">
-          <dt id="section-b.5-1.1">
+<section id="appendix-B.5">
+        <h3 id="name-generic-options-with-values">
+<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-generic-options-with-values" class="section-name selfRef">Generic Options with Values</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.5-1">
+          <dt id="appendix-B.5-1.1">
 <div id="option--basename">
 <code>--basename</code>, <code>-b</code> = NAME                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.2">
-            <p id="section-b.5-1.2.1">
-                          Specify the base name for output files.<a href="#section-b.5-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.2">
+            <p id="appendix-B.5-1.2.1">
+                          Specify the base name for output files.<a href="#appendix-B.5-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.3">
+<dt id="appendix-B.5-1.3">
 <div id="option--cache">
 <code>--cache</code>, <code>-c</code> = PATH                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.4">
-            <p id="section-b.5-1.4.1">
-                          Specify a primary cache directory to write to; default: try [ /var/cache/xml2rfc, ~/.cache/xml2rfc ].<a href="#section-b.5-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.4">
+            <p id="appendix-B.5-1.4.1">
+                          Specify a primary cache directory to write to; default: try [ /var/cache/xml2rfc, ~/.cache/xml2rfc ].<a href="#appendix-B.5-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.5">
+<dt id="appendix-B.5-1.5">
 <div id="option--config-file">
 <code>--config-file</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.6">
-            <p id="section-b.5-1.6.1">
-                          Specify a configuration file.<a href="#section-b.5-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.6.2">
-       This argument can be repeated, to read multiple explicitly specified config files.  They will be read after any config files found in 'standard' locations have been read.  Run <code>xml2rfc --values</code> to see the default search path for config files.<a href="#section-b.5-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.6">
+            <p id="appendix-B.5-1.6.1">
+                          Specify a configuration file.<a href="#appendix-B.5-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.6.2">
+       This argument can be repeated, to read multiple explicitly specified config files.  They will be read after any config files found in 'standard' locations have been read.  Run <code>xml2rfc --values</code> to see the default search path for config files.<a href="#appendix-B.5-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.7">
+<dt id="appendix-B.5-1.7">
 <div id="option--dtd">
 <code>--dtd</code>, <code>-d</code> = DTDFILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.8">
-            <p id="section-b.5-1.8.1">
-                          Specify an alternate dtd file.<a href="#section-b.5-1.8.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.8.2">
-                          This option can be negated with --no-dtd.<a href="#section-b.5-1.8.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.8">
+            <p id="appendix-B.5-1.8.1">
+                          Specify an alternate dtd file.<a href="#appendix-B.5-1.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.8.2">
+                          This option can be negated with --no-dtd.<a href="#appendix-B.5-1.8.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.9">
+<dt id="appendix-B.5-1.9">
 <div id="option--date">
 <code>--date</code>, <code>-D</code> = DATE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.10">
-            <p id="section-b.5-1.10.1">
-                          Run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date.<a href="#section-b.5-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.10">
+            <p id="appendix-B.5-1.10.1">
+                          Run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date.<a href="#appendix-B.5-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.11">
+<dt id="appendix-B.5-1.11">
 <div id="option--filename">
 <code>--filename</code>, <code>-f</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.12">
-            <p id="section-b.5-1.12.1">
-                          Deprecated.  The same as -o.<a href="#section-b.5-1.12.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.12">
+            <p id="appendix-B.5-1.12.1">
+                          Deprecated.  The same as -o.<a href="#appendix-B.5-1.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.13">
+<dt id="appendix-B.5-1.13">
 <div id="option--indent">
 <code>--indent</code>, <code>-i</code> = INDENT                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.14">
-            <p id="section-b.5-1.14.1">
-                          With some v3 formatters: Indentation to use when pretty-printing XML.<a href="#section-b.5-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.14">
+            <p id="appendix-B.5-1.14.1">
+                          With some v3 formatters: Indentation to use when pretty-printing XML.<a href="#appendix-B.5-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.15">
+<dt id="appendix-B.5-1.15">
 <div id="option--out">
 <code>--out</code>, <code>-o</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.16">
-            <p id="section-b.5-1.16.1">
-                          Specify an explicit output filename.<a href="#section-b.5-1.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.16">
+            <p id="appendix-B.5-1.16.1">
+                          Specify an explicit output filename.<a href="#appendix-B.5-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.17">
+<dt id="appendix-B.5-1.17">
 <div id="option--path">
 <code>--path</code>, <code>-p</code> = PATH                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.18">
-            <p id="section-b.5-1.18.1">
-                          Specify the directory path for output files.<a href="#section-b.5-1.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.18">
+            <p id="appendix-B.5-1.18.1">
+                          Specify the directory path for output files.<a href="#appendix-B.5-1.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.19">
+<dt id="appendix-B.5-1.19">
 <div id="option--silence">
 <code>--silence</code>, <code>-s</code> = STRING                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.20">
-            <p id="section-b.5-1.20.1">
-                          Silence any warning beginning with the given string.<a href="#section-b.5-1.20.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.20.2">
-       Specifies a string prefix or a regular expression to match against warning messages.  Any warning message that matches is silenced.  Example:<a href="#section-b.5-1.20.2" class="pilcrow">¶</a></p>
-<div id="section-b.5-1.20.3">
-<pre class="sourcecode">xml2rfc --silence='The document date' draft-foo-bar.xml</pre><a href="#section-b.5-1.20.3" class="pilcrow">¶</a>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.20">
+            <p id="appendix-B.5-1.20.1">
+                          Silence any warning beginning with the given string.<a href="#appendix-B.5-1.20.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.20.2">
+       Specifies a string prefix or a regular expression to match against warning messages.  Any warning message that matches is silenced.  Example:<a href="#appendix-B.5-1.20.2" class="pilcrow">¶</a></p>
+<div id="appendix-B.5-1.20.3">
+<pre class="sourcecode">xml2rfc --silence='The document date' draft-foo-bar.xml</pre><a href="#appendix-B.5-1.20.3" class="pilcrow">¶</a>
 </div>
-<p id="section-b.5-1.20.4">
-       This will not show any message about the document date being too far from the current date.  The option can be repeated with different prefix strings or regular expressions in order to silence multiple warning messages.<a href="#section-b.5-1.20.4" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.20.5">
-       Alternatively, instead of indicating this on the command line, an xml2rfc-specific PI (processing instruction) is available for use in XML input files. This will have the same effect as the example above, except when processing prepped drafts; running the preptool on a file will strip XML PIs before writing the prepped file:<a href="#section-b.5-1.20.5" class="pilcrow">¶</a></p>
-<div id="section-b.5-1.20.6">
-<pre class="sourcecode">&lt;?v3xml2rfc silence="The document date" ?&gt;</pre><a href="#section-b.5-1.20.6" class="pilcrow">¶</a>
+<p id="appendix-B.5-1.20.4">
+       This will not show any message about the document date being too far from the current date.  The option can be repeated with different prefix strings or regular expressions in order to silence multiple warning messages.<a href="#appendix-B.5-1.20.4" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.20.5">
+       Alternatively, instead of indicating this on the command line, an xml2rfc-specific PI (processing instruction) is available for use in XML input files. This will have the same effect as the example above, except when processing prepped drafts; running the preptool on a file will strip XML PIs before writing the prepped file:<a href="#appendix-B.5-1.20.5" class="pilcrow">¶</a></p>
+<div id="appendix-B.5-1.20.6">
+<pre class="sourcecode">&lt;?v3xml2rfc silence="The document date" ?&gt;</pre><a href="#appendix-B.5-1.20.6" class="pilcrow">¶</a>
 </div>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.6">
-        <h2 id="name-generic-format-options">
-<a href="#section-b.6" class="section-number selfRef">B.6. </a><a href="#name-generic-format-options" class="section-name selfRef">Generic Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.6-1">
-          <dt id="section-b.6-1.1">
+<section id="appendix-B.6">
+        <h3 id="name-generic-format-options">
+<a href="#appendix-B.6" class="section-number selfRef">B.6. </a><a href="#name-generic-format-options" class="section-name selfRef">Generic Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.6-1">
+          <dt id="appendix-B.6-1.1">
 <div id="option--v3">
 <code>--v3</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.2">
-            <p id="section-b.6-1.2.1">
-                          With --text and --html: use the v3 formatter, rather than the legacy one.<a href="#section-b.6-1.2.1" class="pilcrow">¶</a></p>
-<p id="section-b.6-1.2.2">
-       This is the default.  With both v2 schema and v3 schema XML input files, use the v3 output formatters.  Input with deprecated v2 elements will be converted to v3 on the fly.  This means some loss of functionality and exact control of the output, due to the intermediary conversion step.<a href="#section-b.6-1.2.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.2">
+            <p id="appendix-B.6-1.2.1">
+                          With --text and --html: use the v3 formatter, rather than the legacy one.<a href="#appendix-B.6-1.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.6-1.2.2">
+       This is the default.  With both v2 schema and v3 schema XML input files, use the v3 output formatters.  Input with deprecated v2 elements will be converted to v3 on the fly.  This means some loss of functionality and exact control of the output, due to the intermediary conversion step.<a href="#appendix-B.6-1.2.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.6-1.3">
+<dt id="appendix-B.6-1.3">
 <div id="option--v2">
 <code>--v2</code>, <code>--legacy</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.4">
-            <p id="section-b.6-1.4.1">
-                          With --text and --html: use the legacy output formatters, rather than the v3 ones.<a href="#section-b.6-1.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.6-1.4.2">
-       Invokes the legacy (schema v2) validator and output formatters, instead of the default schema v3 output formatters.  This can only be used with pure v2 input files.<a href="#section-b.6-1.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.4">
+            <p id="appendix-B.6-1.4.1">
+                          With --text and --html: use the legacy output formatters, rather than the v3 ones.<a href="#appendix-B.6-1.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.6-1.4.2">
+       Invokes the legacy (schema v2) validator and output formatters, instead of the default schema v3 output formatters.  This can only be used with pure v2 input files.<a href="#appendix-B.6-1.4.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.6-1.5">
+<dt id="appendix-B.6-1.5">
 <div id="option--id-is-work-in-progress">
 <code>--id-is-work-in-progress</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.6">
-            <p id="section-b.6-1.6.1">
-                          In references, refer to Internet-Drafts as "Work in Progress".<a href="#section-b.6-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.6">
+            <p id="appendix-B.6-1.6.1">
+                          In references, refer to Internet-Drafts as "Work in Progress".<a href="#appendix-B.6-1.6.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.7">
-        <h2 id="name-text-format-options">
-<a href="#section-b.7" class="section-number selfRef">B.7. </a><a href="#name-text-format-options" class="section-name selfRef">Text Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1">
-          <dt id="section-b.7-1.1">
+<section id="appendix-B.7">
+        <h3 id="name-text-format-options">
+<a href="#appendix-B.7" class="section-number selfRef">B.7. </a><a href="#name-text-format-options" class="section-name selfRef">Text Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1">
+          <dt id="appendix-B.7-1.1">
 <div id="option--no-headers">
 <code>--no-headers</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.2">
-            <p id="section-b.7-1.2.1">
-                          Calculate page breaks, and emit form feeds and page top spacing, but omit headers and footers from the paginated format.<a href="#section-b.7-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.2">
+            <p id="appendix-B.7-1.2.1">
+                          Calculate page breaks, and emit form feeds and page top spacing, but omit headers and footers from the paginated format.<a href="#appendix-B.7-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.3">
+<dt id="appendix-B.7-1.3">
 <div id="option--legacy-list-symbols">
 <code>--legacy-list-symbols</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.4">
-            <p id="section-b.7-1.4.1">
-                          Use the legacy list bullet symbols, rather than the new ones.<a href="#section-b.7-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.4">
+            <p id="appendix-B.7-1.4.1">
+                          Use the legacy list bullet symbols, rather than the new ones.<a href="#appendix-B.7-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.5">
+<dt id="appendix-B.7-1.5">
 <div id="option--legacy-date-format">
 <code>--legacy-date-format</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.6">
-            <p id="section-b.7-1.6.1">
-                          Use the legacy date format, rather than the new one.<a href="#section-b.7-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.6.2">
-                          This option can be negated with --no-legacy-date-format.<a href="#section-b.7-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.6">
+            <p id="appendix-B.7-1.6.1">
+                          Use the legacy date format, rather than the new one.<a href="#appendix-B.7-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.6.2">
+                          This option can be negated with --no-legacy-date-format.<a href="#appendix-B.7-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.7">
+<dt id="appendix-B.7-1.7">
 <div id="option--list-symbols">
 <code>--list-symbols</code> = 4*CHAR                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.8">
-            <p id="section-b.7-1.8.1">
-                          Use the characters given as list bullet symbols.<a href="#section-b.7-1.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.8">
+            <p id="appendix-B.7-1.8.1">
+                          Use the characters given as list bullet symbols.<a href="#appendix-B.7-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.9">
+<dt id="appendix-B.7-1.9">
 <div id="option--BOM">
 <code>--BOM</code>, <code>--bom</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.10">
-            <p id="section-b.7-1.10.1">
-                          Add a BOM (unicode byte order mark) to the start of text files.<a href="#section-b.7-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.10">
+            <p id="appendix-B.7-1.10.1">
+                          Add a BOM (unicode byte order mark) to the start of text files.<a href="#appendix-B.7-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.11">
+<dt id="appendix-B.7-1.11">
 <div id="option--pagination">
 <code>--pagination</code>, <code>--paginate</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.12">
-            <p id="section-b.7-1.12.1">
-                          Do pagination.<a href="#section-b.7-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.12.2">
-       By default, drafts are paginated, but not RFCs.  Use this switch if you want to force pagination of all text output.<a href="#section-b.7-1.12.2" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.12.3">
-                          This option can be negated with --no-pagination.<a href="#section-b.7-1.12.3" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.12">
+            <p id="appendix-B.7-1.12.1">
+                          Do pagination.<a href="#appendix-B.7-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.12.2">
+       By default, drafts are paginated, but not RFCs.  Use this switch if you want to force pagination of all text output.<a href="#appendix-B.7-1.12.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.12.3">
+                          This option can be negated with --no-pagination.<a href="#appendix-B.7-1.12.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.13">
+<dt id="appendix-B.7-1.13">
 <div id="option--table-hyphen-breaks">
 <code>--table-hyphen-breaks</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.14">
-            <p id="section-b.7-1.14.1">
-                          More easily do line breaks after hyphens in table cells to give a more compact table.<a href="#section-b.7-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.14">
+            <p id="appendix-B.7-1.14.1">
+                          More easily do line breaks after hyphens in table cells to give a more compact table.<a href="#appendix-B.7-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.15">
+<dt id="appendix-B.7-1.15">
 <div id="option--table-borders">
 <code>--table-borders</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.16">
-            <p id="section-b.7-1.16.1"><br>Default value: full<a href="#section-b.7-1.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.16.2">
-                          The style of table borders to use for text output; one of full/light/minimal.<a href="#section-b.7-1.16.2" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.16.3">
-       Examples (these will only have visible differences in text mode):<a href="#section-b.7-1.16.3" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.4">
-              <dt id="section-b.7-1.16.4.1">"full":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.4.2">
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.16">
+            <p id="appendix-B.7-1.16.1"><br>Default value: full<a href="#appendix-B.7-1.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.16.2">
+                          The style of table borders to use for text output; one of full/light/minimal.<a href="#appendix-B.7-1.16.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.16.3">
+       Examples (these will only have visible differences in text mode):<a href="#appendix-B.7-1.16.3" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.4">
+              <dt id="appendix-B.7-1.16.4.1">"full":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.4.2">
                 <table class="center" id="table-2">
                   <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
 <thead>
@@ -6063,13 +6063,13 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.4.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.4.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.5">
-              <dt id="section-b.7-1.16.5.1">"light":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.5.2">
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.5">
+              <dt id="appendix-B.7-1.16.5.1">"light":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.5.2">
                 <table class="center" id="table-3">
                   <caption><a href="#table-3" class="selfRef">Table 3</a></caption>
 <thead>
@@ -6111,13 +6111,13 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.5.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.5.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.6">
-              <dt id="section-b.7-1.16.6.1">"minimal":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.6.2">
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.6">
+              <dt id="appendix-B.7-1.16.6.1">"minimal":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.6.2">
                 <table class="center" id="table-4">
                   <caption><a href="#table-4" class="selfRef">Table 4</a></caption>
 <thead>
@@ -6159,7 +6159,7 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.6.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.6.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
@@ -6167,213 +6167,213 @@ start |= rfc
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.8">
-        <h2 id="name-html-format-options">
-<a href="#section-b.8" class="section-number selfRef">B.8. </a><a href="#name-html-format-options" class="section-name selfRef">Html Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.8-1">
-          <dt id="section-b.8-1.1">
+<section id="appendix-B.8">
+        <h3 id="name-html-format-options">
+<a href="#appendix-B.8" class="section-number selfRef">B.8. </a><a href="#name-html-format-options" class="section-name selfRef">Html Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.8-1">
+          <dt id="appendix-B.8-1.1">
 <div id="option--css">
 <code>--css</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.2">
-            <p id="section-b.8-1.2.1">
-                          Use the given CSS file instead of the builtin.<a href="#section-b.8-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.2">
+            <p id="appendix-B.8-1.2.1">
+                          Use the given CSS file instead of the builtin.<a href="#appendix-B.8-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.3">
+<dt id="appendix-B.8-1.3">
 <div id="option--external-css">
 <code>--external-css</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.4">
-            <p id="section-b.8-1.4.1">
-                          Place css in external files.<a href="#section-b.8-1.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.4.2">
-                          This option can be negated with --no-external-css.<a href="#section-b.8-1.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.4">
+            <p id="appendix-B.8-1.4.1">
+                          Place css in external files.<a href="#appendix-B.8-1.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.4.2">
+                          This option can be negated with --no-external-css.<a href="#appendix-B.8-1.4.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.5">
+<dt id="appendix-B.8-1.5">
 <div id="option--external-js">
 <code>--external-js</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.6">
-            <p id="section-b.8-1.6.1">
-                          Place js in external files.<a href="#section-b.8-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.6.2">
-                          This option can be negated with --no-external-js.<a href="#section-b.8-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.6">
+            <p id="appendix-B.8-1.6.1">
+                          Place js in external files.<a href="#appendix-B.8-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.6.2">
+                          This option can be negated with --no-external-js.<a href="#appendix-B.8-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.7">
+<dt id="appendix-B.8-1.7">
 <div id="option--rfc-base-url">
 <code>--rfc-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.8">
-            <p id="section-b.8-1.8.1"><br>Default value: https://www.rfc-editor.org/rfc/<a href="#section-b.8-1.8.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.8.2">
-                          Base URL for RFC links.<a href="#section-b.8-1.8.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.8">
+            <p id="appendix-B.8-1.8.1"><br>Default value: https://www.rfc-editor.org/rfc/<a href="#appendix-B.8-1.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.8.2">
+                          Base URL for RFC links.<a href="#appendix-B.8-1.8.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.9">
+<dt id="appendix-B.8-1.9">
 <div id="option--id-base-url">
 <code>--id-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.10">
-            <p id="section-b.8-1.10.1"><br>Default value: https://tools.ietf.org/html/<a href="#section-b.8-1.10.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.10.2">
-                          Base URL for Internet-Draft links.<a href="#section-b.8-1.10.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.10">
+            <p id="appendix-B.8-1.10.1"><br>Default value: https://tools.ietf.org/html/<a href="#appendix-B.8-1.10.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.10.2">
+                          Base URL for Internet-Draft links.<a href="#appendix-B.8-1.10.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.11">
+<dt id="appendix-B.8-1.11">
 <div id="option--rfc-reference-base-url">
 <code>--rfc-reference-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.12">
-            <p id="section-b.8-1.12.1"><br>Default value: https://rfc-editor.org/rfc/<a href="#section-b.8-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.12.2">
-                          Base URL for RFC reference targets, replacing the target="..." value given in the reference entry.<a href="#section-b.8-1.12.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.12">
+            <p id="appendix-B.8-1.12.1"><br>Default value: https://rfc-editor.org/rfc/<a href="#appendix-B.8-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.12.2">
+                          Base URL for RFC reference targets, replacing the target="..." value given in the reference entry.<a href="#appendix-B.8-1.12.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.13">
+<dt id="appendix-B.8-1.13">
 <div id="option--id-reference-base-url">
 <code>--id-reference-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.14">
-            <p id="section-b.8-1.14.1"><br>Default value: https://tools.ietf.org/html/<a href="#section-b.8-1.14.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.14.2">
-                          Base URL for I-D reference targets.<a href="#section-b.8-1.14.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.14">
+            <p id="appendix-B.8-1.14.1"><br>Default value: https://tools.ietf.org/html/<a href="#appendix-B.8-1.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.14.2">
+                          Base URL for I-D reference targets.<a href="#appendix-B.8-1.14.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.15">
+<dt id="appendix-B.8-1.15">
 <div id="option--metadata-js-url">
 <code>--metadata-js-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.16">
-            <p id="section-b.8-1.16.1"><br>Default value: metadata.min.js<a href="#section-b.8-1.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.16.2">
-                          URL for the metadata script.<a href="#section-b.8-1.16.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.16">
+            <p id="appendix-B.8-1.16.1"><br>Default value: metadata.min.js<a href="#appendix-B.8-1.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.16.2">
+                          URL for the metadata script.<a href="#appendix-B.8-1.16.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.9">
-        <h2 id="name-v2-v3-converter-options">
-<a href="#section-b.9" class="section-number selfRef">B.9. </a><a href="#name-v2-v3-converter-options" class="section-name selfRef">V2-V3 Converter Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.9-1">
-          <dt id="section-b.9-1.1">
+<section id="appendix-B.9">
+        <h3 id="name-v2-v3-converter-options">
+<a href="#appendix-B.9" class="section-number selfRef">B.9. </a><a href="#name-v2-v3-converter-options" class="section-name selfRef">V2-V3 Converter Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.9-1">
+          <dt id="appendix-B.9-1.1">
 <div id="option--add-xinclude">
 <code>--add-xinclude</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.2">
-            <p id="section-b.9-1.2.1">
-                          Replace reference elements with RFC and Internet-Draft seriesInfo with the appropriate XInclude element.<a href="#section-b.9-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.2">
+            <p id="appendix-B.9-1.2.1">
+                          Replace reference elements with RFC and Internet-Draft seriesInfo with the appropriate XInclude element.<a href="#appendix-B.9-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.9-1.3">
+<dt id="appendix-B.9-1.3">
 <div id="option--draft-revs">
 <code>--draft-revs</code>, <code>--draft-revisions</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.4">
-            <p id="section-b.9-1.4.1">
-                          Reference explicit draft revisions when inserting XIncludes for draft references.<a href="#section-b.9-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.4">
+            <p id="appendix-B.9-1.4.1">
+                          Reference explicit draft revisions when inserting XIncludes for draft references.<a href="#appendix-B.9-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.9-1.5">
+<dt id="appendix-B.9-1.5">
 <div id="option--strict">
 <code>--strict</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.6">
-            <p id="section-b.9-1.6.1">
-                          Be strict about stripping some deprecated attributes.<a href="#section-b.9-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.6">
+            <p id="appendix-B.9-1.6.1">
+                          Be strict about stripping some deprecated attributes.<a href="#appendix-B.9-1.6.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.10">
-        <h2 id="name-preptool-options">
-<a href="#section-b.10" class="section-number selfRef">B.10. </a><a href="#name-preptool-options" class="section-name selfRef">Preptool Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.10-1">
-          <dt id="section-b.10-1.1">
+<section id="appendix-B.10">
+        <h3 id="name-preptool-options">
+<a href="#appendix-B.10" class="section-number selfRef">B.10. </a><a href="#name-preptool-options" class="section-name selfRef">Preptool Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.10-1">
+          <dt id="appendix-B.10-1.1">
 <div id="option--accept-prepped">
 <code>--accept-prepped</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.10-1.2">
-            <p id="section-b.10-1.2.1">
-                          Accept already prepped input.<a href="#section-b.10-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.10-1.2">
+            <p id="appendix-B.10-1.2.1">
+                          Accept already prepped input.<a href="#appendix-B.10-1.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-xml2rfc-configuration-files">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-xml2rfc-configuration-files" class="section-name selfRef"><code>xml2rfc</code> Configuration Files</a>
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-xml2rfc-configuration-files" class="section-name selfRef"><code>xml2rfc</code> Configuration Files</a>
       </h2>
-<p id="section-appendix.c-1">
-       Most options have built-in defaults, and the command-line switches above can be used to override those.  Additionally, <code>xml2rfc</code> will look for config files in some standard file locations.  The option <code>--⁠values</code> will show the places <code>xml2rfc</code> will look for config files on your system (among other information).  Any settings in config files will override the program defaults, but will in turn be overridden by command-line options.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.c-2">
-       The config files are expected to contain lines with option value assignments. Lines with '#' as the first character are considered comments.  Here is an example:<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
-<div id="section-appendix.c-3">
+<p id="appendix-C-1">
+       Most options have built-in defaults, and the command-line switches above can be used to override those.  Additionally, <code>xml2rfc</code> will look for config files in some standard file locations.  The option <code>--⁠values</code> will show the places <code>xml2rfc</code> will look for config files on your system (among other information).  Any settings in config files will override the program defaults, but will in turn be overridden by command-line options.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">
+       The config files are expected to contain lines with option value assignments. Lines with '#' as the first character are considered comments.  Here is an example:<a href="#appendix-C-2" class="pilcrow">¶</a></p>
+<div id="appendix-C-3">
 <pre class="sourcecode">
 # ----
 legacy-date-format = true
 add-xinclude = true
 external-js = false
 # ----
-</pre><a href="#section-appendix.c-3" class="pilcrow">¶</a>
+</pre><a href="#appendix-C-3" class="pilcrow">¶</a>
 </div>
-<p id="section-appendix.c-4">
-       The complete long option names must be used in configuration files; abbreviations will not be recognised (in contrast with how abbreviations are handled during command-line option processing).<a href="#section-appendix.c-4" class="pilcrow">¶</a></p>
+<p id="appendix-C-4">
+       The complete long option names must be used in configuration files; abbreviations will not be recognised (in contrast with how abbreviations are handled during command-line option processing).<a href="#appendix-C-4" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.d">
+<section id="appendix-D">
       <h2 id="name-xml2rfc-documentation-templ">
-<a href="#section-appendix.d" class="section-number selfRef">Appendix D. </a><a href="#name-xml2rfc-documentation-templ" class="section-name selfRef"><code>xml2rfc</code> Documentation Template Variables</a>
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-xml2rfc-documentation-templ" class="section-name selfRef"><code>xml2rfc</code> Documentation Template Variables</a>
       </h2>
-<p id="section-appendix.d-1">
+<p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.7.0:<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-appendix.d-2">
-        <dt id="section-appendix.d-2.1">{{ bare_latin_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.2"></dd>
+            manpage Jinja2 template, as of xml2rfc version 3.7.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-D-2">
+        <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.3">{{ descriptions }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.4">The descriptions read from the <code>doc.yaml</code> file<a href="#section-appendix.d-2.4" class="pilcrow">¶</a>
+<dt id="appendix-D-2.3">{{ descriptions }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.4">The descriptions read from the <code>doc.yaml</code> file<a href="#appendix-D-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.5">{{ element_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.6">A list of all the element tags in the XML schema<a href="#section-appendix.d-2.6" class="pilcrow">¶</a>
+<dt id="appendix-D-2.5">{{ element_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.6">A list of all the element tags in the XML schema<a href="#appendix-D-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.7">{{ elements }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.8">A list of dictionaries, each with information about one schema element: {"attributes": ..., "children": ..., "deprecated": ..., "deprecated_attributes": ..., "description": ..., "new": ..., "parents": ..., "rnc": ..., "tag": ..., }<a href="#section-appendix.d-2.8" class="pilcrow">¶</a>
+<dt id="appendix-D-2.7">{{ elements }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.8">A list of dictionaries, each with information about one schema element: {"attributes": ..., "children": ..., "deprecated": ..., "deprecated_attributes": ..., "description": ..., "new": ..., "parents": ..., "rnc": ..., "tag": ..., }<a href="#appendix-D-2.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.9">{{ options }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.10">A list of dictionaries describing the command-line options<a href="#section-appendix.d-2.10" class="pilcrow">¶</a>
+<dt id="appendix-D-2.9">{{ options }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.10">A list of dictionaries describing the command-line options<a href="#appendix-D-2.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.11">{{ schema }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.12">The full RelaxNG Compact representation of the schema in text form<a href="#section-appendix.d-2.12" class="pilcrow">¶</a>
+<dt id="appendix-D-2.11">{{ schema }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.12">The full RelaxNG Compact representation of the schema in text form<a href="#appendix-D-2.12" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.13">{{ toc_depth }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.14">ToC depth setting; 1 when running --man, 2 otherwise<a href="#section-appendix.d-2.14" class="pilcrow">¶</a>
+<dt id="appendix-D-2.13">{{ toc_depth }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.14">ToC depth setting; 1 when running --man, 2 otherwise<a href="#appendix-D-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.15">{{ v3_element_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.16">A list of v3 element tags, excluding deprecated tags<a href="#section-appendix.d-2.16" class="pilcrow">¶</a>
+<dt id="appendix-D-2.15">{{ v3_element_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.16">A list of v3 element tags, excluding deprecated tags<a href="#appendix-D-2.16" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.17">{{ version }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.18">The xml2rfc version number<a href="#section-appendix.d-2.18" class="pilcrow">¶</a>
+<dt id="appendix-D-2.17">{{ version }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.18">The xml2rfc version number<a href="#appendix-D-2.18" class="pilcrow">¶</a>
 </dd>
       <dd class="break"></dd>
 </dl>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.e">
+<section id="appendix-E">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/docfile.py38.html
+++ b/cli/tests/valid/docfile.py38.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta content="Cherokee,Common,Greek,Latin" name="scripts">
 <meta content="initial-scale=1.0" name="viewport">
-<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.7.0</title>
+<title>Xml2rfc Vocabulary Version 3 Schema xml2rfc release 3.8.0</title>
 <meta content="xml2rfc(1)" name="author">
 <meta content="
        
        This document provides information about the XML schema implemented in this release of xml2rfc, and the individual elements of that schema.  The document is generated from the RNG schema file that is part of the xml2rfc distribution, so schema information in this document should always be in sync with the schema in actual use.  The textual descriptions depend on manual updates in order to reflect the implementation.
        
     " name="description">
-<meta content="xml2rfc 3.7.0" name="generator">
-<meta content="xml2rfc-docs-3.7.0" name="ietf.draft">
+<meta content="xml2rfc 3.8.0" name="generator">
+<meta content="xml2rfc-docs-3.8.0" name="ietf.draft">
 <link href="tests/out/docfile.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <link href="xml2rfc.css" rel="stylesheet">
@@ -24,7 +24,7 @@
 <thead><tr>
 <td class="left"></td>
 <td class="center">Xml2rfc Vocabulary V3 Schema</td>
-<td class="right">May 2021</td>
+<td class="right">June 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">xml2rfc(1)</td>
@@ -45,7 +45,7 @@
 </dd>
 </dl>
 </div>
-<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.7.0</h1>
+<h1 id="title">Xml2rfc Vocabulary Version 3 Schema<br>xml2rfc release 3.8.0</h1>
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
@@ -367,7 +367,7 @@
 <p id="section-1-5">
        The latest version of this documentation is available in HTML form at <span><a href="https://xml2rfc.ietf.org/xml2rfc-doc">https://xml2rfc.ietf.org/xml2rfc-doc</a></span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
 <p id="section-1-6">
-            This documentation applies to xml2rfc version 3.7.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
+            This documentation applies to xml2rfc version 3.8.0.<a href="#section-1-6" class="pilcrow">¶</a></p>
 </section>
 <section id="section-2">
       <h2 id="name-schema-version-3-elements">
@@ -6333,7 +6333,7 @@ external-js = false
 <p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.7.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+            manpage Jinja2 template, as of xml2rfc version 3.8.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="appendix-D-2">
         <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
         <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>

--- a/cli/tests/valid/docfile.py38.html
+++ b/cli/tests/valid/docfile.py38.html
@@ -302,51 +302,51 @@
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-references-2" class="xref">References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-relax-ng-schema" class="xref">RELAX NG Schema</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-relax-ng-schema" class="xref">RELAX NG Schema</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-xml2rfc-command-line-option" class="xref"><code>xml2rfc</code> Command-line Options</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-xml2rfc-command-line-option" class="xref"><code>xml2rfc</code> Command-line Options</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-positional-arguments" class="xref">Positional arguments</a></p>
+                <p id="section-toc.1-1.6.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-positional-arguments" class="xref">Positional arguments</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-documentation-options" class="xref">Documentation options</a></p>
+                <p id="section-toc.1-1.6.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-documentation-options" class="xref">Documentation options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.3">
-                <p id="section-toc.1-1.6.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-format-selection" class="xref">Format selection</a></p>
+                <p id="section-toc.1-1.6.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-format-selection" class="xref">Format selection</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.4">
-                <p id="section-toc.1-1.6.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-generic-switch-options" class="xref">Generic Switch Options</a></p>
+                <p id="section-toc.1-1.6.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-generic-switch-options" class="xref">Generic Switch Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.5">
-                <p id="section-toc.1-1.6.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-generic-options-with-values" class="xref">Generic Options with Values</a></p>
+                <p id="section-toc.1-1.6.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-generic-options-with-values" class="xref">Generic Options with Values</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.6">
-                <p id="section-toc.1-1.6.2.6.1"><a href="#section-b.6" class="xref">B.6</a>.  <a href="#name-generic-format-options" class="xref">Generic Format Options</a></p>
+                <p id="section-toc.1-1.6.2.6.1"><a href="#appendix-B.6" class="xref">B.6</a>.  <a href="#name-generic-format-options" class="xref">Generic Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.7">
-                <p id="section-toc.1-1.6.2.7.1"><a href="#section-b.7" class="xref">B.7</a>.  <a href="#name-text-format-options" class="xref">Text Format Options</a></p>
+                <p id="section-toc.1-1.6.2.7.1"><a href="#appendix-B.7" class="xref">B.7</a>.  <a href="#name-text-format-options" class="xref">Text Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.8">
-                <p id="section-toc.1-1.6.2.8.1"><a href="#section-b.8" class="xref">B.8</a>.  <a href="#name-html-format-options" class="xref">Html Format Options</a></p>
+                <p id="section-toc.1-1.6.2.8.1"><a href="#appendix-B.8" class="xref">B.8</a>.  <a href="#name-html-format-options" class="xref">Html Format Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.9">
-                <p id="section-toc.1-1.6.2.9.1"><a href="#section-b.9" class="xref">B.9</a>.  <a href="#name-v2-v3-converter-options" class="xref">V2-V3 Converter Options</a></p>
+                <p id="section-toc.1-1.6.2.9.1"><a href="#appendix-B.9" class="xref">B.9</a>.  <a href="#name-v2-v3-converter-options" class="xref">V2-V3 Converter Options</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.10">
-                <p id="section-toc.1-1.6.2.10.1"><a href="#section-b.10" class="xref">B.10</a>. <a href="#name-preptool-options" class="xref">Preptool Options</a></p>
+                <p id="section-toc.1-1.6.2.10.1"><a href="#appendix-B.10" class="xref">B.10</a>. <a href="#name-preptool-options" class="xref">Preptool Options</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-xml2rfc-configuration-files" class="xref"><code>xml2rfc</code> Configuration Files</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-xml2rfc-configuration-files" class="xref"><code>xml2rfc</code> Configuration Files</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-appendix.d" class="xref">Appendix D</a>.  <a href="#name-xml2rfc-documentation-templ" class="xref"><code>xml2rfc</code> Documentation Template Variables</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#appendix-D" class="xref">Appendix D</a>.  <a href="#name-xml2rfc-documentation-templ" class="xref"><code>xml2rfc</code> Documentation Template Variables</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-appendix.e" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#appendix-E" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -4306,11 +4306,11 @@ src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww..."&gt;
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-relax-ng-schema">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-relax-ng-schema" class="section-name selfRef">RELAX NG Schema</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-relax-ng-schema" class="section-name selfRef">RELAX NG Schema</a>
       </h2>
-<div id="section-appendix.a-1">
+<div id="appendix-A-1">
 <pre class="sourcecode lang-relax-ng-compact">&lt;CODE BEGINS&gt; file "v3.rnc"
 
 
@@ -5458,570 +5458,570 @@ u =
 start |= rfc
 
 
-&lt;CODE ENDS&gt;</pre><a href="#section-appendix.a-1" class="pilcrow">¶</a>
+&lt;CODE ENDS&gt;</pre><a href="#appendix-A-1" class="pilcrow">¶</a>
 </div>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-xml2rfc-command-line-option">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-xml2rfc-command-line-option" class="section-name selfRef"><code>xml2rfc</code> Command-line Options</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-xml2rfc-command-line-option" class="section-name selfRef"><code>xml2rfc</code> Command-line Options</a>
       </h2>
-<p id="section-appendix.b-1">
-       The following command-line options are available.  Long options may be shortened to the shortest substring that still makes the option string unique, when given on the command line.  In config files, the full long option string must be used.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
-<section id="section-b.1">
-        <h2 id="name-positional-arguments">
-<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-positional-arguments" class="section-name selfRef">Positional arguments</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.1-1">
-          <dt id="section-b.1-1.1"><code>source</code></dt>
-          <dd style="margin-left: 1.5em" id="section-b.1-1.2">Input XML file to render to one or more of the available formats.<a href="#section-b.1-1.2" class="pilcrow">¶</a>
+<p id="appendix-B-1">
+       The following command-line options are available.  Long options may be shortened to the shortest substring that still makes the option string unique, when given on the command line.  In config files, the full long option string must be used.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<section id="appendix-B.1">
+        <h3 id="name-positional-arguments">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-positional-arguments" class="section-name selfRef">Positional arguments</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.1-1">
+          <dt id="appendix-B.1-1.1"><code>source</code></dt>
+          <dd style="margin-left: 1.5em" id="appendix-B.1-1.2">Input XML file to render to one or more of the available formats.<a href="#appendix-B.1-1.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.2">
-        <h2 id="name-documentation-options">
-<a href="#section-b.2" class="section-number selfRef">B.2. </a><a href="#name-documentation-options" class="section-name selfRef">Documentation options</a>
-        </h2>
-<p id="section-b.2-1">
+<section id="appendix-B.2">
+        <h3 id="name-documentation-options">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-documentation-options" class="section-name selfRef">Documentation options</a>
+        </h3>
+<p id="appendix-B.2-1">
                Some options to generate built-in documentation.
-               The group has 8 options.<a href="#section-b.2-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.2-2">
-          <dt id="section-b.2-2.1">
+               The group has 8 options.<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.2-2">
+          <dt id="appendix-B.2-2.1">
 <div id="option--help">
 <code>--help</code>, <code>-h</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.2">
-            <p id="section-b.2-2.2.1">
-                          Show a help message and exit.<a href="#section-b.2-2.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.2">
+            <p id="appendix-B.2-2.2.1">
+                          Show a help message and exit.<a href="#appendix-B.2-2.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.3">
+<dt id="appendix-B.2-2.3">
 <div id="option--docfile">
 <code>--docfile</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.4">
-            <p id="section-b.2-2.4.1">
-                          Generate a documentation XML file ready for formatting.<a href="#section-b.2-2.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.4.2">
-       The <code>--docfile</code> and <code>--manpage</code> switches takes input from 5 places:<a href="#section-b.2-2.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.4">
+            <p id="appendix-B.2-2.4.1">
+                          Generate a documentation XML file ready for formatting.<a href="#appendix-B.2-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.4.2">
+       The <code>--docfile</code> and <code>--manpage</code> switches takes input from 5 places:<a href="#appendix-B.2-2.4.2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-b.2-2.4.3.1">The <code>v3.rng</code> file distributed as part of the xml2rfc package, which is also used to validate and process v3 XML input.<a href="#section-b.2-2.4.3.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-B.2-2.4.3.1">The <code>v3.rng</code> file distributed as part of the xml2rfc package, which is also used to validate and process v3 XML input.<a href="#appendix-B.2-2.4.3.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.2">A <code>rfc7991.rng</code> file distributed as part of the xml2rfc package, which holds the schema defined in <span>[<a href="#RFC7991" class="xref">RFC7991</a>]</span>.  This is used in determining elements and attributes that are new in the current <code>v3.rng</code> schema, compared to the RFC7991 schema.<a href="#section-b.2-2.4.3.2" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.2">A <code>rfc7991.rng</code> file distributed as part of the xml2rfc package, which holds the schema defined in <span>[<a href="#RFC7991" class="xref">RFC7991</a>]</span>.  This is used in determining elements and attributes that are new in the current <code>v3.rng</code> schema, compared to the RFC7991 schema.<a href="#appendix-B.2-2.4.3.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.3">Lists of deprecated elements and attributes, which are part of the xml2rfc source.<a href="#section-b.2-2.4.3.3" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.3">Lists of deprecated elements and attributes, which are part of the xml2rfc source.<a href="#appendix-B.2-2.4.3.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.4">A YAML file <code>doc.yaml</code> that contains XML snippets with descriptions of elements, attributes, attribute values, and switches, from the same directory as <code>doc.xml</code>.<a href="#section-b.2-2.4.3.4" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.4">A YAML file <code>doc.yaml</code> that contains XML snippets with descriptions of elements, attributes, attribute values, and switches, from the same directory as <code>doc.xml</code>.<a href="#appendix-B.2-2.4.3.4" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.4.3.5">An XML template file <code>doc.xml</code>, by default taken from the <code>templates</code> directory of the xml2rfc package (but this can be changed with the <code>--templates-dir</code> switch).  The 4 preceding sources provide content that is used to expand the template file when generating the <code>--⁠docfile</code> and <code>--⁠manpage</code> output.<a href="#section-b.2-2.4.3.5" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.4.3.5">An XML template file <code>doc.xml</code>, by default taken from the <code>templates</code> directory of the xml2rfc package (but this can be changed with the <code>--templates-dir</code> switch).  The 4 preceding sources provide content that is used to expand the template file when generating the <code>--⁠docfile</code> and <code>--⁠manpage</code> output.<a href="#appendix-B.2-2.4.3.5" class="pilcrow">¶</a>
 </li>
             </ul>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.5">
+<dt id="appendix-B.2-2.5">
 <div id="option--manpage">
 <code>--manpage</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.6">
-            <p id="section-b.2-2.6.1">
-                          Show paged text documentation.<a href="#section-b.2-2.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.6.2">
-       Generates on-the-fly paged text documentation for the v3 schema elements and attributes from the v3 RelaxNG schema file which is part of the xml2rfc distribution, and YAML and XML files that provide the text content and formatting.  See the <code>--docfile</code> switch for more details.<a href="#section-b.2-2.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.6">
+            <p id="appendix-B.2-2.6.1">
+                          Show paged text documentation.<a href="#appendix-B.2-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.6.2">
+       Generates on-the-fly paged text documentation for the v3 schema elements and attributes from the v3 RelaxNG schema file which is part of the xml2rfc distribution, and YAML and XML files that provide the text content and formatting.  See the <code>--docfile</code> switch for more details.<a href="#appendix-B.2-2.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.7">
+<dt id="appendix-B.2-2.7">
 <div id="option--country-help">
 <code>--country-help</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.8">
-            <p id="section-b.2-2.8.1">
-                          Show the recognized &lt;country&gt; strings.<a href="#section-b.2-2.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.8">
+            <p id="appendix-B.2-2.8.1">
+                          Show the recognized &lt;country&gt; strings.<a href="#appendix-B.2-2.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.9">
+<dt id="appendix-B.2-2.9">
 <div id="option--pdf-help">
 <code>--pdf-help</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.10">
-            <p id="section-b.2-2.10.1">
-                          Show pdf generation requirements.<a href="#section-b.2-2.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.10">
+            <p id="appendix-B.2-2.10.1">
+                          Show pdf generation requirements.<a href="#appendix-B.2-2.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.11">
+<dt id="appendix-B.2-2.11">
 <div id="option--template-dir">
 <code>--template-dir</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.12">
-            <p id="section-b.2-2.12.1">
-                          Directory to pull the doc.xml and doc.yaml templates from.  The default is the "templates" directory of the xml2rfc package.<a href="#section-b.2-2.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.12.2">
-       This is used to find the templates used by the <code>--⁠docfile</code> and <code>--⁠manpage</code> commands and for legacy .html template and .dtd files.<a href="#section-b.2-2.12.2" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.12.3">
-       A consequence of being able to specify a different template directory than the default is that it's possible to use the <code>--⁠docfile</code> command to generate additional documentation XML files based on the current V3 grammar file.  The default template and snippets file does not include documentation for deprecated elements and attributes, for instance; but if it is desired to generate such documentation from the distributed V3 RelaxNg schema, it should be straightforward.  The templating system used is Jinja2; the snippens file is YAML with extra support for some escape sequences: '\ &lt;' and '\ &gt;'.<a href="#section-b.2-2.12.3" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.12">
+            <p id="appendix-B.2-2.12.1">
+                          Directory to pull the doc.xml and doc.yaml templates from.  The default is the "templates" directory of the xml2rfc package.<a href="#appendix-B.2-2.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.12.2">
+       This is used to find the templates used by the <code>--⁠docfile</code> and <code>--⁠manpage</code> commands and for legacy .html template and .dtd files.<a href="#appendix-B.2-2.12.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.12.3">
+       A consequence of being able to specify a different template directory than the default is that it's possible to use the <code>--⁠docfile</code> command to generate additional documentation XML files based on the current V3 grammar file.  The default template and snippets file does not include documentation for deprecated elements and attributes, for instance; but if it is desired to generate such documentation from the distributed V3 RelaxNg schema, it should be straightforward.  The templating system used is Jinja2; the snippens file is YAML with extra support for some escape sequences: '\ &lt;' and '\ &gt;'.<a href="#appendix-B.2-2.12.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.13">
+<dt id="appendix-B.2-2.13">
 <div id="option--values">
 <code>--values</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.14">
-            <p id="section-b.2-2.14.1">
-                          Show option values and from where they come.<a href="#section-b.2-2.14.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.14.2">
-       This shows (in order):<a href="#section-b.2-2.14.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.14">
+            <p id="appendix-B.2-2.14.1">
+                          Show option values and from where they come.<a href="#appendix-B.2-2.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.14.2">
+       This shows (in order):<a href="#appendix-B.2-2.14.2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-b.2-2.14.3.1">Command line arguments<a href="#section-b.2-2.14.3.1" class="pilcrow">¶</a>
+<li class="compact" id="appendix-B.2-2.14.3.1">Command line arguments<a href="#appendix-B.2-2.14.3.1" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.2">Config file settings, per config file<a href="#section-b.2-2.14.3.2" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.2">Config file settings, per config file<a href="#appendix-B.2-2.14.3.2" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.3">Default values<a href="#section-b.2-2.14.3.3" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.3">Default values<a href="#appendix-B.2-2.14.3.3" class="pilcrow">¶</a>
 </li>
-              <li class="compact" id="section-b.2-2.14.3.4">Config file search path<a href="#section-b.2-2.14.3.4" class="pilcrow">¶</a>
+              <li class="compact" id="appendix-B.2-2.14.3.4">Config file search path<a href="#appendix-B.2-2.14.3.4" class="pilcrow">¶</a>
 </li>
             </ul>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.2-2.15">
+<dt id="appendix-B.2-2.15">
 <div id="option--version">
 <code>--version</code>, <code>-V</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.2-2.16">
-            <p id="section-b.2-2.16.1">
-                          Display the version number and exit.<a href="#section-b.2-2.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.2-2.16.2">
-       With the <code>--verbose</code> switch, the versions of the external python modules used will also be shown.<a href="#section-b.2-2.16.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.2-2.16">
+            <p id="appendix-B.2-2.16.1">
+                          Display the version number and exit.<a href="#appendix-B.2-2.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2.16.2">
+       With the <code>--verbose</code> switch, the versions of the external python modules used will also be shown.<a href="#appendix-B.2-2.16.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.3">
-        <h2 id="name-format-selection">
-<a href="#section-b.3" class="section-number selfRef">B.3. </a><a href="#name-format-selection" class="section-name selfRef">Format selection</a>
-        </h2>
-<p id="section-b.3-1">
+<section id="appendix-B.3">
+        <h3 id="name-format-selection">
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-format-selection" class="section-name selfRef">Format selection</a>
+        </h3>
+<p id="appendix-B.3-1">
                One or more of the following output formats may be specified. The default is --text. The destination filename will be based on the input filename, unless --out=FILE or --basename=BASE is used.
-               The group has 10 options.<a href="#section-b.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.3-2">
-          <dt id="section-b.3-2.1">
+               The group has 10 options.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.3-2">
+          <dt id="appendix-B.3-2.1">
 <div id="option--text">
 <code>--text</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.2">
-            <p id="section-b.3-2.2.1">
-                          Outputs formatted text to file, with proper page breaks.<a href="#section-b.3-2.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.2">
+            <p id="appendix-B.3-2.2.1">
+                          Outputs formatted text to file, with proper page breaks.<a href="#appendix-B.3-2.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.3">
+<dt id="appendix-B.3-2.3">
 <div id="option--html">
 <code>--html</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.4">
-            <p id="section-b.3-2.4.1">
-                          Outputs formatted HTML to file.<a href="#section-b.3-2.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.4">
+            <p id="appendix-B.3-2.4.1">
+                          Outputs formatted HTML to file.<a href="#appendix-B.3-2.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.5">
+<dt id="appendix-B.3-2.5">
 <div id="option--nroff">
 <code>--nroff</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.6">
-            <p id="section-b.3-2.6.1">
-                          Outputs formatted nroff to file (only v2 input).<a href="#section-b.3-2.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.6">
+            <p id="appendix-B.3-2.6.1">
+                          Outputs formatted nroff to file (only v2 input).<a href="#appendix-B.3-2.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.7">
+<dt id="appendix-B.3-2.7">
 <div id="option--pdf">
 <code>--pdf</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.8">
-            <p id="section-b.3-2.8.1">
-                          Outputs formatted PDF to file.<a href="#section-b.3-2.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.8">
+            <p id="appendix-B.3-2.8.1">
+                          Outputs formatted PDF to file.<a href="#appendix-B.3-2.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.9">
+<dt id="appendix-B.3-2.9">
 <div id="option--raw">
 <code>--raw</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.10">
-            <p id="section-b.3-2.10.1">
-                          Outputs formatted text to file, unpaginated (only v2 input).<a href="#section-b.3-2.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.10">
+            <p id="appendix-B.3-2.10.1">
+                          Outputs formatted text to file, unpaginated (only v2 input).<a href="#appendix-B.3-2.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.11">
+<dt id="appendix-B.3-2.11">
 <div id="option--expand">
 <code>--expand</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.12">
-            <p id="section-b.3-2.12.1">
-                          Outputs XML to file with all references expanded.<a href="#section-b.3-2.12.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.12">
+            <p id="appendix-B.3-2.12.1">
+                          Outputs XML to file with all references expanded.<a href="#appendix-B.3-2.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.13">
+<dt id="appendix-B.3-2.13">
 <div id="option--v2v3">
 <code>--v2v3</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.14">
-            <p id="section-b.3-2.14.1">
-                          Convert vocabulary version 2 XML to version 3.<a href="#section-b.3-2.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.14">
+            <p id="appendix-B.3-2.14.1">
+                          Convert vocabulary version 2 XML to version 3.<a href="#appendix-B.3-2.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.15">
+<dt id="appendix-B.3-2.15">
 <div id="option--preptool">
 <code>--preptool</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.16">
-            <p id="section-b.3-2.16.1">
-                          Run preptool on the input.<a href="#section-b.3-2.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.16">
+            <p id="appendix-B.3-2.16.1">
+                          Run preptool on the input.<a href="#appendix-B.3-2.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.17">
+<dt id="appendix-B.3-2.17">
 <div id="option--unprep">
 <code>--unprep</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.18">
-            <p id="section-b.3-2.18.1">
-                          Reduce prepped xml to unprepped.<a href="#section-b.3-2.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.18">
+            <p id="appendix-B.3-2.18.1">
+                          Reduce prepped xml to unprepped.<a href="#appendix-B.3-2.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.3-2.19">
+<dt id="appendix-B.3-2.19">
 <div id="option--info">
 <code>--info</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.3-2.20">
-            <p id="section-b.3-2.20.1">
-                          Generate a JSON file with anchor to section lookup information.<a href="#section-b.3-2.20.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.3-2.20">
+            <p id="appendix-B.3-2.20.1">
+                          Generate a JSON file with anchor to section lookup information.<a href="#appendix-B.3-2.20.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.4">
-        <h2 id="name-generic-switch-options">
-<a href="#section-b.4" class="section-number selfRef">B.4. </a><a href="#name-generic-switch-options" class="section-name selfRef">Generic Switch Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.4-1">
-          <dt id="section-b.4-1.1">
+<section id="appendix-B.4">
+        <h3 id="name-generic-switch-options">
+<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-generic-switch-options" class="section-name selfRef">Generic Switch Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.4-1">
+          <dt id="appendix-B.4-1.1">
 <div id="option--clear-cache">
 <code>--clear-cache</code>, <code>-C</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.2">
-            <p id="section-b.4-1.2.1">
-                          Purge the cache and exit.<a href="#section-b.4-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.2">
+            <p id="appendix-B.4-1.2.1">
+                          Purge the cache and exit.<a href="#appendix-B.4-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.3">
+<dt id="appendix-B.4-1.3">
 <div id="option--debug">
 <code>--debug</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.4">
-            <p id="section-b.4-1.4.1">
-                          Show debugging output.<a href="#section-b.4-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.4">
+            <p id="appendix-B.4-1.4.1">
+                          Show debugging output.<a href="#appendix-B.4-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.5">
+<dt id="appendix-B.4-1.5">
 <div id="option--no-network">
 <code>--no-network</code>, <code>-N</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.6">
-            <p id="section-b.4-1.6.1">
-                          Don't use the network to resolve references.<a href="#section-b.4-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.6">
+            <p id="appendix-B.4-1.6.1">
+                          Don't use the network to resolve references.<a href="#appendix-B.4-1.6.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.7">
+<dt id="appendix-B.4-1.7">
 <div id="option--no-org-info">
 <code>--no-org-info</code>, <code>-O</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.8">
-            <p id="section-b.4-1.8.1">
-                          Don't show author orgainzation info on page one (legacy only).<a href="#section-b.4-1.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.8">
+            <p id="appendix-B.4-1.8.1">
+                          Don't show author orgainzation info on page one (legacy only).<a href="#appendix-B.4-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.9">
+<dt id="appendix-B.4-1.9">
 <div id="option--quiet">
 <code>--quiet</code>, <code>-q</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.10">
-            <p id="section-b.4-1.10.1">
-                          Don't print anything while working.<a href="#section-b.4-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.10">
+            <p id="appendix-B.4-1.10.1">
+                          Don't print anything while working.<a href="#appendix-B.4-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.11">
+<dt id="appendix-B.4-1.11">
 <div id="option--skip-config-files">
 <code>--skip-config-files</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.12">
-            <p id="section-b.4-1.12.1">
-                          Ignore config file settings.<a href="#section-b.4-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.4-1.12.2">
-       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#section-b.4-1.12.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.12">
+            <p id="appendix-B.4-1.12.1">
+                          Ignore config file settings.<a href="#appendix-B.4-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-1.12.2">
+       Use this to ignore values in config files, even if there are config files in the search path.  Somewhat ironically, this option can itself be set in a config file, and cause all other config file settings to be ignored.<a href="#appendix-B.4-1.12.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.13">
+<dt id="appendix-B.4-1.13">
 <div id="option--remove-pis">
 <code>--remove-pis</code>, <code>-r</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.14">
-            <p id="section-b.4-1.14.1">
-                          Remove XML processing instructions.<a href="#section-b.4-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.14">
+            <p id="appendix-B.4-1.14.1">
+                          Remove XML processing instructions.<a href="#appendix-B.4-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.15">
+<dt id="appendix-B.4-1.15">
 <div id="option--utf8">
 <code>--utf8</code>, <code>-u</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.16">
-            <p id="section-b.4-1.16.1">
-                          Generate utf8 output.<a href="#section-b.4-1.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.16">
+            <p id="appendix-B.4-1.16.1">
+                          Generate utf8 output.<a href="#appendix-B.4-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.4-1.17">
+<dt id="appendix-B.4-1.17">
 <div id="option--verbose">
 <code>--verbose</code>, <code>-v</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.4-1.18">
-            <p id="section-b.4-1.18.1">
-                          Print extra information.<a href="#section-b.4-1.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.4-1.18">
+            <p id="appendix-B.4-1.18.1">
+                          Print extra information.<a href="#appendix-B.4-1.18.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.5">
-        <h2 id="name-generic-options-with-values">
-<a href="#section-b.5" class="section-number selfRef">B.5. </a><a href="#name-generic-options-with-values" class="section-name selfRef">Generic Options with Values</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.5-1">
-          <dt id="section-b.5-1.1">
+<section id="appendix-B.5">
+        <h3 id="name-generic-options-with-values">
+<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-generic-options-with-values" class="section-name selfRef">Generic Options with Values</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.5-1">
+          <dt id="appendix-B.5-1.1">
 <div id="option--basename">
 <code>--basename</code>, <code>-b</code> = NAME                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.2">
-            <p id="section-b.5-1.2.1">
-                          Specify the base name for output files.<a href="#section-b.5-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.2">
+            <p id="appendix-B.5-1.2.1">
+                          Specify the base name for output files.<a href="#appendix-B.5-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.3">
+<dt id="appendix-B.5-1.3">
 <div id="option--cache">
 <code>--cache</code>, <code>-c</code> = PATH                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.4">
-            <p id="section-b.5-1.4.1">
-                          Specify a primary cache directory to write to; default: try [ /var/cache/xml2rfc, ~/.cache/xml2rfc ].<a href="#section-b.5-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.4">
+            <p id="appendix-B.5-1.4.1">
+                          Specify a primary cache directory to write to; default: try [ /var/cache/xml2rfc, ~/.cache/xml2rfc ].<a href="#appendix-B.5-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.5">
+<dt id="appendix-B.5-1.5">
 <div id="option--config-file">
 <code>--config-file</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.6">
-            <p id="section-b.5-1.6.1">
-                          Specify a configuration file.<a href="#section-b.5-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.6.2">
-       This argument can be repeated, to read multiple explicitly specified config files.  They will be read after any config files found in 'standard' locations have been read.  Run <code>xml2rfc --values</code> to see the default search path for config files.<a href="#section-b.5-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.6">
+            <p id="appendix-B.5-1.6.1">
+                          Specify a configuration file.<a href="#appendix-B.5-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.6.2">
+       This argument can be repeated, to read multiple explicitly specified config files.  They will be read after any config files found in 'standard' locations have been read.  Run <code>xml2rfc --values</code> to see the default search path for config files.<a href="#appendix-B.5-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.7">
+<dt id="appendix-B.5-1.7">
 <div id="option--dtd">
 <code>--dtd</code>, <code>-d</code> = DTDFILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.8">
-            <p id="section-b.5-1.8.1">
-                          Specify an alternate dtd file.<a href="#section-b.5-1.8.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.8.2">
-                          This option can be negated with --no-dtd.<a href="#section-b.5-1.8.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.8">
+            <p id="appendix-B.5-1.8.1">
+                          Specify an alternate dtd file.<a href="#appendix-B.5-1.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.8.2">
+                          This option can be negated with --no-dtd.<a href="#appendix-B.5-1.8.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.9">
+<dt id="appendix-B.5-1.9">
 <div id="option--date">
 <code>--date</code>, <code>-D</code> = DATE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.10">
-            <p id="section-b.5-1.10.1">
-                          Run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date.<a href="#section-b.5-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.10">
+            <p id="appendix-B.5-1.10.1">
+                          Run as if the date is DATE (format: yyyy-mm-dd).  Default: Today's date.<a href="#appendix-B.5-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.11">
+<dt id="appendix-B.5-1.11">
 <div id="option--filename">
 <code>--filename</code>, <code>-f</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.12">
-            <p id="section-b.5-1.12.1">
-                          Deprecated.  The same as -o.<a href="#section-b.5-1.12.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.12">
+            <p id="appendix-B.5-1.12.1">
+                          Deprecated.  The same as -o.<a href="#appendix-B.5-1.12.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.13">
+<dt id="appendix-B.5-1.13">
 <div id="option--indent">
 <code>--indent</code>, <code>-i</code> = INDENT                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.14">
-            <p id="section-b.5-1.14.1">
-                          With some v3 formatters: Indentation to use when pretty-printing XML.<a href="#section-b.5-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.14">
+            <p id="appendix-B.5-1.14.1">
+                          With some v3 formatters: Indentation to use when pretty-printing XML.<a href="#appendix-B.5-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.15">
+<dt id="appendix-B.5-1.15">
 <div id="option--out">
 <code>--out</code>, <code>-o</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.16">
-            <p id="section-b.5-1.16.1">
-                          Specify an explicit output filename.<a href="#section-b.5-1.16.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.16">
+            <p id="appendix-B.5-1.16.1">
+                          Specify an explicit output filename.<a href="#appendix-B.5-1.16.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.17">
+<dt id="appendix-B.5-1.17">
 <div id="option--path">
 <code>--path</code>, <code>-p</code> = PATH                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.18">
-            <p id="section-b.5-1.18.1">
-                          Specify the directory path for output files.<a href="#section-b.5-1.18.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.18">
+            <p id="appendix-B.5-1.18.1">
+                          Specify the directory path for output files.<a href="#appendix-B.5-1.18.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.5-1.19">
+<dt id="appendix-B.5-1.19">
 <div id="option--silence">
 <code>--silence</code>, <code>-s</code> = STRING                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.5-1.20">
-            <p id="section-b.5-1.20.1">
-                          Silence any warning beginning with the given string.<a href="#section-b.5-1.20.1" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.20.2">
-       Specifies a string prefix or a regular expression to match against warning messages.  Any warning message that matches is silenced.  Example:<a href="#section-b.5-1.20.2" class="pilcrow">¶</a></p>
-<div id="section-b.5-1.20.3">
-<pre class="sourcecode">xml2rfc --silence='The document date' draft-foo-bar.xml</pre><a href="#section-b.5-1.20.3" class="pilcrow">¶</a>
+<dd style="margin-left: 1.5em" id="appendix-B.5-1.20">
+            <p id="appendix-B.5-1.20.1">
+                          Silence any warning beginning with the given string.<a href="#appendix-B.5-1.20.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.20.2">
+       Specifies a string prefix or a regular expression to match against warning messages.  Any warning message that matches is silenced.  Example:<a href="#appendix-B.5-1.20.2" class="pilcrow">¶</a></p>
+<div id="appendix-B.5-1.20.3">
+<pre class="sourcecode">xml2rfc --silence='The document date' draft-foo-bar.xml</pre><a href="#appendix-B.5-1.20.3" class="pilcrow">¶</a>
 </div>
-<p id="section-b.5-1.20.4">
-       This will not show any message about the document date being too far from the current date.  The option can be repeated with different prefix strings or regular expressions in order to silence multiple warning messages.<a href="#section-b.5-1.20.4" class="pilcrow">¶</a></p>
-<p id="section-b.5-1.20.5">
-       Alternatively, instead of indicating this on the command line, an xml2rfc-specific PI (processing instruction) is available for use in XML input files. This will have the same effect as the example above, except when processing prepped drafts; running the preptool on a file will strip XML PIs before writing the prepped file:<a href="#section-b.5-1.20.5" class="pilcrow">¶</a></p>
-<div id="section-b.5-1.20.6">
-<pre class="sourcecode">&lt;?v3xml2rfc silence="The document date" ?&gt;</pre><a href="#section-b.5-1.20.6" class="pilcrow">¶</a>
+<p id="appendix-B.5-1.20.4">
+       This will not show any message about the document date being too far from the current date.  The option can be repeated with different prefix strings or regular expressions in order to silence multiple warning messages.<a href="#appendix-B.5-1.20.4" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-1.20.5">
+       Alternatively, instead of indicating this on the command line, an xml2rfc-specific PI (processing instruction) is available for use in XML input files. This will have the same effect as the example above, except when processing prepped drafts; running the preptool on a file will strip XML PIs before writing the prepped file:<a href="#appendix-B.5-1.20.5" class="pilcrow">¶</a></p>
+<div id="appendix-B.5-1.20.6">
+<pre class="sourcecode">&lt;?v3xml2rfc silence="The document date" ?&gt;</pre><a href="#appendix-B.5-1.20.6" class="pilcrow">¶</a>
 </div>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.6">
-        <h2 id="name-generic-format-options">
-<a href="#section-b.6" class="section-number selfRef">B.6. </a><a href="#name-generic-format-options" class="section-name selfRef">Generic Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.6-1">
-          <dt id="section-b.6-1.1">
+<section id="appendix-B.6">
+        <h3 id="name-generic-format-options">
+<a href="#appendix-B.6" class="section-number selfRef">B.6. </a><a href="#name-generic-format-options" class="section-name selfRef">Generic Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.6-1">
+          <dt id="appendix-B.6-1.1">
 <div id="option--v3">
 <code>--v3</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.2">
-            <p id="section-b.6-1.2.1">
-                          With --text and --html: use the v3 formatter, rather than the legacy one.<a href="#section-b.6-1.2.1" class="pilcrow">¶</a></p>
-<p id="section-b.6-1.2.2">
-       This is the default.  With both v2 schema and v3 schema XML input files, use the v3 output formatters.  Input with deprecated v2 elements will be converted to v3 on the fly.  This means some loss of functionality and exact control of the output, due to the intermediary conversion step.<a href="#section-b.6-1.2.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.2">
+            <p id="appendix-B.6-1.2.1">
+                          With --text and --html: use the v3 formatter, rather than the legacy one.<a href="#appendix-B.6-1.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.6-1.2.2">
+       This is the default.  With both v2 schema and v3 schema XML input files, use the v3 output formatters.  Input with deprecated v2 elements will be converted to v3 on the fly.  This means some loss of functionality and exact control of the output, due to the intermediary conversion step.<a href="#appendix-B.6-1.2.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.6-1.3">
+<dt id="appendix-B.6-1.3">
 <div id="option--v2">
 <code>--v2</code>, <code>--legacy</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.4">
-            <p id="section-b.6-1.4.1">
-                          With --text and --html: use the legacy output formatters, rather than the v3 ones.<a href="#section-b.6-1.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.6-1.4.2">
-       Invokes the legacy (schema v2) validator and output formatters, instead of the default schema v3 output formatters.  This can only be used with pure v2 input files.<a href="#section-b.6-1.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.4">
+            <p id="appendix-B.6-1.4.1">
+                          With --text and --html: use the legacy output formatters, rather than the v3 ones.<a href="#appendix-B.6-1.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.6-1.4.2">
+       Invokes the legacy (schema v2) validator and output formatters, instead of the default schema v3 output formatters.  This can only be used with pure v2 input files.<a href="#appendix-B.6-1.4.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.6-1.5">
+<dt id="appendix-B.6-1.5">
 <div id="option--id-is-work-in-progress">
 <code>--id-is-work-in-progress</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.6-1.6">
-            <p id="section-b.6-1.6.1">
-                          In references, refer to Internet-Drafts as "Work in Progress".<a href="#section-b.6-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.6-1.6">
+            <p id="appendix-B.6-1.6.1">
+                          In references, refer to Internet-Drafts as "Work in Progress".<a href="#appendix-B.6-1.6.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.7">
-        <h2 id="name-text-format-options">
-<a href="#section-b.7" class="section-number selfRef">B.7. </a><a href="#name-text-format-options" class="section-name selfRef">Text Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1">
-          <dt id="section-b.7-1.1">
+<section id="appendix-B.7">
+        <h3 id="name-text-format-options">
+<a href="#appendix-B.7" class="section-number selfRef">B.7. </a><a href="#name-text-format-options" class="section-name selfRef">Text Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1">
+          <dt id="appendix-B.7-1.1">
 <div id="option--no-headers">
 <code>--no-headers</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.2">
-            <p id="section-b.7-1.2.1">
-                          Calculate page breaks, and emit form feeds and page top spacing, but omit headers and footers from the paginated format.<a href="#section-b.7-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.2">
+            <p id="appendix-B.7-1.2.1">
+                          Calculate page breaks, and emit form feeds and page top spacing, but omit headers and footers from the paginated format.<a href="#appendix-B.7-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.3">
+<dt id="appendix-B.7-1.3">
 <div id="option--legacy-list-symbols">
 <code>--legacy-list-symbols</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.4">
-            <p id="section-b.7-1.4.1">
-                          Use the legacy list bullet symbols, rather than the new ones.<a href="#section-b.7-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.4">
+            <p id="appendix-B.7-1.4.1">
+                          Use the legacy list bullet symbols, rather than the new ones.<a href="#appendix-B.7-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.5">
+<dt id="appendix-B.7-1.5">
 <div id="option--legacy-date-format">
 <code>--legacy-date-format</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.6">
-            <p id="section-b.7-1.6.1">
-                          Use the legacy date format, rather than the new one.<a href="#section-b.7-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.6.2">
-                          This option can be negated with --no-legacy-date-format.<a href="#section-b.7-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.6">
+            <p id="appendix-B.7-1.6.1">
+                          Use the legacy date format, rather than the new one.<a href="#appendix-B.7-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.6.2">
+                          This option can be negated with --no-legacy-date-format.<a href="#appendix-B.7-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.7">
+<dt id="appendix-B.7-1.7">
 <div id="option--list-symbols">
 <code>--list-symbols</code> = 4*CHAR                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.8">
-            <p id="section-b.7-1.8.1">
-                          Use the characters given as list bullet symbols.<a href="#section-b.7-1.8.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.8">
+            <p id="appendix-B.7-1.8.1">
+                          Use the characters given as list bullet symbols.<a href="#appendix-B.7-1.8.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.9">
+<dt id="appendix-B.7-1.9">
 <div id="option--BOM">
 <code>--BOM</code>, <code>--bom</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.10">
-            <p id="section-b.7-1.10.1">
-                          Add a BOM (unicode byte order mark) to the start of text files.<a href="#section-b.7-1.10.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.10">
+            <p id="appendix-B.7-1.10.1">
+                          Add a BOM (unicode byte order mark) to the start of text files.<a href="#appendix-B.7-1.10.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.11">
+<dt id="appendix-B.7-1.11">
 <div id="option--pagination">
 <code>--pagination</code>, <code>--paginate</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.12">
-            <p id="section-b.7-1.12.1">
-                          Do pagination.<a href="#section-b.7-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.12.2">
-       By default, drafts are paginated, but not RFCs.  Use this switch if you want to force pagination of all text output.<a href="#section-b.7-1.12.2" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.12.3">
-                          This option can be negated with --no-pagination.<a href="#section-b.7-1.12.3" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.12">
+            <p id="appendix-B.7-1.12.1">
+                          Do pagination.<a href="#appendix-B.7-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.12.2">
+       By default, drafts are paginated, but not RFCs.  Use this switch if you want to force pagination of all text output.<a href="#appendix-B.7-1.12.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.12.3">
+                          This option can be negated with --no-pagination.<a href="#appendix-B.7-1.12.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.13">
+<dt id="appendix-B.7-1.13">
 <div id="option--table-hyphen-breaks">
 <code>--table-hyphen-breaks</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.14">
-            <p id="section-b.7-1.14.1">
-                          More easily do line breaks after hyphens in table cells to give a more compact table.<a href="#section-b.7-1.14.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.14">
+            <p id="appendix-B.7-1.14.1">
+                          More easily do line breaks after hyphens in table cells to give a more compact table.<a href="#appendix-B.7-1.14.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.7-1.15">
+<dt id="appendix-B.7-1.15">
 <div id="option--table-borders">
 <code>--table-borders</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.7-1.16">
-            <p id="section-b.7-1.16.1"><br>Default value: full<a href="#section-b.7-1.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.16.2">
-                          The style of table borders to use for text output; one of full/light/minimal.<a href="#section-b.7-1.16.2" class="pilcrow">¶</a></p>
-<p id="section-b.7-1.16.3">
-       Examples (these will only have visible differences in text mode):<a href="#section-b.7-1.16.3" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.4">
-              <dt id="section-b.7-1.16.4.1">"full":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.4.2">
+<dd style="margin-left: 1.5em" id="appendix-B.7-1.16">
+            <p id="appendix-B.7-1.16.1"><br>Default value: full<a href="#appendix-B.7-1.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.16.2">
+                          The style of table borders to use for text output; one of full/light/minimal.<a href="#appendix-B.7-1.16.2" class="pilcrow">¶</a></p>
+<p id="appendix-B.7-1.16.3">
+       Examples (these will only have visible differences in text mode):<a href="#appendix-B.7-1.16.3" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.4">
+              <dt id="appendix-B.7-1.16.4.1">"full":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.4.2">
                 <table class="center" id="table-2">
                   <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
 <thead>
@@ -6063,13 +6063,13 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.4.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.4.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.5">
-              <dt id="section-b.7-1.16.5.1">"light":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.5.2">
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.5">
+              <dt id="appendix-B.7-1.16.5.1">"light":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.5.2">
                 <table class="center" id="table-3">
                   <caption><a href="#table-3" class="selfRef">Table 3</a></caption>
 <thead>
@@ -6111,13 +6111,13 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.5.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.5.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
-<span class="break"></span><dl class="dlNewline" id="section-b.7-1.16.6">
-              <dt id="section-b.7-1.16.6.1">"minimal":</dt>
-              <dd style="margin-left: 1.5em" id="section-b.7-1.16.6.2">
+<span class="break"></span><dl class="dlNewline" id="appendix-B.7-1.16.6">
+              <dt id="appendix-B.7-1.16.6.1">"minimal":</dt>
+              <dd style="margin-left: 1.5em" id="appendix-B.7-1.16.6.2">
                 <table class="center" id="table-4">
                   <caption><a href="#table-4" class="selfRef">Table 4</a></caption>
 <thead>
@@ -6159,7 +6159,7 @@ start |= rfc
                       <td class="text-left" rowspan="1" colspan="1">ccb  </td>
                     </tr>
                   </tbody>
-                </table><a href="#section-b.7-1.16.6.2" class="pilcrow">¶</a>
+                </table><a href="#appendix-B.7-1.16.6.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
@@ -6167,213 +6167,213 @@ start |= rfc
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.8">
-        <h2 id="name-html-format-options">
-<a href="#section-b.8" class="section-number selfRef">B.8. </a><a href="#name-html-format-options" class="section-name selfRef">Html Format Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.8-1">
-          <dt id="section-b.8-1.1">
+<section id="appendix-B.8">
+        <h3 id="name-html-format-options">
+<a href="#appendix-B.8" class="section-number selfRef">B.8. </a><a href="#name-html-format-options" class="section-name selfRef">Html Format Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.8-1">
+          <dt id="appendix-B.8-1.1">
 <div id="option--css">
 <code>--css</code> = FILE                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.2">
-            <p id="section-b.8-1.2.1">
-                          Use the given CSS file instead of the builtin.<a href="#section-b.8-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.2">
+            <p id="appendix-B.8-1.2.1">
+                          Use the given CSS file instead of the builtin.<a href="#appendix-B.8-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.3">
+<dt id="appendix-B.8-1.3">
 <div id="option--external-css">
 <code>--external-css</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.4">
-            <p id="section-b.8-1.4.1">
-                          Place css in external files.<a href="#section-b.8-1.4.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.4.2">
-                          This option can be negated with --no-external-css.<a href="#section-b.8-1.4.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.4">
+            <p id="appendix-B.8-1.4.1">
+                          Place css in external files.<a href="#appendix-B.8-1.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.4.2">
+                          This option can be negated with --no-external-css.<a href="#appendix-B.8-1.4.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.5">
+<dt id="appendix-B.8-1.5">
 <div id="option--external-js">
 <code>--external-js</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.6">
-            <p id="section-b.8-1.6.1">
-                          Place js in external files.<a href="#section-b.8-1.6.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.6.2">
-                          This option can be negated with --no-external-js.<a href="#section-b.8-1.6.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.6">
+            <p id="appendix-B.8-1.6.1">
+                          Place js in external files.<a href="#appendix-B.8-1.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.6.2">
+                          This option can be negated with --no-external-js.<a href="#appendix-B.8-1.6.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.7">
+<dt id="appendix-B.8-1.7">
 <div id="option--rfc-base-url">
 <code>--rfc-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.8">
-            <p id="section-b.8-1.8.1"><br>Default value: https://www.rfc-editor.org/rfc/<a href="#section-b.8-1.8.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.8.2">
-                          Base URL for RFC links.<a href="#section-b.8-1.8.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.8">
+            <p id="appendix-B.8-1.8.1"><br>Default value: https://www.rfc-editor.org/rfc/<a href="#appendix-B.8-1.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.8.2">
+                          Base URL for RFC links.<a href="#appendix-B.8-1.8.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.9">
+<dt id="appendix-B.8-1.9">
 <div id="option--id-base-url">
 <code>--id-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.10">
-            <p id="section-b.8-1.10.1"><br>Default value: https://tools.ietf.org/html/<a href="#section-b.8-1.10.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.10.2">
-                          Base URL for Internet-Draft links.<a href="#section-b.8-1.10.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.10">
+            <p id="appendix-B.8-1.10.1"><br>Default value: https://tools.ietf.org/html/<a href="#appendix-B.8-1.10.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.10.2">
+                          Base URL for Internet-Draft links.<a href="#appendix-B.8-1.10.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.11">
+<dt id="appendix-B.8-1.11">
 <div id="option--rfc-reference-base-url">
 <code>--rfc-reference-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.12">
-            <p id="section-b.8-1.12.1"><br>Default value: https://rfc-editor.org/rfc/<a href="#section-b.8-1.12.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.12.2">
-                          Base URL for RFC reference targets, replacing the target="..." value given in the reference entry.<a href="#section-b.8-1.12.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.12">
+            <p id="appendix-B.8-1.12.1"><br>Default value: https://rfc-editor.org/rfc/<a href="#appendix-B.8-1.12.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.12.2">
+                          Base URL for RFC reference targets, replacing the target="..." value given in the reference entry.<a href="#appendix-B.8-1.12.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.13">
+<dt id="appendix-B.8-1.13">
 <div id="option--id-reference-base-url">
 <code>--id-reference-base-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.14">
-            <p id="section-b.8-1.14.1"><br>Default value: https://tools.ietf.org/html/<a href="#section-b.8-1.14.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.14.2">
-                          Base URL for I-D reference targets.<a href="#section-b.8-1.14.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.14">
+            <p id="appendix-B.8-1.14.1"><br>Default value: https://tools.ietf.org/html/<a href="#appendix-B.8-1.14.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.14.2">
+                          Base URL for I-D reference targets.<a href="#appendix-B.8-1.14.2" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.8-1.15">
+<dt id="appendix-B.8-1.15">
 <div id="option--metadata-js-url">
 <code>--metadata-js-url</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.8-1.16">
-            <p id="section-b.8-1.16.1"><br>Default value: metadata.min.js<a href="#section-b.8-1.16.1" class="pilcrow">¶</a></p>
-<p id="section-b.8-1.16.2">
-                          URL for the metadata script.<a href="#section-b.8-1.16.2" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.8-1.16">
+            <p id="appendix-B.8-1.16.1"><br>Default value: metadata.min.js<a href="#appendix-B.8-1.16.1" class="pilcrow">¶</a></p>
+<p id="appendix-B.8-1.16.2">
+                          URL for the metadata script.<a href="#appendix-B.8-1.16.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.9">
-        <h2 id="name-v2-v3-converter-options">
-<a href="#section-b.9" class="section-number selfRef">B.9. </a><a href="#name-v2-v3-converter-options" class="section-name selfRef">V2-V3 Converter Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.9-1">
-          <dt id="section-b.9-1.1">
+<section id="appendix-B.9">
+        <h3 id="name-v2-v3-converter-options">
+<a href="#appendix-B.9" class="section-number selfRef">B.9. </a><a href="#name-v2-v3-converter-options" class="section-name selfRef">V2-V3 Converter Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.9-1">
+          <dt id="appendix-B.9-1.1">
 <div id="option--add-xinclude">
 <code>--add-xinclude</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.2">
-            <p id="section-b.9-1.2.1">
-                          Replace reference elements with RFC and Internet-Draft seriesInfo with the appropriate XInclude element.<a href="#section-b.9-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.2">
+            <p id="appendix-B.9-1.2.1">
+                          Replace reference elements with RFC and Internet-Draft seriesInfo with the appropriate XInclude element.<a href="#appendix-B.9-1.2.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.9-1.3">
+<dt id="appendix-B.9-1.3">
 <div id="option--draft-revs">
 <code>--draft-revs</code>, <code>--draft-revisions</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.4">
-            <p id="section-b.9-1.4.1">
-                          Reference explicit draft revisions when inserting XIncludes for draft references.<a href="#section-b.9-1.4.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.4">
+            <p id="appendix-B.9-1.4.1">
+                          Reference explicit draft revisions when inserting XIncludes for draft references.<a href="#appendix-B.9-1.4.1" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-b.9-1.5">
+<dt id="appendix-B.9-1.5">
 <div id="option--strict">
 <code>--strict</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.9-1.6">
-            <p id="section-b.9-1.6.1">
-                          Be strict about stripping some deprecated attributes.<a href="#section-b.9-1.6.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.9-1.6">
+            <p id="appendix-B.9-1.6.1">
+                          Be strict about stripping some deprecated attributes.<a href="#appendix-B.9-1.6.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-b.10">
-        <h2 id="name-preptool-options">
-<a href="#section-b.10" class="section-number selfRef">B.10. </a><a href="#name-preptool-options" class="section-name selfRef">Preptool Options</a>
-        </h2>
-<span class="break"></span><dl class="dlNewline" id="section-b.10-1">
-          <dt id="section-b.10-1.1">
+<section id="appendix-B.10">
+        <h3 id="name-preptool-options">
+<a href="#appendix-B.10" class="section-number selfRef">B.10. </a><a href="#name-preptool-options" class="section-name selfRef">Preptool Options</a>
+        </h3>
+<span class="break"></span><dl class="dlNewline" id="appendix-B.10-1">
+          <dt id="appendix-B.10-1.1">
 <div id="option--accept-prepped">
 <code>--accept-prepped</code>                    </div>
           </dt>
-<dd style="margin-left: 1.5em" id="section-b.10-1.2">
-            <p id="section-b.10-1.2.1">
-                          Accept already prepped input.<a href="#section-b.10-1.2.1" class="pilcrow">¶</a></p>
+<dd style="margin-left: 1.5em" id="appendix-B.10-1.2">
+            <p id="appendix-B.10-1.2.1">
+                          Accept already prepped input.<a href="#appendix-B.10-1.2.1" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-xml2rfc-configuration-files">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-xml2rfc-configuration-files" class="section-name selfRef"><code>xml2rfc</code> Configuration Files</a>
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-xml2rfc-configuration-files" class="section-name selfRef"><code>xml2rfc</code> Configuration Files</a>
       </h2>
-<p id="section-appendix.c-1">
-       Most options have built-in defaults, and the command-line switches above can be used to override those.  Additionally, <code>xml2rfc</code> will look for config files in some standard file locations.  The option <code>--⁠values</code> will show the places <code>xml2rfc</code> will look for config files on your system (among other information).  Any settings in config files will override the program defaults, but will in turn be overridden by command-line options.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.c-2">
-       The config files are expected to contain lines with option value assignments. Lines with '#' as the first character are considered comments.  Here is an example:<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
-<div id="section-appendix.c-3">
+<p id="appendix-C-1">
+       Most options have built-in defaults, and the command-line switches above can be used to override those.  Additionally, <code>xml2rfc</code> will look for config files in some standard file locations.  The option <code>--⁠values</code> will show the places <code>xml2rfc</code> will look for config files on your system (among other information).  Any settings in config files will override the program defaults, but will in turn be overridden by command-line options.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">
+       The config files are expected to contain lines with option value assignments. Lines with '#' as the first character are considered comments.  Here is an example:<a href="#appendix-C-2" class="pilcrow">¶</a></p>
+<div id="appendix-C-3">
 <pre class="sourcecode">
 # ----
 legacy-date-format = true
 add-xinclude = true
 external-js = false
 # ----
-</pre><a href="#section-appendix.c-3" class="pilcrow">¶</a>
+</pre><a href="#appendix-C-3" class="pilcrow">¶</a>
 </div>
-<p id="section-appendix.c-4">
-       The complete long option names must be used in configuration files; abbreviations will not be recognised (in contrast with how abbreviations are handled during command-line option processing).<a href="#section-appendix.c-4" class="pilcrow">¶</a></p>
+<p id="appendix-C-4">
+       The complete long option names must be used in configuration files; abbreviations will not be recognised (in contrast with how abbreviations are handled during command-line option processing).<a href="#appendix-C-4" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.d">
+<section id="appendix-D">
       <h2 id="name-xml2rfc-documentation-templ">
-<a href="#section-appendix.d" class="section-number selfRef">Appendix D. </a><a href="#name-xml2rfc-documentation-templ" class="section-name selfRef"><code>xml2rfc</code> Documentation Template Variables</a>
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-xml2rfc-documentation-templ" class="section-name selfRef"><code>xml2rfc</code> Documentation Template Variables</a>
       </h2>
-<p id="section-appendix.d-1">
+<p id="appendix-D-1">
 
             The following variables are available for use in an xml2rfc
-            manpage Jinja2 template, as of xml2rfc version 3.7.0:<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-appendix.d-2">
-        <dt id="section-appendix.d-2.1">{{ bare_latin_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.2"></dd>
+            manpage Jinja2 template, as of xml2rfc version 3.7.0:<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="appendix-D-2">
+        <dt id="appendix-D-2.1">{{ bare_latin_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.2"></dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.3">{{ descriptions }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.4">The descriptions read from the <code>doc.yaml</code> file<a href="#section-appendix.d-2.4" class="pilcrow">¶</a>
+<dt id="appendix-D-2.3">{{ descriptions }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.4">The descriptions read from the <code>doc.yaml</code> file<a href="#appendix-D-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.5">{{ element_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.6">A list of all the element tags in the XML schema<a href="#section-appendix.d-2.6" class="pilcrow">¶</a>
+<dt id="appendix-D-2.5">{{ element_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.6">A list of all the element tags in the XML schema<a href="#appendix-D-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.7">{{ elements }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.8">A list of dictionaries, each with information about one schema element: {"attributes": ..., "children": ..., "deprecated": ..., "deprecated_attributes": ..., "description": ..., "new": ..., "parents": ..., "rnc": ..., "tag": ..., }<a href="#section-appendix.d-2.8" class="pilcrow">¶</a>
+<dt id="appendix-D-2.7">{{ elements }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.8">A list of dictionaries, each with information about one schema element: {"attributes": ..., "children": ..., "deprecated": ..., "deprecated_attributes": ..., "description": ..., "new": ..., "parents": ..., "rnc": ..., "tag": ..., }<a href="#appendix-D-2.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.9">{{ options }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.10">A list of dictionaries describing the command-line options<a href="#section-appendix.d-2.10" class="pilcrow">¶</a>
+<dt id="appendix-D-2.9">{{ options }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.10">A list of dictionaries describing the command-line options<a href="#appendix-D-2.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.11">{{ schema }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.12">The full RelaxNG Compact representation of the schema in text form<a href="#section-appendix.d-2.12" class="pilcrow">¶</a>
+<dt id="appendix-D-2.11">{{ schema }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.12">The full RelaxNG Compact representation of the schema in text form<a href="#appendix-D-2.12" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.13">{{ toc_depth }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.14">ToC depth setting; 1 when running --man, 2 otherwise<a href="#section-appendix.d-2.14" class="pilcrow">¶</a>
+<dt id="appendix-D-2.13">{{ toc_depth }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.14">ToC depth setting; 1 when running --man, 2 otherwise<a href="#appendix-D-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.15">{{ v3_element_tags }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.16">A list of v3 element tags, excluding deprecated tags<a href="#section-appendix.d-2.16" class="pilcrow">¶</a>
+<dt id="appendix-D-2.15">{{ v3_element_tags }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.16">A list of v3 element tags, excluding deprecated tags<a href="#appendix-D-2.16" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-appendix.d-2.17">{{ version }}:</dt>
-        <dd style="margin-left: 1.5em" id="section-appendix.d-2.18">The xml2rfc version number<a href="#section-appendix.d-2.18" class="pilcrow">¶</a>
+<dt id="appendix-D-2.17">{{ version }}:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-D-2.18">The xml2rfc version number<a href="#appendix-D-2.18" class="pilcrow">¶</a>
 </dd>
       <dd class="break"></dd>
 </dl>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.e">
+<section id="appendix-E">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/draft-miek-test.pages.text
+++ b/cli/tests/valid/draft-miek-test.pages.text
@@ -1137,14 +1137,14 @@ Index
       L
 
          list
-            Uppercase Letters  Section A.7, Paragraph 28
-            default markers  Section A.7, Paragraph 20
+            Uppercase Letters  Appendix A.7, Paragraph 28
+            default markers  Appendix A.7, Paragraph 20
 
       T
 
          table
-            grid  Section A.8, Paragraph 10
-            simple  Section A.8, Paragraph 3
+            grid  Appendix A.8, Paragraph 10
+            simple  Appendix A.8, Paragraph 3
 
 Author's Address
 

--- a/cli/tests/valid/draft-miek-test.prepped.xml
+++ b/cli/tests/valid/draft-miek-test.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" consensus="false" docName="draft-gieben-writing-rfcs-pandoc-02" indexInclude="true" ipr="trust200902" prepTime="2021-04-28T15:39:19" scripts="Common,Latin" sortRefs="true" submissionType="IETF" symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
-  <!-- xml2rfc v2v3 conversion 3.7.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" consensus="false" docName="draft-gieben-writing-rfcs-pandoc-02" indexInclude="true" ipr="trust200902" prepTime="2021-06-08T13:25:38" scripts="Common,Latin" sortRefs="true" submissionType="IETF" symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
+  <!-- xml2rfc v2v3 conversion 3.8.0 -->
   <!--generate a table of contents -->
    <!--use anchors instead of numbers for references -->
    <!--alphabetize the references -->

--- a/cli/tests/valid/draft-miek-test.prepped.xml
+++ b/cli/tests/valid/draft-miek-test.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" consensus="false" docName="draft-gieben-writing-rfcs-pandoc-02" indexInclude="true" ipr="trust200902" prepTime="2021-04-22T19:05:51" scripts="Common,Latin" sortRefs="true" submissionType="IETF" symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="info" consensus="false" docName="draft-gieben-writing-rfcs-pandoc-02" indexInclude="true" ipr="trust200902" prepTime="2021-04-28T15:39:19" scripts="Common,Latin" sortRefs="true" submissionType="IETF" symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
   <!-- xml2rfc v2v3 conversion 3.7.0 -->
   <!--generate a table of contents -->
    <!--use anchors instead of numbers for references -->
@@ -223,37 +223,37 @@
             <t indent="0" pn="section-toc.1-1.12.1"><xref derivedContent="Appendix A" format="default" sectionFormat="of" target="section-appendix.a"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-tests">Tests</xref></t>
             <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.12.2">
               <li pn="section-toc.1-1.12.2.1">
-                <t indent="0" pn="section-toc.1-1.12.2.1.1"><xref derivedContent="A.1" format="counter" sectionFormat="of" target="section-a.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-a-very-long-title-considera">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.1.1"><xref derivedContent="A.1" format="counter" sectionFormat="of" target="section-appendix.a.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-a-very-long-title-considera">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.2">
-                <t indent="0" pn="section-toc.1-1.12.2.2.1"><xref derivedContent="A.2" format="counter" sectionFormat="of" target="section-a.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-markup-in-heading">Markup in heading</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.2.1"><xref derivedContent="A.2" format="counter" sectionFormat="of" target="section-appendix.a.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-markup-in-heading">Markup in heading</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.3">
-                <t indent="0" pn="section-toc.1-1.12.2.3.1"><xref derivedContent="A.3" format="counter" sectionFormat="of" target="section-a.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-blockquote">Blockquote</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.3.1"><xref derivedContent="A.3" format="counter" sectionFormat="of" target="section-appendix.a.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-blockquote">Blockquote</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.4">
-                <t indent="0" pn="section-toc.1-1.12.2.4.1"><xref derivedContent="A.4" format="counter" sectionFormat="of" target="section-a.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-verbatim-code-blocks">Verbatim code blocks</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.4.1"><xref derivedContent="A.4" format="counter" sectionFormat="of" target="section-appendix.a.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-verbatim-code-blocks">Verbatim code blocks</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.5">
-                <t indent="0" pn="section-toc.1-1.12.2.5.1"><xref derivedContent="A.5" format="counter" sectionFormat="of" target="section-a.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-reference-tests">Reference Tests</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.5.1"><xref derivedContent="A.5" format="counter" sectionFormat="of" target="section-appendix.a.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-reference-tests">Reference Tests</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.6">
-                <t indent="0" pn="section-toc.1-1.12.2.6.1"><xref derivedContent="A.6" format="counter" sectionFormat="of" target="section-a.6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-spanx-tests">Spanx Tests</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.6.1"><xref derivedContent="A.6" format="counter" sectionFormat="of" target="section-appendix.a.6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-spanx-tests">Spanx Tests</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.7">
-                <t indent="0" pn="section-toc.1-1.12.2.7.1"><xref derivedContent="A.7" format="counter" sectionFormat="of" target="section-a.7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-list-tests">List Tests</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.7.1"><xref derivedContent="A.7" format="counter" sectionFormat="of" target="section-appendix.a.7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-list-tests">List Tests</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.8">
-                <t indent="0" pn="section-toc.1-1.12.2.8.1"><xref derivedContent="A.8" format="counter" sectionFormat="of" target="section-a.8"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-table-tests">Table Tests</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.8.1"><xref derivedContent="A.8" format="counter" sectionFormat="of" target="section-appendix.a.8"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-table-tests">Table Tests</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.9">
-                <t indent="0" pn="section-toc.1-1.12.2.9.1"><xref derivedContent="A.9" format="counter" sectionFormat="of" target="section-a.9"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-numbered-examples">Numbered examples</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.9.1"><xref derivedContent="A.9" format="counter" sectionFormat="of" target="section-appendix.a.9"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-numbered-examples">Numbered examples</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.10">
-                <t indent="0" pn="section-toc.1-1.12.2.10.1"><xref derivedContent="A.10" format="counter" sectionFormat="of" target="section-a.10"/>. <xref derivedContent="" format="title" sectionFormat="of" target="name-figure-tests">Figure tests</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.10.1"><xref derivedContent="A.10" format="counter" sectionFormat="of" target="section-appendix.a.10"/>. <xref derivedContent="" format="title" sectionFormat="of" target="name-figure-tests">Figure tests</xref></t>
               </li>
               <li pn="section-toc.1-1.12.2.11">
-                <t indent="0" pn="section-toc.1-1.12.2.11.1"><xref derivedContent="A.11" format="counter" sectionFormat="of" target="section-a.11"/>. <xref derivedContent="" format="title" sectionFormat="of" target="name-verse-tests">Verse tests</xref></t>
+                <t indent="0" pn="section-toc.1-1.12.2.11.1"><xref derivedContent="A.11" format="counter" sectionFormat="of" target="section-appendix.a.11"/>. <xref derivedContent="" format="title" sectionFormat="of" target="name-verse-tests">Verse tests</xref></t>
               </li>
             </ul>
           </li>
@@ -1160,324 +1160,324 @@ draft-gieben-writing-rfcs-pandoc-00.txt -> draft.txt
             This appendix consists out of a few tests that should all render to proper
             <tt>xml2rfc</tt> XML.  
       </t>
-      <section anchor="a-very-long-title-considerations-with-regards-to-the-already-deployed-routing-policy" toc="include" numbered="true" removeInRFC="false" pn="section-a.1">
+      <section anchor="a-very-long-title-considerations-with-regards-to-the-already-deployed-routing-policy" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.1">
         <name slugifiedName="name-a-very-long-title-considera">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</name>
-        <t indent="0" pn="section-a.1-1">
+        <t indent="0" pn="section-appendix.a.1-1">
                Test a very long title.  
         </t>
       </section>
-      <section anchor="markup-in-heading" toc="include" numbered="true" removeInRFC="false" pn="section-a.2">
+      <section anchor="markup-in-heading" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.2">
         <name slugifiedName="name-markup-in-heading">Markup in heading</name>
-        <t indent="0" pn="section-a.2-1">
+        <t indent="0" pn="section-appendix.a.2-1">
                This is discarded by <tt>xml2rfc</tt>.  
         </t>
       </section>
-      <section anchor="blockquote" toc="include" numbered="true" removeInRFC="false" pn="section-a.3">
+      <section anchor="blockquote" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.3">
         <name slugifiedName="name-blockquote">Blockquote</name>
-        <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-a.3-1">
-          <li pn="section-a.3-1.1">
+        <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-appendix.a.3-1">
+          <li pn="section-appendix.a.3-1.1">
                      This is a blockquote, how does it look? 
                   </li>
         </ul>
       </section>
-      <section anchor="verbatim-code-blocks" toc="include" numbered="true" removeInRFC="false" pn="section-a.4">
+      <section anchor="verbatim-code-blocks" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.4">
         <name slugifiedName="name-verbatim-code-blocks">Verbatim code blocks</name>
-        <artwork name="" type="" align="left" alt="" pn="section-a.4-1"><![CDATA[
+        <artwork name="" type="" align="left" alt="" pn="section-appendix.a.4-1"><![CDATA[
 A verbatim code block
 jkasjksajassjasjsajsajkas
                ]]></artwork>
       </section>
-      <section anchor="reference-tests" toc="include" numbered="true" removeInRFC="false" pn="section-a.5">
+      <section anchor="reference-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.5">
         <name slugifiedName="name-reference-tests">Reference Tests</name>
-        <t indent="0" pn="section-a.5-1">
+        <t indent="0" pn="section-appendix.a.5-1">
                Refer to <xref target="RFC2119" format="default" sectionFormat="of" derivedContent="RFC2119">RFC 2119</xref> if you will. Or maybe you want to inspect <xref target="fig-a-minimal-" format="default" sectionFormat="of" derivedContent="Figure 2"/> in <xref target="pandoc-to-rfc" format="default" sectionFormat="of" derivedContent="Section 2"/> again. Or you might want to <eref target="http://miek.nl" brackets="none">Click here</eref>.  
         </t>
       </section>
-      <section anchor="spanx-tests" toc="include" numbered="true" removeInRFC="false" pn="section-a.6">
+      <section anchor="spanx-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.6">
         <name slugifiedName="name-spanx-tests">Spanx Tests</name>
-        <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-a.6-1">
-          <li pn="section-a.6-1.1">
+        <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-appendix.a.6-1">
+          <li pn="section-appendix.a.6-1.1">
                      underscores: <em>underscores</em>
           </li>
-          <li pn="section-a.6-1.2">
+          <li pn="section-appendix.a.6-1.2">
                      asterisks: <em>asterisks</em>
           </li>
-          <li pn="section-a.6-1.3">
+          <li pn="section-appendix.a.6-1.3">
                      double asterisks: <strong>double asterisks</strong>
           </li>
-          <li pn="section-a.6-1.4">
+          <li pn="section-appendix.a.6-1.4">
                      backticks: <tt>backticks</tt>
           </li>
         </ul>
       </section>
-      <section anchor="list-tests" toc="include" numbered="true" removeInRFC="false" pn="section-a.7">
+      <section anchor="list-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.7">
         <name slugifiedName="name-list-tests">List Tests</name>
-        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-1"><li pn="section-a.7-1.1" derivedCounter="1.">
+        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-1"><li pn="section-appendix.a.7-1.1" derivedCounter="1.">
                      First we do 
                   </li>
-          <li pn="section-a.7-1.2" derivedCounter="2.">
-            <t indent="0" pn="section-a.7-1.2.1">
+          <li pn="section-appendix.a.7-1.2" derivedCounter="2.">
+            <t indent="0" pn="section-appendix.a.7-1.2.1">
                      And then </t>
-            <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-a.7-1.2.2">
-              <li pn="section-a.7-1.2.2.1">
+            <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-appendix.a.7-1.2.2">
+              <li pn="section-appendix.a.7-1.2.2.1">
                            item 1 
                         </li>
-              <li pn="section-a.7-1.2.2.2">
+              <li pn="section-appendix.a.7-1.2.2.2">
                            item 2 
                         </li>
             </ul>
           </li>
         </ol>
-        <t indent="0" pn="section-a.7-2">
+        <t indent="0" pn="section-appendix.a.7-2">
                And the other around.  
         </t>
-        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-a.7-3">
-          <li pn="section-a.7-3.1">
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-appendix.a.7-3">
+          <li pn="section-appendix.a.7-3.1">
                      First we do 
                   </li>
-          <li pn="section-a.7-3.2">
-            <t indent="0" pn="section-a.7-3.2.1">
+          <li pn="section-appendix.a.7-3.2">
+            <t indent="0" pn="section-appendix.a.7-3.2.1">
                      Then </t>
-            <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-3.2.2"><li pn="section-a.7-3.2.2.1" derivedCounter="1.">
+            <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-3.2.2"><li pn="section-appendix.a.7-3.2.2.1" derivedCounter="1.">
                            Something 
                         </li>
-              <li pn="section-a.7-3.2.2.2" derivedCounter="2.">
+              <li pn="section-appendix.a.7-3.2.2.2" derivedCounter="2.">
                            Another thing 
                         </li>
             </ol>
           </li>
         </ul>
-        <t indent="0" pn="section-a.7-4">
+        <t indent="0" pn="section-appendix.a.7-4">
                Description lists: 
         </t>
-        <dl newline="false" spacing="normal" indent="3" pn="section-a.7-5">
-          <dt pn="section-a.7-5.1">Item to explain:</dt>
-          <dd pn="section-a.7-5.2">It works because of herbs.  
+        <dl newline="false" spacing="normal" indent="3" pn="section-appendix.a.7-5">
+          <dt pn="section-appendix.a.7-5.1">Item to explain:</dt>
+          <dd pn="section-appendix.a.7-5.2">It works because of herbs.  
                   </dd>
-          <dt pn="section-a.7-5.3">Another item to explain:</dt>
-          <dd pn="section-a.7-5.4">
-            <t indent="0" pn="section-a.7-5.4.1">More explaining.  </t>
-            <t indent="0" pn="section-a.7-5.4.2"> Multiple paragraphs in such a list.  
+          <dt pn="section-appendix.a.7-5.3">Another item to explain:</dt>
+          <dd pn="section-appendix.a.7-5.4">
+            <t indent="0" pn="section-appendix.a.7-5.4.1">More explaining.  </t>
+            <t indent="0" pn="section-appendix.a.7-5.4.2"> Multiple paragraphs in such a list.  
             </t>
           </dd>
         </dl>
-        <t indent="0" pn="section-a.7-6">
+        <t indent="0" pn="section-appendix.a.7-6">
                lists in description lists.  
         </t>
-        <dl newline="false" spacing="normal" indent="3" pn="section-a.7-7">
-          <dt pn="section-a.7-7.1">Item to explain:</dt>
-          <dd pn="section-a.7-7.2">
-            <t indent="0" pn="section-a.7-7.2.1">It works because of </t>
-            <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-7.2.2"><li pn="section-a.7-7.2.2.1" derivedCounter="1.">
+        <dl newline="false" spacing="normal" indent="3" pn="section-appendix.a.7-7">
+          <dt pn="section-appendix.a.7-7.1">Item to explain:</dt>
+          <dd pn="section-appendix.a.7-7.2">
+            <t indent="0" pn="section-appendix.a.7-7.2.1">It works because of </t>
+            <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-7.2.2"><li pn="section-appendix.a.7-7.2.2.1" derivedCounter="1.">
                         One 
                      </li>
-              <li pn="section-a.7-7.2.2.2" derivedCounter="2.">
+              <li pn="section-appendix.a.7-7.2.2.2" derivedCounter="2.">
                         Two 
                      </li>
             </ol>
           </dd>
-          <dt pn="section-a.7-7.3">Another item to explain:</dt>
-          <dd pn="section-a.7-7.4">More explaining 
+          <dt pn="section-appendix.a.7-7.3">Another item to explain:</dt>
+          <dd pn="section-appendix.a.7-7.4">More explaining 
                   </dd>
-          <dt pn="section-a.7-7.5">Item to explain:</dt>
-          <dd pn="section-a.7-7.6">
-            <t indent="0" pn="section-a.7-7.6.1">It works because of </t>
-            <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-7.6.2"><li pn="section-a.7-7.6.2.1" derivedCounter="1.">
+          <dt pn="section-appendix.a.7-7.5">Item to explain:</dt>
+          <dd pn="section-appendix.a.7-7.6">
+            <t indent="0" pn="section-appendix.a.7-7.6.1">It works because of </t>
+            <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-7.6.2"><li pn="section-appendix.a.7-7.6.2.1" derivedCounter="1.">
                         One1 
                      </li>
-              <li pn="section-a.7-7.6.2.2" derivedCounter="2.">
-                <t indent="0" pn="section-a.7-7.6.2.2.1">
+              <li pn="section-appendix.a.7-7.6.2.2" derivedCounter="2.">
+                <t indent="0" pn="section-appendix.a.7-7.6.2.2.1">
                         Two1 </t>
-                <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-a.7-7.6.2.2.2">
-                  <li pn="section-a.7-7.6.2.2.2.1">
+                <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-appendix.a.7-7.6.2.2.2">
+                  <li pn="section-appendix.a.7-7.6.2.2.2.1">
                               Itemize list 
                            </li>
-                  <li pn="section-a.7-7.6.2.2.2.2">
+                  <li pn="section-appendix.a.7-7.6.2.2.2.2">
                               Another item 
                            </li>
                 </ul>
               </li>
             </ol>
           </dd>
-          <dt pn="section-a.7-7.7">Another item to explain again:</dt>
-          <dd pn="section-a.7-7.8">More explaining 
+          <dt pn="section-appendix.a.7-7.7">Another item to explain again:</dt>
+          <dd pn="section-appendix.a.7-7.8">More explaining 
                   </dd>
         </dl>
-        <t indent="0" pn="section-a.7-8">
+        <t indent="0" pn="section-appendix.a.7-8">
                list with description lists.  
         </t>
-        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-9"><li pn="section-a.7-9.1" derivedCounter="1.">
-            <t indent="0" pn="section-a.7-9.1.1">
+        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-9"><li pn="section-appendix.a.7-9.1" derivedCounter="1.">
+            <t indent="0" pn="section-appendix.a.7-9.1.1">
                      More </t>
-            <dl newline="false" spacing="normal" indent="3" pn="section-a.7-9.1.2">
-              <dt pn="section-a.7-9.1.2.1">Item to explain:</dt>
-              <dd pn="section-a.7-9.1.2.2">Explanation ...  
+            <dl newline="false" spacing="normal" indent="3" pn="section-appendix.a.7-9.1.2">
+              <dt pn="section-appendix.a.7-9.1.2.1">Item to explain:</dt>
+              <dd pn="section-appendix.a.7-9.1.2.2">Explanation ...  
                         </dd>
-              <dt pn="section-a.7-9.1.2.3">Item to explain:</dt>
-              <dd pn="section-a.7-9.1.2.4">Another explanation ...  
+              <dt pn="section-appendix.a.7-9.1.2.3">Item to explain:</dt>
+              <dd pn="section-appendix.a.7-9.1.2.4">Another explanation ...  
                         </dd>
             </dl>
           </li>
-          <li pn="section-a.7-9.2" derivedCounter="2.">
+          <li pn="section-appendix.a.7-9.2" derivedCounter="2.">
                      Go'bye 
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-10">
+        <t indent="0" pn="section-appendix.a.7-10">
                Multiple paragraphs in a list.  
         </t>
-        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-11"><li pn="section-a.7-11.1" derivedCounter="1.">
-            <t indent="0" pn="section-a.7-11.1.1">
+        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-11"><li pn="section-appendix.a.7-11.1" derivedCounter="1.">
+            <t indent="0" pn="section-appendix.a.7-11.1.1">
                      This is the first bullet point and it needs multiple paragraphs...
             </t>
-            <t indent="0" pn="section-a.7-11.1.2"> ... to be explained properly.  
+            <t indent="0" pn="section-appendix.a.7-11.1.2"> ... to be explained properly.  
             </t>
           </li>
-          <li pn="section-a.7-11.2" derivedCounter="2.">
+          <li pn="section-appendix.a.7-11.2" derivedCounter="2.">
                      This is the next bullet. New paragraphs should be indented with 4 four spaces.  
                   </li>
-          <li pn="section-a.7-11.3" derivedCounter="3.">
-            <t indent="0" pn="section-a.7-11.3.1">
+          <li pn="section-appendix.a.7-11.3" derivedCounter="3.">
+            <t indent="0" pn="section-appendix.a.7-11.3.1">
                      Another item with some artwork, indented by 8 spaces.
             </t>
-            <artwork name="" type="" align="left" alt="" pn="section-a.7-11.3.2"><![CDATA[
+            <artwork name="" type="" align="left" alt="" pn="section-appendix.a.7-11.3.2"><![CDATA[
 Artwork
                         ]]></artwork>
           </li>
-          <li pn="section-a.7-11.4" derivedCounter="4.">
+          <li pn="section-appendix.a.7-11.4" derivedCounter="4.">
                      Final item.  
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-12">
+        <t indent="0" pn="section-appendix.a.7-12">
                xml2rfc does not allow this, so the second paragraph is faked with a 
         </t>
-        <artwork name="" type="" align="left" alt="" pn="section-a.7-13"><![CDATA[
+        <artwork name="" type="" align="left" alt="" pn="section-appendix.a.7-13"><![CDATA[
 <vspace blankLines='1'>
                ]]></artwork>
-        <t indent="0" pn="section-a.7-14">
+        <t indent="0" pn="section-appendix.a.7-14">
                Ordered lists.  
         </t>
-        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-15"><li pn="section-a.7-15.1" derivedCounter="1.">
+        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-15"><li pn="section-appendix.a.7-15.1" derivedCounter="1.">
                      First item 
                   </li>
-          <li pn="section-a.7-15.2" derivedCounter="2.">
+          <li pn="section-appendix.a.7-15.2" derivedCounter="2.">
                      Second item 
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-16">
+        <t indent="0" pn="section-appendix.a.7-16">
                A lowercase roman list: 
         </t>
-        <ol spacing="normal" type="%i." indent="adaptive" start="1" pn="section-a.7-17"><li pn="section-a.7-17.1" derivedCounter="i.">
+        <ol spacing="normal" type="%i." indent="adaptive" start="1" pn="section-appendix.a.7-17"><li pn="section-appendix.a.7-17.1" derivedCounter="i.">
                      Item 1 
                   </li>
-          <li pn="section-a.7-17.2" derivedCounter="ii.">
+          <li pn="section-appendix.a.7-17.2" derivedCounter="ii.">
                      Item 2 
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-18">
+        <t indent="0" pn="section-appendix.a.7-18">
                An uppercase roman list.  
         </t>
-        <ol spacing="normal" type="(%d)" indent="adaptive" start="1" pn="section-a.7-19"><li pn="section-a.7-19.1" derivedCounter="(1)">
+        <ol spacing="normal" type="(%d)" indent="adaptive" start="1" pn="section-appendix.a.7-19"><li pn="section-appendix.a.7-19.1" derivedCounter="(1)">
                      Item1 
                   </li>
-          <li pn="section-a.7-19.2" derivedCounter="(2)">
+          <li pn="section-appendix.a.7-19.2" derivedCounter="(2)">
                      Item2 
                   </li>
-          <li pn="section-a.7-19.3" derivedCounter="(3)">
+          <li pn="section-appendix.a.7-19.3" derivedCounter="(3)">
                      Item 3 
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-20">
+        <t indent="0" pn="section-appendix.a.7-20">
                And default list markers.<iref item="list" subitem="default markers" primary="false" pn="iref-list-default-markers-1"/>
         </t>
-        <t indent="0" pn="section-a.7-21">
+        <t indent="0" pn="section-appendix.a.7-21">
                Some surrounding text, to make it look better.  
         </t>
-        <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-a.7-22">
-          <li pn="section-a.7-22.1">
+        <ul empty="true" spacing="normal" bare="false" indent="3" pn="section-appendix.a.7-22">
+          <li pn="section-appendix.a.7-22.1">
                      First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.
 		     First item. Use lot of text to get a real paragraphs sense.  
                   </li>
-          <li pn="section-a.7-22.2">
+          <li pn="section-appendix.a.7-22.2">
                      Second item. So this is the second para in your list. Enjoy; 
                   </li>
-          <li pn="section-a.7-22.3">
+          <li pn="section-appendix.a.7-22.3">
                      Another item.  
                   </li>
         </ul>
-        <t indent="0" pn="section-a.7-23">
+        <t indent="0" pn="section-appendix.a.7-23">
                Text at the end.  
         </t>
-        <t indent="0" pn="section-a.7-24">
+        <t indent="0" pn="section-appendix.a.7-24">
                Lowercase letters list.  
         </t>
-        <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-a.7-25"><li pn="section-a.7-25.1" derivedCounter="a.">
+        <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-appendix.a.7-25"><li pn="section-appendix.a.7-25.1" derivedCounter="a.">
                      First item 
                   </li>
-          <li pn="section-a.7-25.2" derivedCounter="b.">
+          <li pn="section-appendix.a.7-25.2" derivedCounter="b.">
                      Second item 
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-26">
+        <t indent="0" pn="section-appendix.a.7-26">
                Uppercase letters list.  
         </t>
-        <ol spacing="normal" type="%C." indent="adaptive" start="1" pn="section-a.7-27"><li pn="section-a.7-27.1" derivedCounter="A.">
+        <ol spacing="normal" type="%C." indent="adaptive" start="1" pn="section-appendix.a.7-27"><li pn="section-appendix.a.7-27.1" derivedCounter="A.">
                      First item 
                   </li>
-          <li pn="section-a.7-27.2" derivedCounter="B.">
+          <li pn="section-appendix.a.7-27.2" derivedCounter="B.">
                      Second item 
                   </li>
         </ol>
-        <t indent="0" pn="section-a.7-28">
+        <t indent="0" pn="section-appendix.a.7-28">
                <iref item="list" subitem="Uppercase Letters" primary="false" pn="iref-list-uppercase-letters-2"/>
         </t>
-        <t indent="0" pn="section-a.7-29">
+        <t indent="0" pn="section-appendix.a.7-29">
                And artwork in a description list.  
         </t>
-        <dl newline="false" spacing="normal" indent="3" pn="section-a.7-30">
-          <dt pn="section-a.7-30.1">Item1:</dt>
-          <dd pn="section-a.7-30.2">
-            <t indent="0" pn="section-a.7-30.2.1">
+        <dl newline="false" spacing="normal" indent="3" pn="section-appendix.a.7-30">
+          <dt pn="section-appendix.a.7-30.1">Item1:</dt>
+          <dd pn="section-appendix.a.7-30.2">
+            <t indent="0" pn="section-appendix.a.7-30.2.1">
                      Tell something about it. Tell something about it. Tell something about
 		     it. Tell something about it. Tell something about it. Tell something about it.
             </t>
-            <artwork name="" type="" align="left" alt="" pn="section-a.7-30.2.2"><![CDATA[
+            <artwork name="" type="" align="left" alt="" pn="section-appendix.a.7-30.2.2"><![CDATA[
 miek.nl.    IN  NS  a.miek.nl.                             
 a.miek.nl.  IN  A   192.0.2.1    ; <- this is glue            
                      ]]></artwork>
-            <t indent="0" pn="section-a.7-30.2.3">
+            <t indent="0" pn="section-appendix.a.7-30.2.3">
                      Tell some more about it. Tell some more about it. Tell some more about it.  
             </t>
           </dd>
-          <dt pn="section-a.7-30.3">Item2:</dt>
-          <dd pn="section-a.7-30.4">Another description 
+          <dt pn="section-appendix.a.7-30.3">Item2:</dt>
+          <dd pn="section-appendix.a.7-30.4">Another description 
                   </dd>
         </dl>
-        <t indent="0" pn="section-a.7-31">
+        <t indent="0" pn="section-appendix.a.7-31">
                List with a sublist with a paragraph above the sublist 
         </t>
-        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.7-32"><li pn="section-a.7-32.1" derivedCounter="1.">
+        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.7-32"><li pn="section-appendix.a.7-32.1" derivedCounter="1.">
                      First Item 
                   </li>
-          <li pn="section-a.7-32.2" derivedCounter="2.">
+          <li pn="section-appendix.a.7-32.2" derivedCounter="2.">
                      Second item 
                   </li>
-          <li pn="section-a.7-32.3" derivedCounter="3.">
-            <t indent="0" pn="section-a.7-32.3.1">
+          <li pn="section-appendix.a.7-32.3" derivedCounter="3.">
+            <t indent="0" pn="section-appendix.a.7-32.3.1">
                      Third item </t>
-            <t indent="0" pn="section-a.7-32.3.2"> A paragraph that comes first </t>
-            <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-a.7-32.3.3"><li pn="section-a.7-32.3.3.1" derivedCounter="a.">
+            <t indent="0" pn="section-appendix.a.7-32.3.2"> A paragraph that comes first </t>
+            <ol spacing="normal" type="a" indent="adaptive" start="1" pn="section-appendix.a.7-32.3.3"><li pn="section-appendix.a.7-32.3.3.1" derivedCounter="a.">
                            But what do you know 
                         </li>
-              <li pn="section-a.7-32.3.3.2" derivedCounter="b.">
+              <li pn="section-appendix.a.7-32.3.3.2" derivedCounter="b.">
                            This is another list 
                         </li>
             </ol>
           </li>
         </ol>
       </section>
-      <section anchor="anchor-table-tests" toc="include" numbered="true" removeInRFC="false" pn="section-a.8">
+      <section anchor="anchor-table-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.8">
         <name slugifiedName="name-table-tests">Table Tests</name>
         <table anchor="tab-demonstrat" align="center" pn="table-1">
           <name slugifiedName="name-demonstration-of-simple-tab">Demonstration of simple table
@@ -1537,7 +1537,7 @@ a.miek.nl.  IN  A   192.0.2.1    ; <- this is glue
             </tr>
           </tbody>
         </table>
-        <t indent="0" pn="section-a.8-3">
+        <t indent="0" pn="section-appendix.a.8-3">
                <iref item="table" subitem="simple" primary="false" pn="iref-table-simple-3"/>
         </t>
         <table anchor="tab-sample-gri" align="center" pn="table-3">
@@ -1562,7 +1562,7 @@ a.miek.nl.  IN  A   192.0.2.1    ; <- this is glue
             </tr>
           </tbody>
         </table>
-        <t indent="0" pn="section-a.8-5">
+        <t indent="0" pn="section-appendix.a.8-5">
                Grid tables without a caption 
         </t>
         <table align="center" pn="table-4">
@@ -1586,19 +1586,19 @@ a.miek.nl.  IN  A   192.0.2.1    ; <- this is glue
             </tr>
           </tbody>
         </table>
-        <t indent="0" pn="section-a.8-7">
+        <t indent="0" pn="section-appendix.a.8-7">
                This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance: 
         </t>
-        <artwork name="" type="" align="left" alt="" pn="section-a.8-8"><![CDATA[
+        <artwork name="" type="" align="left" alt="" pn="section-appendix.a.8-8"><![CDATA[
 See [](#tab-here-s-the)
                ]]></artwork>
-        <t indent="0" pn="section-a.8-9">
+        <t indent="0" pn="section-appendix.a.8-9">
                Which will become "See <xref target="tab-here-s-the" format="default" sectionFormat="of" derivedContent="Table 2"/>".  
         </t>
-        <t indent="0" pn="section-a.8-10">
+        <t indent="0" pn="section-appendix.a.8-10">
                <iref item="table" subitem="grid" primary="false" pn="iref-table-grid-4"/>
         </t>
-        <t indent="0" pn="section-a.8-11">
+        <t indent="0" pn="section-appendix.a.8-11">
                We should also be able to refer to the table numbers directly, to say things like 
                'Look at Tables
                <xref target="tab-demonstrat" format="counter" sectionFormat="of" derivedContent="1"/>,
@@ -1606,52 +1606,52 @@ See [](#tab-here-s-the)
                and <xref target="tab-sample-gri" format="counter" sectionFormat="of" derivedContent="3"/>.'
         </t>
       </section>
-      <section anchor="numbered-examples" toc="include" numbered="true" removeInRFC="false" pn="section-a.9">
+      <section anchor="numbered-examples" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.9">
         <name slugifiedName="name-numbered-examples">Numbered examples</name>
-        <t indent="0" pn="section-a.9-1">
+        <t indent="0" pn="section-appendix.a.9-1">
                This is another example: 
         </t>
-        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-a.9-2"><li pn="section-a.9-2.1" derivedCounter="1.">
+        <ol spacing="normal" type="1" indent="adaptive" start="1" pn="section-appendix.a.9-2"><li pn="section-appendix.a.9-2.1" derivedCounter="1.">
                      Another bla bla..  
                   </li>
         </ol>
-        <t indent="0" pn="section-a.9-3">
+        <t indent="0" pn="section-appendix.a.9-3">
                as (1) shows...  
         </t>
       </section>
-      <section anchor="anchor-figure-tests" toc="include" numbered="true" removeInRFC="false" pn="section-a.10">
+      <section anchor="anchor-figure-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.10">
         <name slugifiedName="name-figure-tests">Figure tests</name>
         <figure anchor="fig-this-is-th" align="left" suppress-title="false" pn="figure-4">
           <name slugifiedName="name-this-is-the-caption-with-te">This is the caption, with text in `typewriter`. Which isnt converted to a &lt;spanx&gt; style, because this is copied as-is.</name>
-          <artwork name="" type="" align="left" alt="" pn="section-a.10-1.1"><![CDATA[
+          <artwork name="" type="" align="left" alt="" pn="section-appendix.a.10-1.1"><![CDATA[
 This is a figure
 This is a figure
 This is a figure
 This is a figure
                ]]></artwork>
         </figure>
-        <t indent="0" pn="section-a.10-2">
+        <t indent="0" pn="section-appendix.a.10-2">
                And how a figure that is not centered, do to using <tt>figure</tt> and not <tt>Figure</tt>.  
         </t>
         <figure anchor="fig-a-non-cent" align="left" suppress-title="false" pn="figure-5">
           <name slugifiedName="name-a-non-centered-figure">A non centered figure.</name>
-          <artwork name="" type="" align="left" alt="" pn="section-a.10-3.1"><![CDATA[
+          <artwork name="" type="" align="left" alt="" pn="section-appendix.a.10-3.1"><![CDATA[
 This is a figure
 This is a figure
                ]]></artwork>
         </figure>
-        <t indent="0" pn="section-a.10-4">
+        <t indent="0" pn="section-appendix.a.10-4">
                Test the use of <tt>@title</tt>: 
         </t>
-        <artwork name="" type="" align="left" alt="" pn="section-a.10-5"><![CDATA[
+        <artwork name="" type="" align="left" alt="" pn="section-appendix.a.10-5"><![CDATA[
 This is a figure with a title
 This is a figure with a title
 @title: and here it is: a title, don't mess it up *
                ]]></artwork>
       </section>
-      <section anchor="verse-tests" toc="include" numbered="true" removeInRFC="false" pn="section-a.11">
+      <section anchor="verse-tests" toc="include" numbered="true" removeInRFC="false" pn="section-appendix.a.11">
         <name slugifiedName="name-verse-tests">Verse tests</name>
-        <t indent="0" pn="section-a.11-1">
+        <t indent="0" pn="section-appendix.a.11-1">
                This is a verse text This is another line 
         </t>
       </section>
@@ -1678,13 +1678,13 @@ This is a figure with a title
                     <dt pn="section-appendix.b-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
                     <dd pn="section-appendix.b-2.1.2.1.1.4.1.2">
                       <t indent="0" pn="section-appendix.b-2.1.2.1.1.4.1.2.1">
-                        <xref format="default" sectionFormat="of" target="section-a.7-28" derivedContent="Section A.7, Paragraph 28"/>
+                        <xref format="default" sectionFormat="of" target="section-appendix.a.7-28" derivedContent="Appendix A.7, Paragraph 28"/>
                       </t>
                     </dd>
                     <dt pn="section-appendix.b-2.1.2.1.1.4.1.3">default markers</dt>
                     <dd pn="section-appendix.b-2.1.2.1.1.4.1.4">
                       <t indent="0" pn="section-appendix.b-2.1.2.1.1.4.1.4.1">
-                        <xref format="default" sectionFormat="of" target="section-a.7-20" derivedContent="Section A.7, Paragraph 20"/>
+                        <xref format="default" sectionFormat="of" target="section-appendix.a.7-20" derivedContent="Appendix A.7, Paragraph 20"/>
                       </t>
                     </dd>
                   </dl>
@@ -1708,13 +1708,13 @@ This is a figure with a title
                     <dt pn="section-appendix.b-2.2.2.1.1.4.1.1">grid</dt>
                     <dd pn="section-appendix.b-2.2.2.1.1.4.1.2">
                       <t indent="0" pn="section-appendix.b-2.2.2.1.1.4.1.2.1">
-                        <xref format="default" sectionFormat="of" target="section-a.8-10" derivedContent="Section A.8, Paragraph 10"/>
+                        <xref format="default" sectionFormat="of" target="section-appendix.a.8-10" derivedContent="Appendix A.8, Paragraph 10"/>
                       </t>
                     </dd>
                     <dt pn="section-appendix.b-2.2.2.1.1.4.1.3">simple</dt>
                     <dd pn="section-appendix.b-2.2.2.1.1.4.1.4">
                       <t indent="0" pn="section-appendix.b-2.2.2.1.1.4.1.4.1">
-                        <xref format="default" sectionFormat="of" target="section-a.8-3" derivedContent="Section A.8, Paragraph 3"/>
+                        <xref format="default" sectionFormat="of" target="section-appendix.a.8-3" derivedContent="Appendix A.8, Paragraph 3"/>
                       </t>
                     </dd>
                   </dl>

--- a/cli/tests/valid/draft-miek-test.text
+++ b/cli/tests/valid/draft-miek-test.text
@@ -953,14 +953,14 @@ Index
       L
 
          list
-            Uppercase Letters  Section A.7, Paragraph 28
-            default markers  Section A.7, Paragraph 20
+            Uppercase Letters  Appendix A.7, Paragraph 28
+            default markers  Appendix A.7, Paragraph 20
 
       T
 
          table
-            grid  Section A.8, Paragraph 10
-            simple  Section A.8, Paragraph 3
+            grid  Appendix A.8, Paragraph 10
+            simple  Appendix A.8, Paragraph 3
 
 Author's Address
 

--- a/cli/tests/valid/draft-miek-test.v3.py36.html
+++ b/cli/tests/valid/draft-miek-test.v3.py36.html
@@ -254,48 +254,48 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-tests" class="xref">Tests</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-tests" class="xref">Tests</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-markup-in-heading" class="xref">Markup in heading</a></p>
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-markup-in-heading" class="xref">Markup in heading</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.3">
-                <p id="section-toc.1-1.12.2.3.1"><a href="#section-a.3" class="xref">A.3</a>.  <a href="#name-blockquote" class="xref">Blockquote</a></p>
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-blockquote" class="xref">Blockquote</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.4">
-                <p id="section-toc.1-1.12.2.4.1"><a href="#section-a.4" class="xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="xref">Verbatim code blocks</a></p>
+                <p id="section-toc.1-1.12.2.4.1"><a href="#appendix-A.4" class="xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="xref">Verbatim code blocks</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.5">
-                <p id="section-toc.1-1.12.2.5.1"><a href="#section-a.5" class="xref">A.5</a>.  <a href="#name-reference-tests" class="xref">Reference Tests</a></p>
+                <p id="section-toc.1-1.12.2.5.1"><a href="#appendix-A.5" class="xref">A.5</a>.  <a href="#name-reference-tests" class="xref">Reference Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.6">
-                <p id="section-toc.1-1.12.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-spanx-tests" class="xref">Spanx Tests</a></p>
+                <p id="section-toc.1-1.12.2.6.1"><a href="#appendix-A.6" class="xref">A.6</a>.  <a href="#name-spanx-tests" class="xref">Spanx Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.7">
-                <p id="section-toc.1-1.12.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-list-tests" class="xref">List Tests</a></p>
+                <p id="section-toc.1-1.12.2.7.1"><a href="#appendix-A.7" class="xref">A.7</a>.  <a href="#name-list-tests" class="xref">List Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.8">
-                <p id="section-toc.1-1.12.2.8.1"><a href="#section-a.8" class="xref">A.8</a>.  <a href="#name-table-tests" class="xref">Table Tests</a></p>
+                <p id="section-toc.1-1.12.2.8.1"><a href="#appendix-A.8" class="xref">A.8</a>.  <a href="#name-table-tests" class="xref">Table Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.9">
-                <p id="section-toc.1-1.12.2.9.1"><a href="#section-a.9" class="xref">A.9</a>.  <a href="#name-numbered-examples" class="xref">Numbered examples</a></p>
+                <p id="section-toc.1-1.12.2.9.1"><a href="#appendix-A.9" class="xref">A.9</a>.  <a href="#name-numbered-examples" class="xref">Numbered examples</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.10">
-                <p id="section-toc.1-1.12.2.10.1"><a href="#section-a.10" class="xref">A.10</a>. <a href="#name-figure-tests" class="xref">Figure tests</a></p>
+                <p id="section-toc.1-1.12.2.10.1"><a href="#appendix-A.10" class="xref">A.10</a>. <a href="#name-figure-tests" class="xref">Figure tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.11">
-                <p id="section-toc.1-1.12.2.11.1"><a href="#section-a.11" class="xref">A.11</a>. <a href="#name-verse-tests" class="xref">Verse tests</a></p>
+                <p id="section-toc.1-1.12.2.11.1"><a href="#appendix-A.11" class="xref">A.11</a>. <a href="#name-verse-tests" class="xref">Verse tests</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -1266,371 +1266,371 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </section>
 </section>
 <div id="tests">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-tests">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
       </h2>
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
             This appendix consists out of a few tests that should all render to proper
-            <code>xml2rfc</code> XML.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+            <code>xml2rfc</code> XML.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 <div id="a-very-long-title-considerations-with-regards-to-the-already-deployed-routing-policy">
-<section id="section-a.1">
-        <h2 id="name-a-very-long-title-considera">
-<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
-        </h2>
-<p id="section-a.1-1">
-               Test a very long title.<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.1">
+        <h3 id="name-a-very-long-title-considera">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
+        </h3>
+<p id="appendix-A.1-1">
+               Test a very long title.<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="markup-in-heading">
-<section id="section-a.2">
-        <h2 id="name-markup-in-heading">
-<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
-        </h2>
-<p id="section-a.2-1">
-               This is discarded by <code>xml2rfc</code>.<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.2">
+        <h3 id="name-markup-in-heading">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
+        </h3>
+<p id="appendix-A.2-1">
+               This is discarded by <code>xml2rfc</code>.<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="blockquote">
-<section id="section-a.3">
-        <h2 id="name-blockquote">
-<a href="#section-a.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
-        </h2>
+<section id="appendix-A.3">
+        <h3 id="name-blockquote">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
+        </h3>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.3-1.1">
-                     This is a blockquote, how does it look?<a href="#section-a.3-1.1" class="pilcrow">¶</a>
+<li class="ulEmpty normal" id="appendix-A.3-1.1">
+                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
 </div>
 <div id="verbatim-code-blocks">
-<section id="section-a.4">
-        <h2 id="name-verbatim-code-blocks">
-<a href="#section-a.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
-        </h2>
-<div class="artwork art-text alignLeft" id="section-a.4-1">
+<section id="appendix-A.4">
+        <h3 id="name-verbatim-code-blocks">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
+        </h3>
+<div class="artwork art-text alignLeft" id="appendix-A.4-1">
 <pre>
 A verbatim code block
 jkasjksajassjasjsajsajkas
-</pre><a href="#section-a.4-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.4-1" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 <div id="reference-tests">
-<section id="section-a.5">
-        <h2 id="name-reference-tests">
-<a href="#section-a.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
-        </h2>
-<p id="section-a.5-1">
-               Refer to <span><a href="#RFC2119" class="xref">RFC 2119</a> [<a href="#RFC2119" class="xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#section-a.5-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.5">
+        <h3 id="name-reference-tests">
+<a href="#appendix-A.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
+        </h3>
+<p id="appendix-A.5-1">
+               Refer to <span><a href="#RFC2119" class="xref">RFC 2119</a> [<a href="#RFC2119" class="xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#appendix-A.5-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="spanx-tests">
-<section id="section-a.6">
-        <h2 id="name-spanx-tests">
-<a href="#section-a.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
-        </h2>
+<section id="appendix-A.6">
+        <h3 id="name-spanx-tests">
+<a href="#appendix-A.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
+        </h3>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.6-1.1">
-                     underscores: <em>underscores</em><a href="#section-a.6-1.1" class="pilcrow">¶</a>
+<li class="ulEmpty normal" id="appendix-A.6-1.1">
+                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.2">
-                     asterisks: <em>asterisks</em><a href="#section-a.6-1.2" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.2">
+                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.3">
-                     double asterisks: <strong>double asterisks</strong><a href="#section-a.6-1.3" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.3">
+                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.4">
-                     backticks: <code>backticks</code><a href="#section-a.6-1.4" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.4">
+                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
 </div>
 <div id="list-tests">
-<section id="section-a.7">
-        <h2 id="name-list-tests">
-<a href="#section-a.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
-        </h2>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-1">
-<li id="section-a.7-1.1">
-                     First we do<a href="#section-a.7-1.1" class="pilcrow">¶</a>
+<section id="appendix-A.7">
+        <h3 id="name-list-tests">
+<a href="#appendix-A.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
+        </h3>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-1">
+<li id="appendix-A.7-1.1">
+                     First we do<a href="#appendix-A.7-1.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-1.2">
-            <p id="section-a.7-1.2.1">
-                     And then<a href="#section-a.7-1.2.1" class="pilcrow">¶</a></p>
+          <li id="appendix-A.7-1.2">
+            <p id="appendix-A.7-1.2.1">
+                     And then<a href="#appendix-A.7-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-1.2.2.1">
-                           item 1<a href="#section-a.7-1.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-1.2.2.1">
+                           item 1<a href="#appendix-A.7-1.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li class="normal" id="section-a.7-1.2.2.2">
-                           item 2<a href="#section-a.7-1.2.2.2" class="pilcrow">¶</a>
+              <li class="normal" id="appendix-A.7-1.2.2.2">
+                           item 2<a href="#appendix-A.7-1.2.2.2" class="pilcrow">¶</a>
 </li>
             </ul>
 </li>
         </ol>
-<p id="section-a.7-2">
-               And the other around.<a href="#section-a.7-2" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-2">
+               And the other around.<a href="#appendix-A.7-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-3.1">
-                     First we do<a href="#section-a.7-3.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-3.1">
+                     First we do<a href="#appendix-A.7-3.1" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-a.7-3.2">
-            <p id="section-a.7-3.2.1">
-                     Then<a href="#section-a.7-3.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-3.2.2">
-<li id="section-a.7-3.2.2.1">
-                           Something<a href="#section-a.7-3.2.2.1" class="pilcrow">¶</a>
+          <li class="normal" id="appendix-A.7-3.2">
+            <p id="appendix-A.7-3.2.1">
+                     Then<a href="#appendix-A.7-3.2.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-3.2.2">
+<li id="appendix-A.7-3.2.2.1">
+                           Something<a href="#appendix-A.7-3.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-3.2.2.2">
-                           Another thing<a href="#section-a.7-3.2.2.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-3.2.2.2">
+                           Another thing<a href="#appendix-A.7-3.2.2.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </li>
         </ul>
-<p id="section-a.7-4">
-               Description lists:<a href="#section-a.7-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-5">
-          <dt id="section-a.7-5.1">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-5.2">It works because of herbs.<a href="#section-a.7-5.2" class="pilcrow">¶</a>
+<p id="appendix-A.7-4">
+               Description lists:<a href="#appendix-A.7-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-5">
+          <dt id="appendix-A.7-5.1">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-5.2">It works because of herbs.<a href="#appendix-A.7-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-5.3">Another item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-5.4">
-            <p id="section-a.7-5.4.1">More explaining.<a href="#section-a.7-5.4.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-5.4.2"> Multiple paragraphs in such a list.<a href="#section-a.7-5.4.2" class="pilcrow">¶</a></p>
+<dt id="appendix-A.7-5.3">Another item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-5.4">
+            <p id="appendix-A.7-5.4.1">More explaining.<a href="#appendix-A.7-5.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-5.4.2"> Multiple paragraphs in such a list.<a href="#appendix-A.7-5.4.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-6">
-               lists in description lists.<a href="#section-a.7-6" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-7">
-          <dt id="section-a.7-7.1">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.2">
-            <p id="section-a.7-7.2.1">It works because of<a href="#section-a.7-7.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-7.2.2">
-<li id="section-a.7-7.2.2.1">
-                        One<a href="#section-a.7-7.2.2.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-6">
+               lists in description lists.<a href="#appendix-A.7-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-7">
+          <dt id="appendix-A.7-7.1">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.2">
+            <p id="appendix-A.7-7.2.1">It works because of<a href="#appendix-A.7-7.2.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.2.2">
+<li id="appendix-A.7-7.2.2.1">
+                        One<a href="#appendix-A.7-7.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-7.2.2.2">
-                        Two<a href="#section-a.7-7.2.2.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-7.2.2.2">
+                        Two<a href="#appendix-A.7-7.2.2.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.3">Another item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.4">More explaining<a href="#section-a.7-7.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.3">Another item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.4">More explaining<a href="#appendix-A.7-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.5">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.6">
-            <p id="section-a.7-7.6.1">It works because of<a href="#section-a.7-7.6.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-7.6.2">
-<li id="section-a.7-7.6.2.1">
-                        One1<a href="#section-a.7-7.6.2.1" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.5">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.6">
+            <p id="appendix-A.7-7.6.1">It works because of<a href="#appendix-A.7-7.6.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.6.2">
+<li id="appendix-A.7-7.6.2.1">
+                        One1<a href="#appendix-A.7-7.6.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-7.6.2.2">
-                <p id="section-a.7-7.6.2.2.1">
-                        Two1<a href="#section-a.7-7.6.2.2.1" class="pilcrow">¶</a></p>
+              <li id="appendix-A.7-7.6.2.2">
+                <p id="appendix-A.7-7.6.2.2.1">
+                        Two1<a href="#appendix-A.7-7.6.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-7.6.2.2.2.1">
-                              Itemize list<a href="#section-a.7-7.6.2.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-7.6.2.2.2.1">
+                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1" class="pilcrow">¶</a>
 </li>
-                  <li class="normal" id="section-a.7-7.6.2.2.2.2">
-                              Another item<a href="#section-a.7-7.6.2.2.2.2" class="pilcrow">¶</a>
+                  <li class="normal" id="appendix-A.7-7.6.2.2.2.2">
+                              Another item<a href="#appendix-A.7-7.6.2.2.2.2" class="pilcrow">¶</a>
 </li>
                 </ul>
 </li>
             </ol>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.7">Another item to explain again:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.8">More explaining<a href="#section-a.7-7.8" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.7">Another item to explain again:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.8">More explaining<a href="#appendix-A.7-7.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-8">
-               list with description lists.<a href="#section-a.7-8" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-9">
-<li id="section-a.7-9.1">
-            <p id="section-a.7-9.1.1">
-                     More<a href="#section-a.7-9.1.1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-9.1.2">
-              <dt id="section-a.7-9.1.2.1">Item to explain:</dt>
-              <dd style="margin-left: 1.5em" id="section-a.7-9.1.2.2">Explanation ...<a href="#section-a.7-9.1.2.2" class="pilcrow">¶</a>
+<p id="appendix-A.7-8">
+               list with description lists.<a href="#appendix-A.7-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-9">
+<li id="appendix-A.7-9.1">
+            <p id="appendix-A.7-9.1.1">
+                     More<a href="#appendix-A.7-9.1.1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-9.1.2">
+              <dt id="appendix-A.7-9.1.2.1">Item to explain:</dt>
+              <dd style="margin-left: 1.5em" id="appendix-A.7-9.1.2.2">Explanation ...<a href="#appendix-A.7-9.1.2.2" class="pilcrow">¶</a>
 </dd>
               <dd class="break"></dd>
-<dt id="section-a.7-9.1.2.3">Item to explain:</dt>
-              <dd style="margin-left: 1.5em" id="section-a.7-9.1.2.4">Another explanation ...<a href="#section-a.7-9.1.2.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-9.1.2.3">Item to explain:</dt>
+              <dd style="margin-left: 1.5em" id="appendix-A.7-9.1.2.4">Another explanation ...<a href="#appendix-A.7-9.1.2.4" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
 </li>
-          <li id="section-a.7-9.2">
-                     Go'bye<a href="#section-a.7-9.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-9.2">
+                     Go'bye<a href="#appendix-A.7-9.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-10">
-               Multiple paragraphs in a list.<a href="#section-a.7-10" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-11">
-<li id="section-a.7-11.1">
-            <p id="section-a.7-11.1.1">
-                     This is the first bullet point and it needs multiple paragraphs...<a href="#section-a.7-11.1.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-11.1.2"> ... to be explained properly.<a href="#section-a.7-11.1.2" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-10">
+               Multiple paragraphs in a list.<a href="#appendix-A.7-10" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-11">
+<li id="appendix-A.7-11.1">
+            <p id="appendix-A.7-11.1.1">
+                     This is the first bullet point and it needs multiple paragraphs...<a href="#appendix-A.7-11.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-11.1.2"> ... to be explained properly.<a href="#appendix-A.7-11.1.2" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-a.7-11.2">
-                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#section-a.7-11.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-11.2">
+                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-11.3">
-            <p id="section-a.7-11.3.1">
-                     Another item with some artwork, indented by 8 spaces.<a href="#section-a.7-11.3.1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-11.3.2">
+          <li id="appendix-A.7-11.3">
+            <p id="appendix-A.7-11.3.1">
+                     Another item with some artwork, indented by 8 spaces.<a href="#appendix-A.7-11.3.1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-11.3.2">
 <pre>
 Artwork
-</pre><a href="#section-a.7-11.3.2" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-11.3.2" class="pilcrow">¶</a>
 </div>
 </li>
-          <li id="section-a.7-11.4">
-                     Final item.<a href="#section-a.7-11.4" class="pilcrow">¶</a>
+          <li id="appendix-A.7-11.4">
+                     Final item.<a href="#appendix-A.7-11.4" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-12">
-               xml2rfc does not allow this, so the second paragraph is faked with a<a href="#section-a.7-12" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-13">
+<p id="appendix-A.7-12">
+               xml2rfc does not allow this, so the second paragraph is faked with a<a href="#appendix-A.7-12" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-13">
 <pre>
 &lt;vspace blankLines='1'&gt;
-</pre><a href="#section-a.7-13" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-13" class="pilcrow">¶</a>
 </div>
-<p id="section-a.7-14">
-               Ordered lists.<a href="#section-a.7-14" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-15">
-<li id="section-a.7-15.1">
-                     First item<a href="#section-a.7-15.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-14">
+               Ordered lists.<a href="#appendix-A.7-14" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-15">
+<li id="appendix-A.7-15.1">
+                     First item<a href="#appendix-A.7-15.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-15.2">
-                     Second item<a href="#section-a.7-15.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-15.2">
+                     Second item<a href="#appendix-A.7-15.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-16">
-               A lowercase roman list:<a href="#section-a.7-16" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-17">
+<p id="appendix-A.7-16">
+               A lowercase roman list:<a href="#appendix-A.7-16" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-17">
 <dt>i.</dt>
-<dd id="section-a.7-17.1">
-                     Item 1<a href="#section-a.7-17.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-17.1">
+                     Item 1<a href="#appendix-A.7-17.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>ii.</dt>
-<dd id="section-a.7-17.2">
-                     Item 2<a href="#section-a.7-17.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-17.2">
+                     Item 2<a href="#appendix-A.7-17.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-18">
-               An uppercase roman list.<a href="#section-a.7-18" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-19">
+<p id="appendix-A.7-18">
+               An uppercase roman list.<a href="#appendix-A.7-18" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-19">
 <dt>(1)</dt>
-<dd id="section-a.7-19.1">
-                     Item1<a href="#section-a.7-19.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.1">
+                     Item1<a href="#appendix-A.7-19.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>(2)</dt>
-<dd id="section-a.7-19.2">
-                     Item2<a href="#section-a.7-19.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.2">
+                     Item2<a href="#appendix-A.7-19.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>(3)</dt>
-<dd id="section-a.7-19.3">
-                     Item 3<a href="#section-a.7-19.3" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.3">
+                     Item 3<a href="#appendix-A.7-19.3" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-20">
-               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#section-a.7-20" class="pilcrow">¶</a></p>
-<p id="section-a.7-21">
-               Some surrounding text, to make it look better.<a href="#section-a.7-21" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-20">
+               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#appendix-A.7-20" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-21">
+               Some surrounding text, to make it look better.<a href="#appendix-A.7-21" class="pilcrow">¶</a></p>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.7-22.1">
+<li class="ulEmpty normal" id="appendix-A.7-22.1">
                      First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
-      First item. Use lot of text to get a real paragraphs sense.<a href="#section-a.7-22.1" class="pilcrow">¶</a>
+      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.7-22.2">
-                     Second item. So this is the second para in your list. Enjoy;<a href="#section-a.7-22.2" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.7-22.2">
+                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.7-22.3">
-                     Another item.<a href="#section-a.7-22.3" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.7-22.3">
+                     Another item.<a href="#appendix-A.7-22.3" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-a.7-23">
-               Text at the end.<a href="#section-a.7-23" class="pilcrow">¶</a></p>
-<p id="section-a.7-24">
-               Lowercase letters list.<a href="#section-a.7-24" class="pilcrow">¶</a></p>
-<ol start="1" type="a" class="normal type-a" id="section-a.7-25">
-<li id="section-a.7-25.1">
-                     First item<a href="#section-a.7-25.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-23">
+               Text at the end.<a href="#appendix-A.7-23" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-24">
+               Lowercase letters list.<a href="#appendix-A.7-24" class="pilcrow">¶</a></p>
+<ol start="1" type="a" class="normal type-a" id="appendix-A.7-25">
+<li id="appendix-A.7-25.1">
+                     First item<a href="#appendix-A.7-25.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-25.2">
-                     Second item<a href="#section-a.7-25.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-25.2">
+                     Second item<a href="#appendix-A.7-25.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-26">
-               Uppercase letters list.<a href="#section-a.7-26" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-27">
+<p id="appendix-A.7-26">
+               Uppercase letters list.<a href="#appendix-A.7-26" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-27">
 <dt>A.</dt>
-<dd id="section-a.7-27.1">
-                     First item<a href="#section-a.7-27.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-27.1">
+                     First item<a href="#appendix-A.7-27.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>B.</dt>
-<dd id="section-a.7-27.2">
-                     Second item<a href="#section-a.7-27.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-27.2">
+                     Second item<a href="#appendix-A.7-27.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-28">
-               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#section-a.7-28" class="pilcrow">¶</a></p>
-<p id="section-a.7-29">
-               And artwork in a description list.<a href="#section-a.7-29" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-30">
-          <dt id="section-a.7-30.1">Item1:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-30.2">
-            <p id="section-a.7-30.2.1">
+<p id="appendix-A.7-28">
+               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#appendix-A.7-28" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-29">
+               And artwork in a description list.<a href="#appendix-A.7-29" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-30">
+          <dt id="appendix-A.7-30.1">Item1:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-30.2">
+            <p id="appendix-A.7-30.2.1">
                      Tell something about it. Tell something about it. Tell something about
-      it. Tell something about it. Tell something about it. Tell something about it.<a href="#section-a.7-30.2.1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-30.2.2">
+      it. Tell something about it. Tell something about it. Tell something about it.<a href="#appendix-A.7-30.2.1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-30.2.2">
 <pre>
 miek.nl.    IN  NS  a.miek.nl.
 a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
-</pre><a href="#section-a.7-30.2.2" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-30.2.2" class="pilcrow">¶</a>
 </div>
-<p id="section-a.7-30.2.3">
-                     Tell some more about it. Tell some more about it. Tell some more about it.<a href="#section-a.7-30.2.3" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-30.2.3">
+                     Tell some more about it. Tell some more about it. Tell some more about it.<a href="#appendix-A.7-30.2.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-30.3">Item2:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-30.4">Another description<a href="#section-a.7-30.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-30.3">Item2:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-30.4">Another description<a href="#appendix-A.7-30.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-31">
-               List with a sublist with a paragraph above the sublist<a href="#section-a.7-31" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-32">
-<li id="section-a.7-32.1">
-                     First Item<a href="#section-a.7-32.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-31">
+               List with a sublist with a paragraph above the sublist<a href="#appendix-A.7-31" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-32">
+<li id="appendix-A.7-32.1">
+                     First Item<a href="#appendix-A.7-32.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-32.2">
-                     Second item<a href="#section-a.7-32.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-32.2">
+                     Second item<a href="#appendix-A.7-32.2" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-32.3">
-            <p id="section-a.7-32.3.1">
-                     Third item<a href="#section-a.7-32.3.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-32.3.2"> A paragraph that comes first<a href="#section-a.7-32.3.2" class="pilcrow">¶</a></p>
-<ol start="1" type="a" class="normal type-a" id="section-a.7-32.3.3">
-<li id="section-a.7-32.3.3.1">
-                           But what do you know<a href="#section-a.7-32.3.3.1" class="pilcrow">¶</a>
+          <li id="appendix-A.7-32.3">
+            <p id="appendix-A.7-32.3.1">
+                     Third item<a href="#appendix-A.7-32.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-32.3.2"> A paragraph that comes first<a href="#appendix-A.7-32.3.2" class="pilcrow">¶</a></p>
+<ol start="1" type="a" class="normal type-a" id="appendix-A.7-32.3.3">
+<li id="appendix-A.7-32.3.3.1">
+                           But what do you know<a href="#appendix-A.7-32.3.3.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-32.3.3.2">
-                           This is another list<a href="#section-a.7-32.3.3.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-32.3.3.2">
+                           This is another list<a href="#appendix-A.7-32.3.3.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </li>
@@ -1638,10 +1638,10 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
 </section>
 </div>
 <div id="anchor-table-tests">
-<section id="section-a.8">
-        <h2 id="name-table-tests">
-<a href="#section-a.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
-        </h2>
+<section id="appendix-A.8">
+        <h3 id="name-table-tests">
+<a href="#appendix-A.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
+        </h3>
 <span id="name-demonstration-of-simple-tab"></span><div id="tab-demonstrat">
 <table class="center" id="table-1">
           <caption>
@@ -1710,8 +1710,8 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<p id="section-a.8-3">
-               <span id="iref-table-simple-3" class="iref"></span><a href="#section-a.8-3" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-3">
+               <span id="iref-table-simple-3" class="iref"></span><a href="#appendix-A.8-3" class="pilcrow">¶</a></p>
 <span id="name-sample-grid-table"></span><div id="tab-sample-gri">
 <table class="center" id="table-3">
           <caption>
@@ -1739,8 +1739,8 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<p id="section-a.8-5">
-               Grid tables without a caption<a href="#section-a.8-5" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-5">
+               Grid tables without a caption<a href="#appendix-A.8-5" class="pilcrow">¶</a></p>
 <table class="center" id="table-4">
           <caption><a href="#table-4" class="selfRef">Table 4</a></caption>
 <thead>
@@ -1763,49 +1763,49 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
             </tr>
           </tbody>
         </table>
-<p id="section-a.8-7">
-               This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance:<a href="#section-a.8-7" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.8-8">
+<p id="appendix-A.8-7">
+               This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance:<a href="#appendix-A.8-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.8-8">
 <pre>
 See [](#tab-here-s-the)
-</pre><a href="#section-a.8-8" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.8-8" class="pilcrow">¶</a>
 </div>
-<p id="section-a.8-9">
-               Which will become "See <a href="#tab-here-s-the" class="xref">Table 2</a>".<a href="#section-a.8-9" class="pilcrow">¶</a></p>
-<p id="section-a.8-10">
-               <span id="iref-table-grid-4" class="iref"></span><a href="#section-a.8-10" class="pilcrow">¶</a></p>
-<p id="section-a.8-11">
+<p id="appendix-A.8-9">
+               Which will become "See <a href="#tab-here-s-the" class="xref">Table 2</a>".<a href="#appendix-A.8-9" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-10">
+               <span id="iref-table-grid-4" class="iref"></span><a href="#appendix-A.8-10" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-11">
                We should also be able to refer to the table numbers directly, to say things like 
                'Look at Tables
                <a href="#tab-demonstrat" class="xref">1</a>,
                <a href="#tab-here-s-the" class="xref">2</a>
-               and <a href="#tab-sample-gri" class="xref">3</a>.'<a href="#section-a.8-11" class="pilcrow">¶</a></p>
+               and <a href="#tab-sample-gri" class="xref">3</a>.'<a href="#appendix-A.8-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="numbered-examples">
-<section id="section-a.9">
-        <h2 id="name-numbered-examples">
-<a href="#section-a.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
-        </h2>
-<p id="section-a.9-1">
-               This is another example:<a href="#section-a.9-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.9-2">
-<li id="section-a.9-2.1">
-                     Another bla bla..<a href="#section-a.9-2.1" class="pilcrow">¶</a>
+<section id="appendix-A.9">
+        <h3 id="name-numbered-examples">
+<a href="#appendix-A.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
+        </h3>
+<p id="appendix-A.9-1">
+               This is another example:<a href="#appendix-A.9-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.9-2">
+<li id="appendix-A.9-2.1">
+                     Another bla bla..<a href="#appendix-A.9-2.1" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.9-3">
-               as (1) shows...<a href="#section-a.9-3" class="pilcrow">¶</a></p>
+<p id="appendix-A.9-3">
+               as (1) shows...<a href="#appendix-A.9-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="anchor-figure-tests">
-<section id="section-a.10">
-        <h2 id="name-figure-tests">
-<a href="#section-a.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
-        </h2>
+<section id="appendix-A.10">
+        <h3 id="name-figure-tests">
+<a href="#appendix-A.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
+        </h3>
 <span id="name-this-is-the-caption-with-te"></span><div id="fig-this-is-th">
 <figure id="figure-4">
-          <div class="artwork art-text alignLeft" id="section-a.10-1.1">
+          <div class="artwork art-text alignLeft" id="appendix-A.10-1.1">
 <pre>
 This is a figure
 This is a figure
@@ -1817,11 +1817,11 @@ This is a figure
 <a href="#name-this-is-the-caption-with-te" class="selfRef">This is the caption, with text in `typewriter`. Which isnt converted to a &lt;spanx&gt; style, because this is copied as-is.</a>
           </figcaption></figure>
 </div>
-<p id="section-a.10-2">
-               And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#section-a.10-2" class="pilcrow">¶</a></p>
+<p id="appendix-A.10-2">
+               And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#appendix-A.10-2" class="pilcrow">¶</a></p>
 <span id="name-a-non-centered-figure"></span><div id="fig-a-non-cent">
 <figure id="figure-5">
-          <div class="artwork art-text alignLeft" id="section-a.10-3.1">
+          <div class="artwork art-text alignLeft" id="appendix-A.10-3.1">
 <pre>
 This is a figure
 This is a figure
@@ -1831,62 +1831,62 @@ This is a figure
 <a href="#name-a-non-centered-figure" class="selfRef">A non centered figure.</a>
           </figcaption></figure>
 </div>
-<p id="section-a.10-4">
-               Test the use of <code>@title</code>:<a href="#section-a.10-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.10-5">
+<p id="appendix-A.10-4">
+               Test the use of <code>@title</code>:<a href="#appendix-A.10-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.10-5">
 <pre>
 This is a figure with a title
 This is a figure with a title
 @title: and here it is: a title, don't mess it up *
-</pre><a href="#section-a.10-5" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.10-5" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 <div id="verse-tests">
-<section id="section-a.11">
-        <h2 id="name-verse-tests">
-<a href="#section-a.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
-        </h2>
-<p id="section-a.11-1">
-               This is a verse text This is another line<a href="#section-a.11-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.11">
+        <h3 id="name-verse-tests">
+<a href="#appendix-A.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
+        </h3>
+<p id="appendix-A.11-1">
+               This is a verse text This is another line<a href="#appendix-A.11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.b-1">
+<p id="appendix-B-1">
         <a href="#rfc.index.u76" class="xref">L</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.b-2.1">
+<li class="ulEmpty normal" id="appendix-B-2.1">
           <div id="rfc.index.u76">
-<p id="section-appendix.b-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u76" class="xref">L</a><a href="#section-appendix.b-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u76" class="xref">L</a><a href="#appendix-B-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.b-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.1.2.1.1">
-                <dt id="section-appendix.b-2.1.2.1.1.1">list</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-B-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.1.2.1.1">
+                <dt id="appendix-B-2.1.2.1.1.1">list</dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.b-2.1.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.1.2.1.1.4.1">
-                    <dt id="section-appendix.b-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4.1.2">
-                      <p id="section-appendix.b-2.1.2.1.1.4.1.2.1">
-                        <a href="#section-a.7-28" class="xref">Section A.7, Paragraph 28</a><a href="#section-appendix.b-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.1.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.1.2.1.1.4.1">
+                    <dt id="appendix-B-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4.1.2">
+                      <p id="appendix-B-2.1.2.1.1.4.1.2.1">
+                        <a href="#appendix-A.7-28" class="xref">Appendix A.7, Paragraph 28</a><a href="#appendix-B-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.b-2.1.2.1.1.4.1.3">default markers</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4.1.4">
-                      <p id="section-appendix.b-2.1.2.1.1.4.1.4.1">
-                        <a href="#section-a.7-20" class="xref">Section A.7, Paragraph 20</a><a href="#section-appendix.b-2.1.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.1.2.1.1.4.1.3">default markers</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4.1.4">
+                      <p id="appendix-B-2.1.2.1.1.4.1.4.1">
+                        <a href="#appendix-A.7-20" class="xref">Appendix A.7, Paragraph 20</a><a href="#appendix-B-2.1.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -1896,30 +1896,30 @@ This is a figure with a title
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.b-2.2">
+        <li class="ulEmpty normal" id="appendix-B-2.2">
           <div id="rfc.index.u84">
-<p id="section-appendix.b-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.b-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-B-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.b-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.2.2.1.1">
-                <dt id="section-appendix.b-2.2.2.1.1.1">table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-B-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.2.2.1.1">
+                <dt id="appendix-B-2.2.2.1.1.1">table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.b-2.2.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.2.2.1.1.4.1">
-                    <dt id="section-appendix.b-2.2.2.1.1.4.1.1">grid</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4.1.2">
-                      <p id="section-appendix.b-2.2.2.1.1.4.1.2.1">
-                        <a href="#section-a.8-10" class="xref">Section A.8, Paragraph 10</a><a href="#section-appendix.b-2.2.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.2.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.2.2.1.1.4.1">
+                    <dt id="appendix-B-2.2.2.1.1.4.1.1">grid</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4.1.2">
+                      <p id="appendix-B-2.2.2.1.1.4.1.2.1">
+                        <a href="#appendix-A.8-10" class="xref">Appendix A.8, Paragraph 10</a><a href="#appendix-B-2.2.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.b-2.2.2.1.1.4.1.3">simple</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4.1.4">
-                      <p id="section-appendix.b-2.2.2.1.1.4.1.4.1">
-                        <a href="#section-a.8-3" class="xref">Section A.8, Paragraph 3</a><a href="#section-appendix.b-2.2.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.2.2.1.1.4.1.3">simple</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4.1.4">
+                      <p id="appendix-B-2.2.2.1.1.4.1.4.1">
+                        <a href="#appendix-A.8-3" class="xref">Appendix A.8, Paragraph 3</a><a href="#appendix-B-2.2.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -1932,7 +1932,7 @@ This is a figure with a title
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/draft-miek-test.v3.py37.html
+++ b/cli/tests/valid/draft-miek-test.v3.py37.html
@@ -254,48 +254,48 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-tests" class="xref">Tests</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-tests" class="xref">Tests</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-markup-in-heading" class="xref">Markup in heading</a></p>
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-markup-in-heading" class="xref">Markup in heading</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.3">
-                <p id="section-toc.1-1.12.2.3.1"><a href="#section-a.3" class="xref">A.3</a>.  <a href="#name-blockquote" class="xref">Blockquote</a></p>
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-blockquote" class="xref">Blockquote</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.4">
-                <p id="section-toc.1-1.12.2.4.1"><a href="#section-a.4" class="xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="xref">Verbatim code blocks</a></p>
+                <p id="section-toc.1-1.12.2.4.1"><a href="#appendix-A.4" class="xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="xref">Verbatim code blocks</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.5">
-                <p id="section-toc.1-1.12.2.5.1"><a href="#section-a.5" class="xref">A.5</a>.  <a href="#name-reference-tests" class="xref">Reference Tests</a></p>
+                <p id="section-toc.1-1.12.2.5.1"><a href="#appendix-A.5" class="xref">A.5</a>.  <a href="#name-reference-tests" class="xref">Reference Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.6">
-                <p id="section-toc.1-1.12.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-spanx-tests" class="xref">Spanx Tests</a></p>
+                <p id="section-toc.1-1.12.2.6.1"><a href="#appendix-A.6" class="xref">A.6</a>.  <a href="#name-spanx-tests" class="xref">Spanx Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.7">
-                <p id="section-toc.1-1.12.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-list-tests" class="xref">List Tests</a></p>
+                <p id="section-toc.1-1.12.2.7.1"><a href="#appendix-A.7" class="xref">A.7</a>.  <a href="#name-list-tests" class="xref">List Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.8">
-                <p id="section-toc.1-1.12.2.8.1"><a href="#section-a.8" class="xref">A.8</a>.  <a href="#name-table-tests" class="xref">Table Tests</a></p>
+                <p id="section-toc.1-1.12.2.8.1"><a href="#appendix-A.8" class="xref">A.8</a>.  <a href="#name-table-tests" class="xref">Table Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.9">
-                <p id="section-toc.1-1.12.2.9.1"><a href="#section-a.9" class="xref">A.9</a>.  <a href="#name-numbered-examples" class="xref">Numbered examples</a></p>
+                <p id="section-toc.1-1.12.2.9.1"><a href="#appendix-A.9" class="xref">A.9</a>.  <a href="#name-numbered-examples" class="xref">Numbered examples</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.10">
-                <p id="section-toc.1-1.12.2.10.1"><a href="#section-a.10" class="xref">A.10</a>. <a href="#name-figure-tests" class="xref">Figure tests</a></p>
+                <p id="section-toc.1-1.12.2.10.1"><a href="#appendix-A.10" class="xref">A.10</a>. <a href="#name-figure-tests" class="xref">Figure tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.11">
-                <p id="section-toc.1-1.12.2.11.1"><a href="#section-a.11" class="xref">A.11</a>. <a href="#name-verse-tests" class="xref">Verse tests</a></p>
+                <p id="section-toc.1-1.12.2.11.1"><a href="#appendix-A.11" class="xref">A.11</a>. <a href="#name-verse-tests" class="xref">Verse tests</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -1266,371 +1266,371 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </section>
 </section>
 <div id="tests">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-tests">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
       </h2>
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
             This appendix consists out of a few tests that should all render to proper
-            <code>xml2rfc</code> XML.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+            <code>xml2rfc</code> XML.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 <div id="a-very-long-title-considerations-with-regards-to-the-already-deployed-routing-policy">
-<section id="section-a.1">
-        <h2 id="name-a-very-long-title-considera">
-<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
-        </h2>
-<p id="section-a.1-1">
-               Test a very long title.<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.1">
+        <h3 id="name-a-very-long-title-considera">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
+        </h3>
+<p id="appendix-A.1-1">
+               Test a very long title.<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="markup-in-heading">
-<section id="section-a.2">
-        <h2 id="name-markup-in-heading">
-<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
-        </h2>
-<p id="section-a.2-1">
-               This is discarded by <code>xml2rfc</code>.<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.2">
+        <h3 id="name-markup-in-heading">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
+        </h3>
+<p id="appendix-A.2-1">
+               This is discarded by <code>xml2rfc</code>.<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="blockquote">
-<section id="section-a.3">
-        <h2 id="name-blockquote">
-<a href="#section-a.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
-        </h2>
+<section id="appendix-A.3">
+        <h3 id="name-blockquote">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
+        </h3>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.3-1.1">
-                     This is a blockquote, how does it look?<a href="#section-a.3-1.1" class="pilcrow">¶</a>
+<li class="ulEmpty normal" id="appendix-A.3-1.1">
+                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
 </div>
 <div id="verbatim-code-blocks">
-<section id="section-a.4">
-        <h2 id="name-verbatim-code-blocks">
-<a href="#section-a.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
-        </h2>
-<div class="artwork art-text alignLeft" id="section-a.4-1">
+<section id="appendix-A.4">
+        <h3 id="name-verbatim-code-blocks">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
+        </h3>
+<div class="artwork art-text alignLeft" id="appendix-A.4-1">
 <pre>
 A verbatim code block
 jkasjksajassjasjsajsajkas
-</pre><a href="#section-a.4-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.4-1" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 <div id="reference-tests">
-<section id="section-a.5">
-        <h2 id="name-reference-tests">
-<a href="#section-a.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
-        </h2>
-<p id="section-a.5-1">
-               Refer to <span><a href="#RFC2119" class="xref">RFC 2119</a> [<a href="#RFC2119" class="xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#section-a.5-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.5">
+        <h3 id="name-reference-tests">
+<a href="#appendix-A.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
+        </h3>
+<p id="appendix-A.5-1">
+               Refer to <span><a href="#RFC2119" class="xref">RFC 2119</a> [<a href="#RFC2119" class="xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#appendix-A.5-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="spanx-tests">
-<section id="section-a.6">
-        <h2 id="name-spanx-tests">
-<a href="#section-a.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
-        </h2>
+<section id="appendix-A.6">
+        <h3 id="name-spanx-tests">
+<a href="#appendix-A.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
+        </h3>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.6-1.1">
-                     underscores: <em>underscores</em><a href="#section-a.6-1.1" class="pilcrow">¶</a>
+<li class="ulEmpty normal" id="appendix-A.6-1.1">
+                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.2">
-                     asterisks: <em>asterisks</em><a href="#section-a.6-1.2" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.2">
+                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.3">
-                     double asterisks: <strong>double asterisks</strong><a href="#section-a.6-1.3" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.3">
+                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.4">
-                     backticks: <code>backticks</code><a href="#section-a.6-1.4" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.4">
+                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
 </div>
 <div id="list-tests">
-<section id="section-a.7">
-        <h2 id="name-list-tests">
-<a href="#section-a.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
-        </h2>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-1">
-<li id="section-a.7-1.1">
-                     First we do<a href="#section-a.7-1.1" class="pilcrow">¶</a>
+<section id="appendix-A.7">
+        <h3 id="name-list-tests">
+<a href="#appendix-A.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
+        </h3>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-1">
+<li id="appendix-A.7-1.1">
+                     First we do<a href="#appendix-A.7-1.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-1.2">
-            <p id="section-a.7-1.2.1">
-                     And then<a href="#section-a.7-1.2.1" class="pilcrow">¶</a></p>
+          <li id="appendix-A.7-1.2">
+            <p id="appendix-A.7-1.2.1">
+                     And then<a href="#appendix-A.7-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-1.2.2.1">
-                           item 1<a href="#section-a.7-1.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-1.2.2.1">
+                           item 1<a href="#appendix-A.7-1.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li class="normal" id="section-a.7-1.2.2.2">
-                           item 2<a href="#section-a.7-1.2.2.2" class="pilcrow">¶</a>
+              <li class="normal" id="appendix-A.7-1.2.2.2">
+                           item 2<a href="#appendix-A.7-1.2.2.2" class="pilcrow">¶</a>
 </li>
             </ul>
 </li>
         </ol>
-<p id="section-a.7-2">
-               And the other around.<a href="#section-a.7-2" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-2">
+               And the other around.<a href="#appendix-A.7-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-3.1">
-                     First we do<a href="#section-a.7-3.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-3.1">
+                     First we do<a href="#appendix-A.7-3.1" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-a.7-3.2">
-            <p id="section-a.7-3.2.1">
-                     Then<a href="#section-a.7-3.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-3.2.2">
-<li id="section-a.7-3.2.2.1">
-                           Something<a href="#section-a.7-3.2.2.1" class="pilcrow">¶</a>
+          <li class="normal" id="appendix-A.7-3.2">
+            <p id="appendix-A.7-3.2.1">
+                     Then<a href="#appendix-A.7-3.2.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-3.2.2">
+<li id="appendix-A.7-3.2.2.1">
+                           Something<a href="#appendix-A.7-3.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-3.2.2.2">
-                           Another thing<a href="#section-a.7-3.2.2.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-3.2.2.2">
+                           Another thing<a href="#appendix-A.7-3.2.2.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </li>
         </ul>
-<p id="section-a.7-4">
-               Description lists:<a href="#section-a.7-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-5">
-          <dt id="section-a.7-5.1">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-5.2">It works because of herbs.<a href="#section-a.7-5.2" class="pilcrow">¶</a>
+<p id="appendix-A.7-4">
+               Description lists:<a href="#appendix-A.7-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-5">
+          <dt id="appendix-A.7-5.1">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-5.2">It works because of herbs.<a href="#appendix-A.7-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-5.3">Another item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-5.4">
-            <p id="section-a.7-5.4.1">More explaining.<a href="#section-a.7-5.4.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-5.4.2"> Multiple paragraphs in such a list.<a href="#section-a.7-5.4.2" class="pilcrow">¶</a></p>
+<dt id="appendix-A.7-5.3">Another item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-5.4">
+            <p id="appendix-A.7-5.4.1">More explaining.<a href="#appendix-A.7-5.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-5.4.2"> Multiple paragraphs in such a list.<a href="#appendix-A.7-5.4.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-6">
-               lists in description lists.<a href="#section-a.7-6" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-7">
-          <dt id="section-a.7-7.1">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.2">
-            <p id="section-a.7-7.2.1">It works because of<a href="#section-a.7-7.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-7.2.2">
-<li id="section-a.7-7.2.2.1">
-                        One<a href="#section-a.7-7.2.2.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-6">
+               lists in description lists.<a href="#appendix-A.7-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-7">
+          <dt id="appendix-A.7-7.1">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.2">
+            <p id="appendix-A.7-7.2.1">It works because of<a href="#appendix-A.7-7.2.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.2.2">
+<li id="appendix-A.7-7.2.2.1">
+                        One<a href="#appendix-A.7-7.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-7.2.2.2">
-                        Two<a href="#section-a.7-7.2.2.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-7.2.2.2">
+                        Two<a href="#appendix-A.7-7.2.2.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.3">Another item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.4">More explaining<a href="#section-a.7-7.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.3">Another item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.4">More explaining<a href="#appendix-A.7-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.5">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.6">
-            <p id="section-a.7-7.6.1">It works because of<a href="#section-a.7-7.6.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-7.6.2">
-<li id="section-a.7-7.6.2.1">
-                        One1<a href="#section-a.7-7.6.2.1" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.5">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.6">
+            <p id="appendix-A.7-7.6.1">It works because of<a href="#appendix-A.7-7.6.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.6.2">
+<li id="appendix-A.7-7.6.2.1">
+                        One1<a href="#appendix-A.7-7.6.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-7.6.2.2">
-                <p id="section-a.7-7.6.2.2.1">
-                        Two1<a href="#section-a.7-7.6.2.2.1" class="pilcrow">¶</a></p>
+              <li id="appendix-A.7-7.6.2.2">
+                <p id="appendix-A.7-7.6.2.2.1">
+                        Two1<a href="#appendix-A.7-7.6.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-7.6.2.2.2.1">
-                              Itemize list<a href="#section-a.7-7.6.2.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-7.6.2.2.2.1">
+                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1" class="pilcrow">¶</a>
 </li>
-                  <li class="normal" id="section-a.7-7.6.2.2.2.2">
-                              Another item<a href="#section-a.7-7.6.2.2.2.2" class="pilcrow">¶</a>
+                  <li class="normal" id="appendix-A.7-7.6.2.2.2.2">
+                              Another item<a href="#appendix-A.7-7.6.2.2.2.2" class="pilcrow">¶</a>
 </li>
                 </ul>
 </li>
             </ol>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.7">Another item to explain again:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.8">More explaining<a href="#section-a.7-7.8" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.7">Another item to explain again:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.8">More explaining<a href="#appendix-A.7-7.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-8">
-               list with description lists.<a href="#section-a.7-8" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-9">
-<li id="section-a.7-9.1">
-            <p id="section-a.7-9.1.1">
-                     More<a href="#section-a.7-9.1.1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-9.1.2">
-              <dt id="section-a.7-9.1.2.1">Item to explain:</dt>
-              <dd style="margin-left: 1.5em" id="section-a.7-9.1.2.2">Explanation ...<a href="#section-a.7-9.1.2.2" class="pilcrow">¶</a>
+<p id="appendix-A.7-8">
+               list with description lists.<a href="#appendix-A.7-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-9">
+<li id="appendix-A.7-9.1">
+            <p id="appendix-A.7-9.1.1">
+                     More<a href="#appendix-A.7-9.1.1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-9.1.2">
+              <dt id="appendix-A.7-9.1.2.1">Item to explain:</dt>
+              <dd style="margin-left: 1.5em" id="appendix-A.7-9.1.2.2">Explanation ...<a href="#appendix-A.7-9.1.2.2" class="pilcrow">¶</a>
 </dd>
               <dd class="break"></dd>
-<dt id="section-a.7-9.1.2.3">Item to explain:</dt>
-              <dd style="margin-left: 1.5em" id="section-a.7-9.1.2.4">Another explanation ...<a href="#section-a.7-9.1.2.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-9.1.2.3">Item to explain:</dt>
+              <dd style="margin-left: 1.5em" id="appendix-A.7-9.1.2.4">Another explanation ...<a href="#appendix-A.7-9.1.2.4" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
 </li>
-          <li id="section-a.7-9.2">
-                     Go'bye<a href="#section-a.7-9.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-9.2">
+                     Go'bye<a href="#appendix-A.7-9.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-10">
-               Multiple paragraphs in a list.<a href="#section-a.7-10" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-11">
-<li id="section-a.7-11.1">
-            <p id="section-a.7-11.1.1">
-                     This is the first bullet point and it needs multiple paragraphs...<a href="#section-a.7-11.1.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-11.1.2"> ... to be explained properly.<a href="#section-a.7-11.1.2" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-10">
+               Multiple paragraphs in a list.<a href="#appendix-A.7-10" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-11">
+<li id="appendix-A.7-11.1">
+            <p id="appendix-A.7-11.1.1">
+                     This is the first bullet point and it needs multiple paragraphs...<a href="#appendix-A.7-11.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-11.1.2"> ... to be explained properly.<a href="#appendix-A.7-11.1.2" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-a.7-11.2">
-                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#section-a.7-11.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-11.2">
+                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-11.3">
-            <p id="section-a.7-11.3.1">
-                     Another item with some artwork, indented by 8 spaces.<a href="#section-a.7-11.3.1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-11.3.2">
+          <li id="appendix-A.7-11.3">
+            <p id="appendix-A.7-11.3.1">
+                     Another item with some artwork, indented by 8 spaces.<a href="#appendix-A.7-11.3.1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-11.3.2">
 <pre>
 Artwork
-</pre><a href="#section-a.7-11.3.2" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-11.3.2" class="pilcrow">¶</a>
 </div>
 </li>
-          <li id="section-a.7-11.4">
-                     Final item.<a href="#section-a.7-11.4" class="pilcrow">¶</a>
+          <li id="appendix-A.7-11.4">
+                     Final item.<a href="#appendix-A.7-11.4" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-12">
-               xml2rfc does not allow this, so the second paragraph is faked with a<a href="#section-a.7-12" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-13">
+<p id="appendix-A.7-12">
+               xml2rfc does not allow this, so the second paragraph is faked with a<a href="#appendix-A.7-12" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-13">
 <pre>
 &lt;vspace blankLines='1'&gt;
-</pre><a href="#section-a.7-13" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-13" class="pilcrow">¶</a>
 </div>
-<p id="section-a.7-14">
-               Ordered lists.<a href="#section-a.7-14" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-15">
-<li id="section-a.7-15.1">
-                     First item<a href="#section-a.7-15.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-14">
+               Ordered lists.<a href="#appendix-A.7-14" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-15">
+<li id="appendix-A.7-15.1">
+                     First item<a href="#appendix-A.7-15.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-15.2">
-                     Second item<a href="#section-a.7-15.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-15.2">
+                     Second item<a href="#appendix-A.7-15.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-16">
-               A lowercase roman list:<a href="#section-a.7-16" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-17">
+<p id="appendix-A.7-16">
+               A lowercase roman list:<a href="#appendix-A.7-16" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-17">
 <dt>i.</dt>
-<dd id="section-a.7-17.1">
-                     Item 1<a href="#section-a.7-17.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-17.1">
+                     Item 1<a href="#appendix-A.7-17.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>ii.</dt>
-<dd id="section-a.7-17.2">
-                     Item 2<a href="#section-a.7-17.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-17.2">
+                     Item 2<a href="#appendix-A.7-17.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-18">
-               An uppercase roman list.<a href="#section-a.7-18" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-19">
+<p id="appendix-A.7-18">
+               An uppercase roman list.<a href="#appendix-A.7-18" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-19">
 <dt>(1)</dt>
-<dd id="section-a.7-19.1">
-                     Item1<a href="#section-a.7-19.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.1">
+                     Item1<a href="#appendix-A.7-19.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>(2)</dt>
-<dd id="section-a.7-19.2">
-                     Item2<a href="#section-a.7-19.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.2">
+                     Item2<a href="#appendix-A.7-19.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>(3)</dt>
-<dd id="section-a.7-19.3">
-                     Item 3<a href="#section-a.7-19.3" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.3">
+                     Item 3<a href="#appendix-A.7-19.3" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-20">
-               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#section-a.7-20" class="pilcrow">¶</a></p>
-<p id="section-a.7-21">
-               Some surrounding text, to make it look better.<a href="#section-a.7-21" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-20">
+               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#appendix-A.7-20" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-21">
+               Some surrounding text, to make it look better.<a href="#appendix-A.7-21" class="pilcrow">¶</a></p>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.7-22.1">
+<li class="ulEmpty normal" id="appendix-A.7-22.1">
                      First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
-      First item. Use lot of text to get a real paragraphs sense.<a href="#section-a.7-22.1" class="pilcrow">¶</a>
+      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.7-22.2">
-                     Second item. So this is the second para in your list. Enjoy;<a href="#section-a.7-22.2" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.7-22.2">
+                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.7-22.3">
-                     Another item.<a href="#section-a.7-22.3" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.7-22.3">
+                     Another item.<a href="#appendix-A.7-22.3" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-a.7-23">
-               Text at the end.<a href="#section-a.7-23" class="pilcrow">¶</a></p>
-<p id="section-a.7-24">
-               Lowercase letters list.<a href="#section-a.7-24" class="pilcrow">¶</a></p>
-<ol start="1" type="a" class="normal type-a" id="section-a.7-25">
-<li id="section-a.7-25.1">
-                     First item<a href="#section-a.7-25.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-23">
+               Text at the end.<a href="#appendix-A.7-23" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-24">
+               Lowercase letters list.<a href="#appendix-A.7-24" class="pilcrow">¶</a></p>
+<ol start="1" type="a" class="normal type-a" id="appendix-A.7-25">
+<li id="appendix-A.7-25.1">
+                     First item<a href="#appendix-A.7-25.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-25.2">
-                     Second item<a href="#section-a.7-25.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-25.2">
+                     Second item<a href="#appendix-A.7-25.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-26">
-               Uppercase letters list.<a href="#section-a.7-26" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-27">
+<p id="appendix-A.7-26">
+               Uppercase letters list.<a href="#appendix-A.7-26" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-27">
 <dt>A.</dt>
-<dd id="section-a.7-27.1">
-                     First item<a href="#section-a.7-27.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-27.1">
+                     First item<a href="#appendix-A.7-27.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>B.</dt>
-<dd id="section-a.7-27.2">
-                     Second item<a href="#section-a.7-27.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-27.2">
+                     Second item<a href="#appendix-A.7-27.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-28">
-               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#section-a.7-28" class="pilcrow">¶</a></p>
-<p id="section-a.7-29">
-               And artwork in a description list.<a href="#section-a.7-29" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-30">
-          <dt id="section-a.7-30.1">Item1:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-30.2">
-            <p id="section-a.7-30.2.1">
+<p id="appendix-A.7-28">
+               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#appendix-A.7-28" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-29">
+               And artwork in a description list.<a href="#appendix-A.7-29" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-30">
+          <dt id="appendix-A.7-30.1">Item1:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-30.2">
+            <p id="appendix-A.7-30.2.1">
                      Tell something about it. Tell something about it. Tell something about
-      it. Tell something about it. Tell something about it. Tell something about it.<a href="#section-a.7-30.2.1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-30.2.2">
+      it. Tell something about it. Tell something about it. Tell something about it.<a href="#appendix-A.7-30.2.1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-30.2.2">
 <pre>
 miek.nl.    IN  NS  a.miek.nl.
 a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
-</pre><a href="#section-a.7-30.2.2" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-30.2.2" class="pilcrow">¶</a>
 </div>
-<p id="section-a.7-30.2.3">
-                     Tell some more about it. Tell some more about it. Tell some more about it.<a href="#section-a.7-30.2.3" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-30.2.3">
+                     Tell some more about it. Tell some more about it. Tell some more about it.<a href="#appendix-A.7-30.2.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-30.3">Item2:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-30.4">Another description<a href="#section-a.7-30.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-30.3">Item2:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-30.4">Another description<a href="#appendix-A.7-30.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-31">
-               List with a sublist with a paragraph above the sublist<a href="#section-a.7-31" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-32">
-<li id="section-a.7-32.1">
-                     First Item<a href="#section-a.7-32.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-31">
+               List with a sublist with a paragraph above the sublist<a href="#appendix-A.7-31" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-32">
+<li id="appendix-A.7-32.1">
+                     First Item<a href="#appendix-A.7-32.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-32.2">
-                     Second item<a href="#section-a.7-32.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-32.2">
+                     Second item<a href="#appendix-A.7-32.2" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-32.3">
-            <p id="section-a.7-32.3.1">
-                     Third item<a href="#section-a.7-32.3.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-32.3.2"> A paragraph that comes first<a href="#section-a.7-32.3.2" class="pilcrow">¶</a></p>
-<ol start="1" type="a" class="normal type-a" id="section-a.7-32.3.3">
-<li id="section-a.7-32.3.3.1">
-                           But what do you know<a href="#section-a.7-32.3.3.1" class="pilcrow">¶</a>
+          <li id="appendix-A.7-32.3">
+            <p id="appendix-A.7-32.3.1">
+                     Third item<a href="#appendix-A.7-32.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-32.3.2"> A paragraph that comes first<a href="#appendix-A.7-32.3.2" class="pilcrow">¶</a></p>
+<ol start="1" type="a" class="normal type-a" id="appendix-A.7-32.3.3">
+<li id="appendix-A.7-32.3.3.1">
+                           But what do you know<a href="#appendix-A.7-32.3.3.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-32.3.3.2">
-                           This is another list<a href="#section-a.7-32.3.3.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-32.3.3.2">
+                           This is another list<a href="#appendix-A.7-32.3.3.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </li>
@@ -1638,10 +1638,10 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
 </section>
 </div>
 <div id="anchor-table-tests">
-<section id="section-a.8">
-        <h2 id="name-table-tests">
-<a href="#section-a.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
-        </h2>
+<section id="appendix-A.8">
+        <h3 id="name-table-tests">
+<a href="#appendix-A.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
+        </h3>
 <span id="name-demonstration-of-simple-tab"></span><div id="tab-demonstrat">
 <table class="center" id="table-1">
           <caption>
@@ -1710,8 +1710,8 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<p id="section-a.8-3">
-               <span id="iref-table-simple-3" class="iref"></span><a href="#section-a.8-3" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-3">
+               <span id="iref-table-simple-3" class="iref"></span><a href="#appendix-A.8-3" class="pilcrow">¶</a></p>
 <span id="name-sample-grid-table"></span><div id="tab-sample-gri">
 <table class="center" id="table-3">
           <caption>
@@ -1739,8 +1739,8 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<p id="section-a.8-5">
-               Grid tables without a caption<a href="#section-a.8-5" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-5">
+               Grid tables without a caption<a href="#appendix-A.8-5" class="pilcrow">¶</a></p>
 <table class="center" id="table-4">
           <caption><a href="#table-4" class="selfRef">Table 4</a></caption>
 <thead>
@@ -1763,49 +1763,49 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
             </tr>
           </tbody>
         </table>
-<p id="section-a.8-7">
-               This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance:<a href="#section-a.8-7" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.8-8">
+<p id="appendix-A.8-7">
+               This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance:<a href="#appendix-A.8-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.8-8">
 <pre>
 See [](#tab-here-s-the)
-</pre><a href="#section-a.8-8" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.8-8" class="pilcrow">¶</a>
 </div>
-<p id="section-a.8-9">
-               Which will become "See <a href="#tab-here-s-the" class="xref">Table 2</a>".<a href="#section-a.8-9" class="pilcrow">¶</a></p>
-<p id="section-a.8-10">
-               <span id="iref-table-grid-4" class="iref"></span><a href="#section-a.8-10" class="pilcrow">¶</a></p>
-<p id="section-a.8-11">
+<p id="appendix-A.8-9">
+               Which will become "See <a href="#tab-here-s-the" class="xref">Table 2</a>".<a href="#appendix-A.8-9" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-10">
+               <span id="iref-table-grid-4" class="iref"></span><a href="#appendix-A.8-10" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-11">
                We should also be able to refer to the table numbers directly, to say things like 
                'Look at Tables
                <a href="#tab-demonstrat" class="xref">1</a>,
                <a href="#tab-here-s-the" class="xref">2</a>
-               and <a href="#tab-sample-gri" class="xref">3</a>.'<a href="#section-a.8-11" class="pilcrow">¶</a></p>
+               and <a href="#tab-sample-gri" class="xref">3</a>.'<a href="#appendix-A.8-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="numbered-examples">
-<section id="section-a.9">
-        <h2 id="name-numbered-examples">
-<a href="#section-a.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
-        </h2>
-<p id="section-a.9-1">
-               This is another example:<a href="#section-a.9-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.9-2">
-<li id="section-a.9-2.1">
-                     Another bla bla..<a href="#section-a.9-2.1" class="pilcrow">¶</a>
+<section id="appendix-A.9">
+        <h3 id="name-numbered-examples">
+<a href="#appendix-A.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
+        </h3>
+<p id="appendix-A.9-1">
+               This is another example:<a href="#appendix-A.9-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.9-2">
+<li id="appendix-A.9-2.1">
+                     Another bla bla..<a href="#appendix-A.9-2.1" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.9-3">
-               as (1) shows...<a href="#section-a.9-3" class="pilcrow">¶</a></p>
+<p id="appendix-A.9-3">
+               as (1) shows...<a href="#appendix-A.9-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="anchor-figure-tests">
-<section id="section-a.10">
-        <h2 id="name-figure-tests">
-<a href="#section-a.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
-        </h2>
+<section id="appendix-A.10">
+        <h3 id="name-figure-tests">
+<a href="#appendix-A.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
+        </h3>
 <span id="name-this-is-the-caption-with-te"></span><div id="fig-this-is-th">
 <figure id="figure-4">
-          <div class="artwork art-text alignLeft" id="section-a.10-1.1">
+          <div class="artwork art-text alignLeft" id="appendix-A.10-1.1">
 <pre>
 This is a figure
 This is a figure
@@ -1817,11 +1817,11 @@ This is a figure
 <a href="#name-this-is-the-caption-with-te" class="selfRef">This is the caption, with text in `typewriter`. Which isnt converted to a &lt;spanx&gt; style, because this is copied as-is.</a>
           </figcaption></figure>
 </div>
-<p id="section-a.10-2">
-               And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#section-a.10-2" class="pilcrow">¶</a></p>
+<p id="appendix-A.10-2">
+               And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#appendix-A.10-2" class="pilcrow">¶</a></p>
 <span id="name-a-non-centered-figure"></span><div id="fig-a-non-cent">
 <figure id="figure-5">
-          <div class="artwork art-text alignLeft" id="section-a.10-3.1">
+          <div class="artwork art-text alignLeft" id="appendix-A.10-3.1">
 <pre>
 This is a figure
 This is a figure
@@ -1831,62 +1831,62 @@ This is a figure
 <a href="#name-a-non-centered-figure" class="selfRef">A non centered figure.</a>
           </figcaption></figure>
 </div>
-<p id="section-a.10-4">
-               Test the use of <code>@title</code>:<a href="#section-a.10-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.10-5">
+<p id="appendix-A.10-4">
+               Test the use of <code>@title</code>:<a href="#appendix-A.10-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.10-5">
 <pre>
 This is a figure with a title
 This is a figure with a title
 @title: and here it is: a title, don't mess it up *
-</pre><a href="#section-a.10-5" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.10-5" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 <div id="verse-tests">
-<section id="section-a.11">
-        <h2 id="name-verse-tests">
-<a href="#section-a.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
-        </h2>
-<p id="section-a.11-1">
-               This is a verse text This is another line<a href="#section-a.11-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.11">
+        <h3 id="name-verse-tests">
+<a href="#appendix-A.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
+        </h3>
+<p id="appendix-A.11-1">
+               This is a verse text This is another line<a href="#appendix-A.11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.b-1">
+<p id="appendix-B-1">
         <a href="#rfc.index.u76" class="xref">L</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.b-2.1">
+<li class="ulEmpty normal" id="appendix-B-2.1">
           <div id="rfc.index.u76">
-<p id="section-appendix.b-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u76" class="xref">L</a><a href="#section-appendix.b-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u76" class="xref">L</a><a href="#appendix-B-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.b-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.1.2.1.1">
-                <dt id="section-appendix.b-2.1.2.1.1.1">list</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-B-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.1.2.1.1">
+                <dt id="appendix-B-2.1.2.1.1.1">list</dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.b-2.1.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.1.2.1.1.4.1">
-                    <dt id="section-appendix.b-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4.1.2">
-                      <p id="section-appendix.b-2.1.2.1.1.4.1.2.1">
-                        <a href="#section-a.7-28" class="xref">Section A.7, Paragraph 28</a><a href="#section-appendix.b-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.1.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.1.2.1.1.4.1">
+                    <dt id="appendix-B-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4.1.2">
+                      <p id="appendix-B-2.1.2.1.1.4.1.2.1">
+                        <a href="#appendix-A.7-28" class="xref">Appendix A.7, Paragraph 28</a><a href="#appendix-B-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.b-2.1.2.1.1.4.1.3">default markers</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4.1.4">
-                      <p id="section-appendix.b-2.1.2.1.1.4.1.4.1">
-                        <a href="#section-a.7-20" class="xref">Section A.7, Paragraph 20</a><a href="#section-appendix.b-2.1.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.1.2.1.1.4.1.3">default markers</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4.1.4">
+                      <p id="appendix-B-2.1.2.1.1.4.1.4.1">
+                        <a href="#appendix-A.7-20" class="xref">Appendix A.7, Paragraph 20</a><a href="#appendix-B-2.1.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -1896,30 +1896,30 @@ This is a figure with a title
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.b-2.2">
+        <li class="ulEmpty normal" id="appendix-B-2.2">
           <div id="rfc.index.u84">
-<p id="section-appendix.b-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.b-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-B-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.b-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.2.2.1.1">
-                <dt id="section-appendix.b-2.2.2.1.1.1">table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-B-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.2.2.1.1">
+                <dt id="appendix-B-2.2.2.1.1.1">table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.b-2.2.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.2.2.1.1.4.1">
-                    <dt id="section-appendix.b-2.2.2.1.1.4.1.1">grid</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4.1.2">
-                      <p id="section-appendix.b-2.2.2.1.1.4.1.2.1">
-                        <a href="#section-a.8-10" class="xref">Section A.8, Paragraph 10</a><a href="#section-appendix.b-2.2.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.2.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.2.2.1.1.4.1">
+                    <dt id="appendix-B-2.2.2.1.1.4.1.1">grid</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4.1.2">
+                      <p id="appendix-B-2.2.2.1.1.4.1.2.1">
+                        <a href="#appendix-A.8-10" class="xref">Appendix A.8, Paragraph 10</a><a href="#appendix-B-2.2.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.b-2.2.2.1.1.4.1.3">simple</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4.1.4">
-                      <p id="section-appendix.b-2.2.2.1.1.4.1.4.1">
-                        <a href="#section-a.8-3" class="xref">Section A.8, Paragraph 3</a><a href="#section-appendix.b-2.2.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.2.2.1.1.4.1.3">simple</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4.1.4">
+                      <p id="appendix-B-2.2.2.1.1.4.1.4.1">
+                        <a href="#appendix-A.8-3" class="xref">Appendix A.8, Paragraph 3</a><a href="#appendix-B-2.2.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -1932,7 +1932,7 @@ This is a figure with a title
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/draft-miek-test.v3.py38.html
+++ b/cli/tests/valid/draft-miek-test.v3.py38.html
@@ -254,48 +254,48 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-tests" class="xref">Tests</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-tests" class="xref">Tests</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-a-very-long-title-considera" class="xref">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-markup-in-heading" class="xref">Markup in heading</a></p>
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-markup-in-heading" class="xref">Markup in heading</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.3">
-                <p id="section-toc.1-1.12.2.3.1"><a href="#section-a.3" class="xref">A.3</a>.  <a href="#name-blockquote" class="xref">Blockquote</a></p>
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-blockquote" class="xref">Blockquote</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.4">
-                <p id="section-toc.1-1.12.2.4.1"><a href="#section-a.4" class="xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="xref">Verbatim code blocks</a></p>
+                <p id="section-toc.1-1.12.2.4.1"><a href="#appendix-A.4" class="xref">A.4</a>.  <a href="#name-verbatim-code-blocks" class="xref">Verbatim code blocks</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.5">
-                <p id="section-toc.1-1.12.2.5.1"><a href="#section-a.5" class="xref">A.5</a>.  <a href="#name-reference-tests" class="xref">Reference Tests</a></p>
+                <p id="section-toc.1-1.12.2.5.1"><a href="#appendix-A.5" class="xref">A.5</a>.  <a href="#name-reference-tests" class="xref">Reference Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.6">
-                <p id="section-toc.1-1.12.2.6.1"><a href="#section-a.6" class="xref">A.6</a>.  <a href="#name-spanx-tests" class="xref">Spanx Tests</a></p>
+                <p id="section-toc.1-1.12.2.6.1"><a href="#appendix-A.6" class="xref">A.6</a>.  <a href="#name-spanx-tests" class="xref">Spanx Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.7">
-                <p id="section-toc.1-1.12.2.7.1"><a href="#section-a.7" class="xref">A.7</a>.  <a href="#name-list-tests" class="xref">List Tests</a></p>
+                <p id="section-toc.1-1.12.2.7.1"><a href="#appendix-A.7" class="xref">A.7</a>.  <a href="#name-list-tests" class="xref">List Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.8">
-                <p id="section-toc.1-1.12.2.8.1"><a href="#section-a.8" class="xref">A.8</a>.  <a href="#name-table-tests" class="xref">Table Tests</a></p>
+                <p id="section-toc.1-1.12.2.8.1"><a href="#appendix-A.8" class="xref">A.8</a>.  <a href="#name-table-tests" class="xref">Table Tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.9">
-                <p id="section-toc.1-1.12.2.9.1"><a href="#section-a.9" class="xref">A.9</a>.  <a href="#name-numbered-examples" class="xref">Numbered examples</a></p>
+                <p id="section-toc.1-1.12.2.9.1"><a href="#appendix-A.9" class="xref">A.9</a>.  <a href="#name-numbered-examples" class="xref">Numbered examples</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.10">
-                <p id="section-toc.1-1.12.2.10.1"><a href="#section-a.10" class="xref">A.10</a>. <a href="#name-figure-tests" class="xref">Figure tests</a></p>
+                <p id="section-toc.1-1.12.2.10.1"><a href="#appendix-A.10" class="xref">A.10</a>. <a href="#name-figure-tests" class="xref">Figure tests</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.12.2.11">
-                <p id="section-toc.1-1.12.2.11.1"><a href="#section-a.11" class="xref">A.11</a>. <a href="#name-verse-tests" class="xref">Verse tests</a></p>
+                <p id="section-toc.1-1.12.2.11.1"><a href="#appendix-A.11" class="xref">A.11</a>. <a href="#name-verse-tests" class="xref">Verse tests</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -1266,371 +1266,371 @@ draft-gieben-writing-rfcs-pandoc-00.txt -&gt; draft.txt
 </section>
 </section>
 <div id="tests">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-tests">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-tests" class="section-name selfRef">Tests</a>
       </h2>
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
             This appendix consists out of a few tests that should all render to proper
-            <code>xml2rfc</code> XML.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+            <code>xml2rfc</code> XML.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 <div id="a-very-long-title-considerations-with-regards-to-the-already-deployed-routing-policy">
-<section id="section-a.1">
-        <h2 id="name-a-very-long-title-considera">
-<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
-        </h2>
-<p id="section-a.1-1">
-               Test a very long title.<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.1">
+        <h3 id="name-a-very-long-title-considera">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-a-very-long-title-considera" class="section-name selfRef">A Very Long Title Considerations With Regards to the Already Deployed Routing Policy</a>
+        </h3>
+<p id="appendix-A.1-1">
+               Test a very long title.<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="markup-in-heading">
-<section id="section-a.2">
-        <h2 id="name-markup-in-heading">
-<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
-        </h2>
-<p id="section-a.2-1">
-               This is discarded by <code>xml2rfc</code>.<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.2">
+        <h3 id="name-markup-in-heading">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-markup-in-heading" class="section-name selfRef">Markup in heading</a>
+        </h3>
+<p id="appendix-A.2-1">
+               This is discarded by <code>xml2rfc</code>.<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="blockquote">
-<section id="section-a.3">
-        <h2 id="name-blockquote">
-<a href="#section-a.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
-        </h2>
+<section id="appendix-A.3">
+        <h3 id="name-blockquote">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-blockquote" class="section-name selfRef">Blockquote</a>
+        </h3>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.3-1.1">
-                     This is a blockquote, how does it look?<a href="#section-a.3-1.1" class="pilcrow">¶</a>
+<li class="ulEmpty normal" id="appendix-A.3-1.1">
+                     This is a blockquote, how does it look?<a href="#appendix-A.3-1.1" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
 </div>
 <div id="verbatim-code-blocks">
-<section id="section-a.4">
-        <h2 id="name-verbatim-code-blocks">
-<a href="#section-a.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
-        </h2>
-<div class="artwork art-text alignLeft" id="section-a.4-1">
+<section id="appendix-A.4">
+        <h3 id="name-verbatim-code-blocks">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-verbatim-code-blocks" class="section-name selfRef">Verbatim code blocks</a>
+        </h3>
+<div class="artwork art-text alignLeft" id="appendix-A.4-1">
 <pre>
 A verbatim code block
 jkasjksajassjasjsajsajkas
-</pre><a href="#section-a.4-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.4-1" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 <div id="reference-tests">
-<section id="section-a.5">
-        <h2 id="name-reference-tests">
-<a href="#section-a.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
-        </h2>
-<p id="section-a.5-1">
-               Refer to <span><a href="#RFC2119" class="xref">RFC 2119</a> [<a href="#RFC2119" class="xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#section-a.5-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.5">
+        <h3 id="name-reference-tests">
+<a href="#appendix-A.5" class="section-number selfRef">A.5. </a><a href="#name-reference-tests" class="section-name selfRef">Reference Tests</a>
+        </h3>
+<p id="appendix-A.5-1">
+               Refer to <span><a href="#RFC2119" class="xref">RFC 2119</a> [<a href="#RFC2119" class="xref">RFC2119</a>]</span> if you will. Or maybe you want to inspect <a href="#fig-a-minimal-" class="xref">Figure 2</a> in <a href="#pandoc-to-rfc" class="xref">Section 2</a> again. Or you might want to <a href="http://miek.nl">Click here</a>.<a href="#appendix-A.5-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="spanx-tests">
-<section id="section-a.6">
-        <h2 id="name-spanx-tests">
-<a href="#section-a.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
-        </h2>
+<section id="appendix-A.6">
+        <h3 id="name-spanx-tests">
+<a href="#appendix-A.6" class="section-number selfRef">A.6. </a><a href="#name-spanx-tests" class="section-name selfRef">Spanx Tests</a>
+        </h3>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.6-1.1">
-                     underscores: <em>underscores</em><a href="#section-a.6-1.1" class="pilcrow">¶</a>
+<li class="ulEmpty normal" id="appendix-A.6-1.1">
+                     underscores: <em>underscores</em><a href="#appendix-A.6-1.1" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.2">
-                     asterisks: <em>asterisks</em><a href="#section-a.6-1.2" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.2">
+                     asterisks: <em>asterisks</em><a href="#appendix-A.6-1.2" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.3">
-                     double asterisks: <strong>double asterisks</strong><a href="#section-a.6-1.3" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.3">
+                     double asterisks: <strong>double asterisks</strong><a href="#appendix-A.6-1.3" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.6-1.4">
-                     backticks: <code>backticks</code><a href="#section-a.6-1.4" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.6-1.4">
+                     backticks: <code>backticks</code><a href="#appendix-A.6-1.4" class="pilcrow">¶</a>
 </li>
         </ul>
 </section>
 </div>
 <div id="list-tests">
-<section id="section-a.7">
-        <h2 id="name-list-tests">
-<a href="#section-a.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
-        </h2>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-1">
-<li id="section-a.7-1.1">
-                     First we do<a href="#section-a.7-1.1" class="pilcrow">¶</a>
+<section id="appendix-A.7">
+        <h3 id="name-list-tests">
+<a href="#appendix-A.7" class="section-number selfRef">A.7. </a><a href="#name-list-tests" class="section-name selfRef">List Tests</a>
+        </h3>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-1">
+<li id="appendix-A.7-1.1">
+                     First we do<a href="#appendix-A.7-1.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-1.2">
-            <p id="section-a.7-1.2.1">
-                     And then<a href="#section-a.7-1.2.1" class="pilcrow">¶</a></p>
+          <li id="appendix-A.7-1.2">
+            <p id="appendix-A.7-1.2.1">
+                     And then<a href="#appendix-A.7-1.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-1.2.2.1">
-                           item 1<a href="#section-a.7-1.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-1.2.2.1">
+                           item 1<a href="#appendix-A.7-1.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li class="normal" id="section-a.7-1.2.2.2">
-                           item 2<a href="#section-a.7-1.2.2.2" class="pilcrow">¶</a>
+              <li class="normal" id="appendix-A.7-1.2.2.2">
+                           item 2<a href="#appendix-A.7-1.2.2.2" class="pilcrow">¶</a>
 </li>
             </ul>
 </li>
         </ol>
-<p id="section-a.7-2">
-               And the other around.<a href="#section-a.7-2" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-2">
+               And the other around.<a href="#appendix-A.7-2" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-3.1">
-                     First we do<a href="#section-a.7-3.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-3.1">
+                     First we do<a href="#appendix-A.7-3.1" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-a.7-3.2">
-            <p id="section-a.7-3.2.1">
-                     Then<a href="#section-a.7-3.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-3.2.2">
-<li id="section-a.7-3.2.2.1">
-                           Something<a href="#section-a.7-3.2.2.1" class="pilcrow">¶</a>
+          <li class="normal" id="appendix-A.7-3.2">
+            <p id="appendix-A.7-3.2.1">
+                     Then<a href="#appendix-A.7-3.2.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-3.2.2">
+<li id="appendix-A.7-3.2.2.1">
+                           Something<a href="#appendix-A.7-3.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-3.2.2.2">
-                           Another thing<a href="#section-a.7-3.2.2.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-3.2.2.2">
+                           Another thing<a href="#appendix-A.7-3.2.2.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </li>
         </ul>
-<p id="section-a.7-4">
-               Description lists:<a href="#section-a.7-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-5">
-          <dt id="section-a.7-5.1">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-5.2">It works because of herbs.<a href="#section-a.7-5.2" class="pilcrow">¶</a>
+<p id="appendix-A.7-4">
+               Description lists:<a href="#appendix-A.7-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-5">
+          <dt id="appendix-A.7-5.1">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-5.2">It works because of herbs.<a href="#appendix-A.7-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-5.3">Another item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-5.4">
-            <p id="section-a.7-5.4.1">More explaining.<a href="#section-a.7-5.4.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-5.4.2"> Multiple paragraphs in such a list.<a href="#section-a.7-5.4.2" class="pilcrow">¶</a></p>
+<dt id="appendix-A.7-5.3">Another item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-5.4">
+            <p id="appendix-A.7-5.4.1">More explaining.<a href="#appendix-A.7-5.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-5.4.2"> Multiple paragraphs in such a list.<a href="#appendix-A.7-5.4.2" class="pilcrow">¶</a></p>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-6">
-               lists in description lists.<a href="#section-a.7-6" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-7">
-          <dt id="section-a.7-7.1">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.2">
-            <p id="section-a.7-7.2.1">It works because of<a href="#section-a.7-7.2.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-7.2.2">
-<li id="section-a.7-7.2.2.1">
-                        One<a href="#section-a.7-7.2.2.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-6">
+               lists in description lists.<a href="#appendix-A.7-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-7">
+          <dt id="appendix-A.7-7.1">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.2">
+            <p id="appendix-A.7-7.2.1">It works because of<a href="#appendix-A.7-7.2.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.2.2">
+<li id="appendix-A.7-7.2.2.1">
+                        One<a href="#appendix-A.7-7.2.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-7.2.2.2">
-                        Two<a href="#section-a.7-7.2.2.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-7.2.2.2">
+                        Two<a href="#appendix-A.7-7.2.2.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.3">Another item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.4">More explaining<a href="#section-a.7-7.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.3">Another item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.4">More explaining<a href="#appendix-A.7-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.5">Item to explain:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.6">
-            <p id="section-a.7-7.6.1">It works because of<a href="#section-a.7-7.6.1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-7.6.2">
-<li id="section-a.7-7.6.2.1">
-                        One1<a href="#section-a.7-7.6.2.1" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.5">Item to explain:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.6">
+            <p id="appendix-A.7-7.6.1">It works because of<a href="#appendix-A.7-7.6.1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-7.6.2">
+<li id="appendix-A.7-7.6.2.1">
+                        One1<a href="#appendix-A.7-7.6.2.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-7.6.2.2">
-                <p id="section-a.7-7.6.2.2.1">
-                        Two1<a href="#section-a.7-7.6.2.2.1" class="pilcrow">¶</a></p>
+              <li id="appendix-A.7-7.6.2.2">
+                <p id="appendix-A.7-7.6.2.2.1">
+                        Two1<a href="#appendix-A.7-7.6.2.2.1" class="pilcrow">¶</a></p>
 <ul class="normal">
-<li class="normal" id="section-a.7-7.6.2.2.2.1">
-                              Itemize list<a href="#section-a.7-7.6.2.2.2.1" class="pilcrow">¶</a>
+<li class="normal" id="appendix-A.7-7.6.2.2.2.1">
+                              Itemize list<a href="#appendix-A.7-7.6.2.2.2.1" class="pilcrow">¶</a>
 </li>
-                  <li class="normal" id="section-a.7-7.6.2.2.2.2">
-                              Another item<a href="#section-a.7-7.6.2.2.2.2" class="pilcrow">¶</a>
+                  <li class="normal" id="appendix-A.7-7.6.2.2.2.2">
+                              Another item<a href="#appendix-A.7-7.6.2.2.2.2" class="pilcrow">¶</a>
 </li>
                 </ul>
 </li>
             </ol>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-7.7">Another item to explain again:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-7.8">More explaining<a href="#section-a.7-7.8" class="pilcrow">¶</a>
+<dt id="appendix-A.7-7.7">Another item to explain again:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-7.8">More explaining<a href="#appendix-A.7-7.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-8">
-               list with description lists.<a href="#section-a.7-8" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-9">
-<li id="section-a.7-9.1">
-            <p id="section-a.7-9.1.1">
-                     More<a href="#section-a.7-9.1.1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-9.1.2">
-              <dt id="section-a.7-9.1.2.1">Item to explain:</dt>
-              <dd style="margin-left: 1.5em" id="section-a.7-9.1.2.2">Explanation ...<a href="#section-a.7-9.1.2.2" class="pilcrow">¶</a>
+<p id="appendix-A.7-8">
+               list with description lists.<a href="#appendix-A.7-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-9">
+<li id="appendix-A.7-9.1">
+            <p id="appendix-A.7-9.1.1">
+                     More<a href="#appendix-A.7-9.1.1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-9.1.2">
+              <dt id="appendix-A.7-9.1.2.1">Item to explain:</dt>
+              <dd style="margin-left: 1.5em" id="appendix-A.7-9.1.2.2">Explanation ...<a href="#appendix-A.7-9.1.2.2" class="pilcrow">¶</a>
 </dd>
               <dd class="break"></dd>
-<dt id="section-a.7-9.1.2.3">Item to explain:</dt>
-              <dd style="margin-left: 1.5em" id="section-a.7-9.1.2.4">Another explanation ...<a href="#section-a.7-9.1.2.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-9.1.2.3">Item to explain:</dt>
+              <dd style="margin-left: 1.5em" id="appendix-A.7-9.1.2.4">Another explanation ...<a href="#appendix-A.7-9.1.2.4" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
 </li>
-          <li id="section-a.7-9.2">
-                     Go'bye<a href="#section-a.7-9.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-9.2">
+                     Go'bye<a href="#appendix-A.7-9.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-10">
-               Multiple paragraphs in a list.<a href="#section-a.7-10" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-11">
-<li id="section-a.7-11.1">
-            <p id="section-a.7-11.1.1">
-                     This is the first bullet point and it needs multiple paragraphs...<a href="#section-a.7-11.1.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-11.1.2"> ... to be explained properly.<a href="#section-a.7-11.1.2" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-10">
+               Multiple paragraphs in a list.<a href="#appendix-A.7-10" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-11">
+<li id="appendix-A.7-11.1">
+            <p id="appendix-A.7-11.1.1">
+                     This is the first bullet point and it needs multiple paragraphs...<a href="#appendix-A.7-11.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-11.1.2"> ... to be explained properly.<a href="#appendix-A.7-11.1.2" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-a.7-11.2">
-                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#section-a.7-11.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-11.2">
+                     This is the next bullet. New paragraphs should be indented with 4 four spaces.<a href="#appendix-A.7-11.2" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-11.3">
-            <p id="section-a.7-11.3.1">
-                     Another item with some artwork, indented by 8 spaces.<a href="#section-a.7-11.3.1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-11.3.2">
+          <li id="appendix-A.7-11.3">
+            <p id="appendix-A.7-11.3.1">
+                     Another item with some artwork, indented by 8 spaces.<a href="#appendix-A.7-11.3.1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-11.3.2">
 <pre>
 Artwork
-</pre><a href="#section-a.7-11.3.2" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-11.3.2" class="pilcrow">¶</a>
 </div>
 </li>
-          <li id="section-a.7-11.4">
-                     Final item.<a href="#section-a.7-11.4" class="pilcrow">¶</a>
+          <li id="appendix-A.7-11.4">
+                     Final item.<a href="#appendix-A.7-11.4" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-12">
-               xml2rfc does not allow this, so the second paragraph is faked with a<a href="#section-a.7-12" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-13">
+<p id="appendix-A.7-12">
+               xml2rfc does not allow this, so the second paragraph is faked with a<a href="#appendix-A.7-12" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-13">
 <pre>
 &lt;vspace blankLines='1'&gt;
-</pre><a href="#section-a.7-13" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-13" class="pilcrow">¶</a>
 </div>
-<p id="section-a.7-14">
-               Ordered lists.<a href="#section-a.7-14" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-15">
-<li id="section-a.7-15.1">
-                     First item<a href="#section-a.7-15.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-14">
+               Ordered lists.<a href="#appendix-A.7-14" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-15">
+<li id="appendix-A.7-15.1">
+                     First item<a href="#appendix-A.7-15.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-15.2">
-                     Second item<a href="#section-a.7-15.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-15.2">
+                     Second item<a href="#appendix-A.7-15.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-16">
-               A lowercase roman list:<a href="#section-a.7-16" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-17">
+<p id="appendix-A.7-16">
+               A lowercase roman list:<a href="#appendix-A.7-16" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-17">
 <dt>i.</dt>
-<dd id="section-a.7-17.1">
-                     Item 1<a href="#section-a.7-17.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-17.1">
+                     Item 1<a href="#appendix-A.7-17.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>ii.</dt>
-<dd id="section-a.7-17.2">
-                     Item 2<a href="#section-a.7-17.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-17.2">
+                     Item 2<a href="#appendix-A.7-17.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-18">
-               An uppercase roman list.<a href="#section-a.7-18" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-19">
+<p id="appendix-A.7-18">
+               An uppercase roman list.<a href="#appendix-A.7-18" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-19">
 <dt>(1)</dt>
-<dd id="section-a.7-19.1">
-                     Item1<a href="#section-a.7-19.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.1">
+                     Item1<a href="#appendix-A.7-19.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>(2)</dt>
-<dd id="section-a.7-19.2">
-                     Item2<a href="#section-a.7-19.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.2">
+                     Item2<a href="#appendix-A.7-19.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>(3)</dt>
-<dd id="section-a.7-19.3">
-                     Item 3<a href="#section-a.7-19.3" class="pilcrow">¶</a>
+<dd id="appendix-A.7-19.3">
+                     Item 3<a href="#appendix-A.7-19.3" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-20">
-               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#section-a.7-20" class="pilcrow">¶</a></p>
-<p id="section-a.7-21">
-               Some surrounding text, to make it look better.<a href="#section-a.7-21" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-20">
+               And default list markers.<span id="iref-list-default-markers-1" class="iref"></span><a href="#appendix-A.7-20" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-21">
+               Some surrounding text, to make it look better.<a href="#appendix-A.7-21" class="pilcrow">¶</a></p>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-a.7-22.1">
+<li class="ulEmpty normal" id="appendix-A.7-22.1">
                      First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
       First item. Use lot of text to get a real paragraphs sense.
-      First item. Use lot of text to get a real paragraphs sense.<a href="#section-a.7-22.1" class="pilcrow">¶</a>
+      First item. Use lot of text to get a real paragraphs sense.<a href="#appendix-A.7-22.1" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.7-22.2">
-                     Second item. So this is the second para in your list. Enjoy;<a href="#section-a.7-22.2" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.7-22.2">
+                     Second item. So this is the second para in your list. Enjoy;<a href="#appendix-A.7-22.2" class="pilcrow">¶</a>
 </li>
-          <li class="ulEmpty normal" id="section-a.7-22.3">
-                     Another item.<a href="#section-a.7-22.3" class="pilcrow">¶</a>
+          <li class="ulEmpty normal" id="appendix-A.7-22.3">
+                     Another item.<a href="#appendix-A.7-22.3" class="pilcrow">¶</a>
 </li>
         </ul>
-<p id="section-a.7-23">
-               Text at the end.<a href="#section-a.7-23" class="pilcrow">¶</a></p>
-<p id="section-a.7-24">
-               Lowercase letters list.<a href="#section-a.7-24" class="pilcrow">¶</a></p>
-<ol start="1" type="a" class="normal type-a" id="section-a.7-25">
-<li id="section-a.7-25.1">
-                     First item<a href="#section-a.7-25.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-23">
+               Text at the end.<a href="#appendix-A.7-23" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-24">
+               Lowercase letters list.<a href="#appendix-A.7-24" class="pilcrow">¶</a></p>
+<ol start="1" type="a" class="normal type-a" id="appendix-A.7-25">
+<li id="appendix-A.7-25.1">
+                     First item<a href="#appendix-A.7-25.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-25.2">
-                     Second item<a href="#section-a.7-25.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-25.2">
+                     Second item<a href="#appendix-A.7-25.2" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.7-26">
-               Uppercase letters list.<a href="#section-a.7-26" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="olPercent" id="section-a.7-27">
+<p id="appendix-A.7-26">
+               Uppercase letters list.<a href="#appendix-A.7-26" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="olPercent" id="appendix-A.7-27">
 <dt>A.</dt>
-<dd id="section-a.7-27.1">
-                     First item<a href="#section-a.7-27.1" class="pilcrow">¶</a>
+<dd id="appendix-A.7-27.1">
+                     First item<a href="#appendix-A.7-27.1" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt>B.</dt>
-<dd id="section-a.7-27.2">
-                     Second item<a href="#section-a.7-27.2" class="pilcrow">¶</a>
+<dd id="appendix-A.7-27.2">
+                     Second item<a href="#appendix-A.7-27.2" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-28">
-               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#section-a.7-28" class="pilcrow">¶</a></p>
-<p id="section-a.7-29">
-               And artwork in a description list.<a href="#section-a.7-29" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-a.7-30">
-          <dt id="section-a.7-30.1">Item1:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-30.2">
-            <p id="section-a.7-30.2.1">
+<p id="appendix-A.7-28">
+               <span id="iref-list-uppercase-letters-2" class="iref"></span><a href="#appendix-A.7-28" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-29">
+               And artwork in a description list.<a href="#appendix-A.7-29" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.7-30">
+          <dt id="appendix-A.7-30.1">Item1:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-30.2">
+            <p id="appendix-A.7-30.2.1">
                      Tell something about it. Tell something about it. Tell something about
-      it. Tell something about it. Tell something about it. Tell something about it.<a href="#section-a.7-30.2.1" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.7-30.2.2">
+      it. Tell something about it. Tell something about it. Tell something about it.<a href="#appendix-A.7-30.2.1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.7-30.2.2">
 <pre>
 miek.nl.    IN  NS  a.miek.nl.
 a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
-</pre><a href="#section-a.7-30.2.2" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.7-30.2.2" class="pilcrow">¶</a>
 </div>
-<p id="section-a.7-30.2.3">
-                     Tell some more about it. Tell some more about it. Tell some more about it.<a href="#section-a.7-30.2.3" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-30.2.3">
+                     Tell some more about it. Tell some more about it. Tell some more about it.<a href="#appendix-A.7-30.2.3" class="pilcrow">¶</a></p>
 </dd>
           <dd class="break"></dd>
-<dt id="section-a.7-30.3">Item2:</dt>
-          <dd style="margin-left: 1.5em" id="section-a.7-30.4">Another description<a href="#section-a.7-30.4" class="pilcrow">¶</a>
+<dt id="appendix-A.7-30.3">Item2:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.7-30.4">Another description<a href="#appendix-A.7-30.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-a.7-31">
-               List with a sublist with a paragraph above the sublist<a href="#section-a.7-31" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.7-32">
-<li id="section-a.7-32.1">
-                     First Item<a href="#section-a.7-32.1" class="pilcrow">¶</a>
+<p id="appendix-A.7-31">
+               List with a sublist with a paragraph above the sublist<a href="#appendix-A.7-31" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.7-32">
+<li id="appendix-A.7-32.1">
+                     First Item<a href="#appendix-A.7-32.1" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-32.2">
-                     Second item<a href="#section-a.7-32.2" class="pilcrow">¶</a>
+          <li id="appendix-A.7-32.2">
+                     Second item<a href="#appendix-A.7-32.2" class="pilcrow">¶</a>
 </li>
-          <li id="section-a.7-32.3">
-            <p id="section-a.7-32.3.1">
-                     Third item<a href="#section-a.7-32.3.1" class="pilcrow">¶</a></p>
-<p id="section-a.7-32.3.2"> A paragraph that comes first<a href="#section-a.7-32.3.2" class="pilcrow">¶</a></p>
-<ol start="1" type="a" class="normal type-a" id="section-a.7-32.3.3">
-<li id="section-a.7-32.3.3.1">
-                           But what do you know<a href="#section-a.7-32.3.3.1" class="pilcrow">¶</a>
+          <li id="appendix-A.7-32.3">
+            <p id="appendix-A.7-32.3.1">
+                     Third item<a href="#appendix-A.7-32.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-A.7-32.3.2"> A paragraph that comes first<a href="#appendix-A.7-32.3.2" class="pilcrow">¶</a></p>
+<ol start="1" type="a" class="normal type-a" id="appendix-A.7-32.3.3">
+<li id="appendix-A.7-32.3.3.1">
+                           But what do you know<a href="#appendix-A.7-32.3.3.1" class="pilcrow">¶</a>
 </li>
-              <li id="section-a.7-32.3.3.2">
-                           This is another list<a href="#section-a.7-32.3.3.2" class="pilcrow">¶</a>
+              <li id="appendix-A.7-32.3.3.2">
+                           This is another list<a href="#appendix-A.7-32.3.3.2" class="pilcrow">¶</a>
 </li>
             </ol>
 </li>
@@ -1638,10 +1638,10 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
 </section>
 </div>
 <div id="anchor-table-tests">
-<section id="section-a.8">
-        <h2 id="name-table-tests">
-<a href="#section-a.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
-        </h2>
+<section id="appendix-A.8">
+        <h3 id="name-table-tests">
+<a href="#appendix-A.8" class="section-number selfRef">A.8. </a><a href="#name-table-tests" class="section-name selfRef">Table Tests</a>
+        </h3>
 <span id="name-demonstration-of-simple-tab"></span><div id="tab-demonstrat">
 <table class="center" id="table-1">
           <caption>
@@ -1710,8 +1710,8 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<p id="section-a.8-3">
-               <span id="iref-table-simple-3" class="iref"></span><a href="#section-a.8-3" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-3">
+               <span id="iref-table-simple-3" class="iref"></span><a href="#appendix-A.8-3" class="pilcrow">¶</a></p>
 <span id="name-sample-grid-table"></span><div id="tab-sample-gri">
 <table class="center" id="table-3">
           <caption>
@@ -1739,8 +1739,8 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
           </tbody>
         </table>
 </div>
-<p id="section-a.8-5">
-               Grid tables without a caption<a href="#section-a.8-5" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-5">
+               Grid tables without a caption<a href="#appendix-A.8-5" class="pilcrow">¶</a></p>
 <table class="center" id="table-4">
           <caption><a href="#table-4" class="selfRef">Table 4</a></caption>
 <thead>
@@ -1763,49 +1763,49 @@ a.miek.nl.  IN  A   192.0.2.1    ; &lt;- this is glue
             </tr>
           </tbody>
         </table>
-<p id="section-a.8-7">
-               This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance:<a href="#section-a.8-7" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.8-8">
+<p id="appendix-A.8-7">
+               This table has no caption, and therefor no reference. But you can refer to some of the other tables, with for instance:<a href="#appendix-A.8-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.8-8">
 <pre>
 See [](#tab-here-s-the)
-</pre><a href="#section-a.8-8" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.8-8" class="pilcrow">¶</a>
 </div>
-<p id="section-a.8-9">
-               Which will become "See <a href="#tab-here-s-the" class="xref">Table 2</a>".<a href="#section-a.8-9" class="pilcrow">¶</a></p>
-<p id="section-a.8-10">
-               <span id="iref-table-grid-4" class="iref"></span><a href="#section-a.8-10" class="pilcrow">¶</a></p>
-<p id="section-a.8-11">
+<p id="appendix-A.8-9">
+               Which will become "See <a href="#tab-here-s-the" class="xref">Table 2</a>".<a href="#appendix-A.8-9" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-10">
+               <span id="iref-table-grid-4" class="iref"></span><a href="#appendix-A.8-10" class="pilcrow">¶</a></p>
+<p id="appendix-A.8-11">
                We should also be able to refer to the table numbers directly, to say things like 
                'Look at Tables
                <a href="#tab-demonstrat" class="xref">1</a>,
                <a href="#tab-here-s-the" class="xref">2</a>
-               and <a href="#tab-sample-gri" class="xref">3</a>.'<a href="#section-a.8-11" class="pilcrow">¶</a></p>
+               and <a href="#tab-sample-gri" class="xref">3</a>.'<a href="#appendix-A.8-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="numbered-examples">
-<section id="section-a.9">
-        <h2 id="name-numbered-examples">
-<a href="#section-a.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
-        </h2>
-<p id="section-a.9-1">
-               This is another example:<a href="#section-a.9-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-a.9-2">
-<li id="section-a.9-2.1">
-                     Another bla bla..<a href="#section-a.9-2.1" class="pilcrow">¶</a>
+<section id="appendix-A.9">
+        <h3 id="name-numbered-examples">
+<a href="#appendix-A.9" class="section-number selfRef">A.9. </a><a href="#name-numbered-examples" class="section-name selfRef">Numbered examples</a>
+        </h3>
+<p id="appendix-A.9-1">
+               This is another example:<a href="#appendix-A.9-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-A.9-2">
+<li id="appendix-A.9-2.1">
+                     Another bla bla..<a href="#appendix-A.9-2.1" class="pilcrow">¶</a>
 </li>
         </ol>
-<p id="section-a.9-3">
-               as (1) shows...<a href="#section-a.9-3" class="pilcrow">¶</a></p>
+<p id="appendix-A.9-3">
+               as (1) shows...<a href="#appendix-A.9-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="anchor-figure-tests">
-<section id="section-a.10">
-        <h2 id="name-figure-tests">
-<a href="#section-a.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
-        </h2>
+<section id="appendix-A.10">
+        <h3 id="name-figure-tests">
+<a href="#appendix-A.10" class="section-number selfRef">A.10. </a><a href="#name-figure-tests" class="section-name selfRef">Figure tests</a>
+        </h3>
 <span id="name-this-is-the-caption-with-te"></span><div id="fig-this-is-th">
 <figure id="figure-4">
-          <div class="artwork art-text alignLeft" id="section-a.10-1.1">
+          <div class="artwork art-text alignLeft" id="appendix-A.10-1.1">
 <pre>
 This is a figure
 This is a figure
@@ -1817,11 +1817,11 @@ This is a figure
 <a href="#name-this-is-the-caption-with-te" class="selfRef">This is the caption, with text in `typewriter`. Which isnt converted to a &lt;spanx&gt; style, because this is copied as-is.</a>
           </figcaption></figure>
 </div>
-<p id="section-a.10-2">
-               And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#section-a.10-2" class="pilcrow">¶</a></p>
+<p id="appendix-A.10-2">
+               And how a figure that is not centered, do to using <code>figure</code> and not <code>Figure</code>.<a href="#appendix-A.10-2" class="pilcrow">¶</a></p>
 <span id="name-a-non-centered-figure"></span><div id="fig-a-non-cent">
 <figure id="figure-5">
-          <div class="artwork art-text alignLeft" id="section-a.10-3.1">
+          <div class="artwork art-text alignLeft" id="appendix-A.10-3.1">
 <pre>
 This is a figure
 This is a figure
@@ -1831,62 +1831,62 @@ This is a figure
 <a href="#name-a-non-centered-figure" class="selfRef">A non centered figure.</a>
           </figcaption></figure>
 </div>
-<p id="section-a.10-4">
-               Test the use of <code>@title</code>:<a href="#section-a.10-4" class="pilcrow">¶</a></p>
-<div class="artwork art-text alignLeft" id="section-a.10-5">
+<p id="appendix-A.10-4">
+               Test the use of <code>@title</code>:<a href="#appendix-A.10-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.10-5">
 <pre>
 This is a figure with a title
 This is a figure with a title
 @title: and here it is: a title, don't mess it up *
-</pre><a href="#section-a.10-5" class="pilcrow">¶</a>
+</pre><a href="#appendix-A.10-5" class="pilcrow">¶</a>
 </div>
 </section>
 </div>
 <div id="verse-tests">
-<section id="section-a.11">
-        <h2 id="name-verse-tests">
-<a href="#section-a.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
-        </h2>
-<p id="section-a.11-1">
-               This is a verse text This is another line<a href="#section-a.11-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.11">
+        <h3 id="name-verse-tests">
+<a href="#appendix-A.11" class="section-number selfRef">A.11. </a><a href="#name-verse-tests" class="section-name selfRef">Verse tests</a>
+        </h3>
+<p id="appendix-A.11-1">
+               This is a verse text This is another line<a href="#appendix-A.11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.b-1">
+<p id="appendix-B-1">
         <a href="#rfc.index.u76" class="xref">L</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.b-2.1">
+<li class="ulEmpty normal" id="appendix-B-2.1">
           <div id="rfc.index.u76">
-<p id="section-appendix.b-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u76" class="xref">L</a><a href="#section-appendix.b-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u76" class="xref">L</a><a href="#appendix-B-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.b-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.1.2.1.1">
-                <dt id="section-appendix.b-2.1.2.1.1.1">list</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-B-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.1.2.1.1">
+                <dt id="appendix-B-2.1.2.1.1.1">list</dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.b-2.1.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.1.2.1.1.4.1">
-                    <dt id="section-appendix.b-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4.1.2">
-                      <p id="section-appendix.b-2.1.2.1.1.4.1.2.1">
-                        <a href="#section-a.7-28" class="xref">Section A.7, Paragraph 28</a><a href="#section-appendix.b-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.1.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.1.2.1.1.4.1">
+                    <dt id="appendix-B-2.1.2.1.1.4.1.1">Uppercase Letters</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4.1.2">
+                      <p id="appendix-B-2.1.2.1.1.4.1.2.1">
+                        <a href="#appendix-A.7-28" class="xref">Appendix A.7, Paragraph 28</a><a href="#appendix-B-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.b-2.1.2.1.1.4.1.3">default markers</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.1.2.1.1.4.1.4">
-                      <p id="section-appendix.b-2.1.2.1.1.4.1.4.1">
-                        <a href="#section-a.7-20" class="xref">Section A.7, Paragraph 20</a><a href="#section-appendix.b-2.1.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.1.2.1.1.4.1.3">default markers</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.1.2.1.1.4.1.4">
+                      <p id="appendix-B-2.1.2.1.1.4.1.4.1">
+                        <a href="#appendix-A.7-20" class="xref">Appendix A.7, Paragraph 20</a><a href="#appendix-B-2.1.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -1896,30 +1896,30 @@ This is a figure with a title
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.b-2.2">
+        <li class="ulEmpty normal" id="appendix-B-2.2">
           <div id="rfc.index.u84">
-<p id="section-appendix.b-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.b-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-B-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.b-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.2.2.1.1">
-                <dt id="section-appendix.b-2.2.2.1.1.1">table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-B-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.2.2.1.1">
+                <dt id="appendix-B-2.2.2.1.1.1">table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.b-2.2.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.b-2.2.2.1.1.4.1">
-                    <dt id="section-appendix.b-2.2.2.1.1.4.1.1">grid</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4.1.2">
-                      <p id="section-appendix.b-2.2.2.1.1.4.1.2.1">
-                        <a href="#section-a.8-10" class="xref">Section A.8, Paragraph 10</a><a href="#section-appendix.b-2.2.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.2.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-B-2.2.2.1.1.4.1">
+                    <dt id="appendix-B-2.2.2.1.1.4.1.1">grid</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4.1.2">
+                      <p id="appendix-B-2.2.2.1.1.4.1.2.1">
+                        <a href="#appendix-A.8-10" class="xref">Appendix A.8, Paragraph 10</a><a href="#appendix-B-2.2.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.b-2.2.2.1.1.4.1.3">simple</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.b-2.2.2.1.1.4.1.4">
-                      <p id="section-appendix.b-2.2.2.1.1.4.1.4.1">
-                        <a href="#section-a.8-3" class="xref">Section A.8, Paragraph 3</a><a href="#section-appendix.b-2.2.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-B-2.2.2.1.1.4.1.3">simple</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-B-2.2.2.1.1.4.1.4">
+                      <p id="appendix-B-2.2.2.1.1.4.1.4.1">
+                        <a href="#appendix-A.8-3" class="xref">Appendix A.8, Paragraph 3</a><a href="#appendix-B-2.2.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -1932,7 +1932,7 @@ This is a figure with a title
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/draft-template.v3.py36.html
+++ b/cli/tests/valid/draft-template.v3.py36.html
@@ -178,13 +178,13 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -861,23 +861,23 @@ main(int argc, char *argv[])
 </section>
 </section>
 <div id="app-additional">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-additional-stuff">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
       </h2>
-<p id="section-appendix.a-1">This becomes an Appendix.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-1">This becomes an Appendix.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="contributors">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-contributors">
 <a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<p id="section-appendix.b-1">This becomes an unnumbered section<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This becomes an unnumbered section<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/draft-template.v3.py37.html
+++ b/cli/tests/valid/draft-template.v3.py37.html
@@ -11,7 +11,7 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
@@ -178,13 +178,13 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -861,23 +861,23 @@ main(int argc, char *argv[])
 </section>
 </section>
 <div id="app-additional">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-additional-stuff">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
       </h2>
-<p id="section-appendix.a-1">This becomes an Appendix.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-1">This becomes an Appendix.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="contributors">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-contributors">
 <a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<p id="section-appendix.b-1">This becomes an unnumbered section<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This becomes an unnumbered section<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/draft-template.v3.py38.html
+++ b/cli/tests/valid/draft-template.v3.py38.html
@@ -11,7 +11,7 @@
        Insert an abstract: MANDATORY. This template is for creating an
       Internet Draft. 
     " name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="template" name="keyword">
 <meta content="draft-ietf-xml2rfc-template-05" name="ietf.draft">
 <link href="tests/input/draft-template.xml" rel="alternate" type="application/rfc+xml">
@@ -178,13 +178,13 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-additional-stuff" class="xref">Additional Stuff</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -861,23 +861,23 @@ main(int argc, char *argv[])
 </section>
 </section>
 <div id="app-additional">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-additional-stuff">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-additional-stuff" class="section-name selfRef">Additional Stuff</a>
       </h2>
-<p id="section-appendix.a-1">This becomes an Appendix.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-1">This becomes an Appendix.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="contributors">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-contributors">
 <a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<p id="section-appendix.b-1">This becomes an unnumbered section<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This becomes an unnumbered section<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/draft-v3-features.prepped.xml
+++ b/cli/tests/valid/draft-v3-features.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc version="3" category="exp" docName="draft-v3-features" indexInclude="true" ipr="trust200902" prepTime="2021-04-26T16:16:20" scripts="Cherokee,Common,Cyrillic,Greek,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc version="3" category="exp" docName="draft-v3-features" indexInclude="true" ipr="trust200902" prepTime="2021-04-30T01:55:44" scripts="Cherokee,Common,Cyrillic,Greek,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.7.0 -->
   
   
@@ -270,7 +270,7 @@
             <t indent="0" pn="section-toc.1-1.14.1"><xref derivedContent="Appendix B" format="default" sectionFormat="of" target="section-appendix.b"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-another-change-log-only-con">Another Change Log only containing Subsections</xref></t>
             <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.14.2">
               <li pn="section-toc.1-1.14.2.1">
-                <t indent="0" pn="section-toc.1-1.14.2.1.1"><xref derivedContent="B.1" format="counter" sectionFormat="of" target="section-b.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-test">Test</xref></t>
+                <t indent="0" pn="section-toc.1-1.14.2.1.1"><xref derivedContent="B.1" format="counter" sectionFormat="of" target="section-appendix.b.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-test">Test</xref></t>
               </li>
             </ul>
           </li>
@@ -284,7 +284,7 @@
             <t indent="0" pn="section-toc.1-1.17.1"><xref derivedContent="Appendix E" format="default" sectionFormat="of" target="section-appendix.e"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-test-removeinrfc-without-na">Test removeInRFC without name</xref></t>
             <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.17.2">
               <li pn="section-toc.1-1.17.2.1">
-                <t indent="0" pn="section-toc.1-1.17.2.1.1"><xref derivedContent="E.1" format="counter" sectionFormat="of" target="section-e.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-section-as-first-child">section as first child</xref></t>
+                <t indent="0" pn="section-toc.1-1.17.2.1.1"><xref derivedContent="E.1" format="counter" sectionFormat="of" target="section-appendix.e.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-section-as-first-child">section as first child</xref></t>
               </li>
             </ul>
           </li>
@@ -4097,9 +4097,9 @@ foo = bar
     <section removeInRFC="true" numbered="true" toc="include" pn="section-appendix.b">
       <name slugifiedName="name-another-change-log-only-con">Another Change Log only containing Subsections</name>
       <t indent="0" pn="section-appendix.b-1">This section is to be removed before publishing as an RFC.</t>
-      <section numbered="true" removeInRFC="false" toc="include" pn="section-b.1">
+      <section numbered="true" removeInRFC="false" toc="include" pn="section-appendix.b.1">
         <name slugifiedName="name-test">Test</name>
-        <t indent="0" pn="section-b.1-1">Foo</t>
+        <t indent="0" pn="section-appendix.b.1-1">Foo</t>
       </section>
     </section>
     <section removeInRFC="true" numbered="true" toc="include" pn="section-appendix.c">
@@ -4117,9 +4117,9 @@ foo = bar
     <section removeInRFC="true" numbered="true" toc="include" pn="section-appendix.e">
       <name slugifiedName="name-test-removeinrfc-without-na">Test removeInRFC without name</name>
       <t indent="0" pn="section-appendix.e-1">This section is to be removed before publishing as an RFC.</t>
-      <section numbered="true" removeInRFC="false" toc="include" pn="section-e.1">
+      <section numbered="true" removeInRFC="false" toc="include" pn="section-appendix.e.1">
         <name slugifiedName="name-section-as-first-child">section as first child</name>
-        <t indent="0" pn="section-e.1-1">The warning should still appear.</t>
+        <t indent="0" pn="section-appendix.e.1-1">The warning should still appear.</t>
       </section>
     </section>
     <section numbered="false" anchor="contributors" removeInRFC="false" toc="include" pn="section-appendix.f">
@@ -4151,7 +4151,7 @@ foo = bar
                 <dt pn="section-appendix.g-2.1.2.1.1.1">$Dollar item</dt>
                 <dd pn="section-appendix.g-2.1.2.1.1.2">
                   <t indent="0" pn="section-appendix.g-2.1.2.1.1.2.1">
-                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Section Appendix.A, Paragraph 3"/>
+                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Appendix A, Paragraph 3"/>
                   </t>
                 </dd>
               </dl>
@@ -4168,7 +4168,7 @@ foo = bar
                 <dt pn="section-appendix.g-2.2.2.1.1.1">%</dt>
                 <dd pn="section-appendix.g-2.2.2.1.1.2">
                   <t indent="0" pn="section-appendix.g-2.2.2.1.1.2.1">
-                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Section Appendix.A, Paragraph 3"/>
+                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Appendix A, Paragraph 3"/>
                   </t>
                 </dd>
               </dl>
@@ -4185,7 +4185,7 @@ foo = bar
                 <dt pn="section-appendix.g-2.3.2.1.1.1">[Bracket item</dt>
                 <dd pn="section-appendix.g-2.3.2.1.1.2">
                   <t indent="0" pn="section-appendix.g-2.3.2.1.1.2.1">
-                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Section Appendix.A, Paragraph 3"/>
+                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Appendix A, Paragraph 3"/>
                   </t>
                 </dd>
               </dl>
@@ -4202,7 +4202,7 @@ foo = bar
                 <dt pn="section-appendix.g-2.4.2.1.1.1">\Backslash item</dt>
                 <dd pn="section-appendix.g-2.4.2.1.1.2">
                   <t indent="0" pn="section-appendix.g-2.4.2.1.1.2.1">
-                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Section Appendix.A, Paragraph 3"/>
+                    <xref format="default" sectionFormat="of" target="section-appendix.a-3" derivedContent="Appendix A, Paragraph 3"/>
                   </t>
                 </dd>
               </dl>

--- a/cli/tests/valid/draft-v3-features.text
+++ b/cli/tests/valid/draft-v3-features.text
@@ -1450,19 +1450,19 @@ Index
 
       $
 
-         $Dollar item  Section Appendix.A, Paragraph 3
+         $Dollar item  Appendix A, Paragraph 3
 
       %
 
-         %  Section Appendix.A, Paragraph 3
+         %  Appendix A, Paragraph 3
 
       [
 
-         [Bracket item  Section Appendix.A, Paragraph 3
+         [Bracket item  Appendix A, Paragraph 3
 
       \
 
-         \Backslash item  Section Appendix.A, Paragraph 3
+         \Backslash item  Appendix A, Paragraph 3
 
       B
 

--- a/cli/tests/valid/draft-v3-features.v3.py36.html
+++ b/cli/tests/valid/draft-v3-features.v3.py36.html
@@ -302,38 +302,38 @@
             <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-some-references" class="xref">Some References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-change-log" class="xref">Change Log</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-change-log" class="xref">Change Log</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-another-change-log-only-con" class="xref">Another Change Log only containing Subsections</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-another-change-log-only-con" class="xref">Another Change Log only containing Subsections</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-test" class="xref">Test</a></p>
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-test" class="xref">Test</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-test-removeinrfc-duplicatio" class="xref">Test removeInRFC duplication</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-test-removeinrfc-duplicatio" class="xref">Test removeInRFC duplication</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#section-appendix.d" class="xref">Appendix D</a>.  <a href="#name-test-removeinrfc-duplication" class="xref">Test removeInRFC duplication again</a></p>
+            <p id="section-toc.1-1.16.1"><a href="#appendix-D" class="xref">Appendix D</a>.  <a href="#name-test-removeinrfc-duplication" class="xref">Test removeInRFC duplication again</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#section-appendix.e" class="xref">Appendix E</a>.  <a href="#name-test-removeinrfc-without-na" class="xref">Test removeInRFC without name</a></p>
+            <p id="section-toc.1-1.17.1"><a href="#appendix-E" class="xref">Appendix E</a>.  <a href="#name-test-removeinrfc-without-na" class="xref">Test removeInRFC without name</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.17.2.1">
-                <p id="section-toc.1-1.17.2.1.1"><a href="#section-e.1" class="xref">E.1</a>.  <a href="#name-section-as-first-child" class="xref">section as first child</a></p>
+                <p id="section-toc.1-1.17.2.1.1"><a href="#appendix-E.1" class="xref">E.1</a>.  <a href="#name-section-as-first-child" class="xref">section as first child</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#section-appendix.f" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.18.1"><a href="#appendix-F" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.g" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-G" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.h" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-H" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -5008,74 +5008,74 @@ foo = bar
 </dl>
 </section>
 </div>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-change-log">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
       </h2>
-<p id="section-appendix.a-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-2">
-    Foo bar.<a href="#section-appendix.a-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-3">
+<p id="appendix-A-1">This section is to be removed before publishing as an RFC.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">
+    Foo bar.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">
     <span id="iref-backslash-item-5" class="iref"></span>
         <span id="iref-dollar-item-6" class="iref"></span>
         <span id="iref-bracket-item-7" class="iref"></span>
-        <span id="iref-8" class="iref"></span><a href="#section-appendix.a-3" class="pilcrow">¶</a></p>
+        <span id="iref-8" class="iref"></span><a href="#appendix-A-3" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-another-change-log-only-con">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-another-change-log-only-con" class="section-name selfRef">Another Change Log only containing Subsections</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-another-change-log-only-con" class="section-name selfRef">Another Change Log only containing Subsections</a>
       </h2>
-<p id="section-appendix.b-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
-<section id="section-b.1">
-        <h2 id="name-test">
-<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-test" class="section-name selfRef">Test</a>
-        </h2>
-<p id="section-b.1-1">Foo<a href="#section-b.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This section is to be removed before publishing as an RFC.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<section id="appendix-B.1">
+        <h3 id="name-test">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-test" class="section-name selfRef">Test</a>
+        </h3>
+<p id="appendix-B.1-1">Foo<a href="#appendix-B.1-1" class="pilcrow">¶</a></p>
 </section>
 </section>
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-test-removeinrfc-duplicatio">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-test-removeinrfc-duplicatio" class="section-name selfRef">Test removeInRFC duplication</a>
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-test-removeinrfc-duplicatio" class="section-name selfRef">Test removeInRFC duplication</a>
       </h2>
-<p id="section-appendix.c-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.c-2">The above note should NOT appear twice.<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
+<p id="appendix-C-1">This section is to be removed before publishing as an RFC.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">The above note should NOT appear twice.<a href="#appendix-C-2" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.d">
+<section id="appendix-D">
       <h2 id="name-test-removeinrfc-duplication">
-<a href="#section-appendix.d" class="section-number selfRef">Appendix D. </a><a href="#name-test-removeinrfc-duplication" class="section-name selfRef">Test removeInRFC duplication again</a>
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-test-removeinrfc-duplication" class="section-name selfRef">Test removeInRFC duplication again</a>
       </h2>
-<p id="section-appendix.d-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-2">Since it is not the first paragraph in the source XML,<a href="#section-appendix.d-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-3">This section is to be removed before publishing as an RFC.<a href="#section-appendix.d-3" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-4">should appear twice this time.<a href="#section-appendix.d-4" class="pilcrow">¶</a></p>
+<p id="appendix-D-1">This section is to be removed before publishing as an RFC.<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<p id="appendix-D-2">Since it is not the first paragraph in the source XML,<a href="#appendix-D-2" class="pilcrow">¶</a></p>
+<p id="appendix-D-3">This section is to be removed before publishing as an RFC.<a href="#appendix-D-3" class="pilcrow">¶</a></p>
+<p id="appendix-D-4">should appear twice this time.<a href="#appendix-D-4" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.e">
+<section id="appendix-E">
       <h2 id="name-test-removeinrfc-without-na">
-<a href="#section-appendix.e" class="section-number selfRef">Appendix E. </a><a href="#name-test-removeinrfc-without-na" class="section-name selfRef">Test removeInRFC without name</a>
+<a href="#appendix-E" class="section-number selfRef">Appendix E. </a><a href="#name-test-removeinrfc-without-na" class="section-name selfRef">Test removeInRFC without name</a>
       </h2>
-<p id="section-appendix.e-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.e-1" class="pilcrow">¶</a></p>
-<section id="section-e.1">
-        <h2 id="name-section-as-first-child">
-<a href="#section-e.1" class="section-number selfRef">E.1. </a><a href="#name-section-as-first-child" class="section-name selfRef">section as first child</a>
-        </h2>
-<p id="section-e.1-1">The warning should still appear.<a href="#section-e.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-E-1">This section is to be removed before publishing as an RFC.<a href="#appendix-E-1" class="pilcrow">¶</a></p>
+<section id="appendix-E.1">
+        <h3 id="name-section-as-first-child">
+<a href="#appendix-E.1" class="section-number selfRef">E.1. </a><a href="#name-section-as-first-child" class="section-name selfRef">section as first child</a>
+        </h3>
+<p id="appendix-E.1-1">The warning should still appear.<a href="#appendix-E.1-1" class="pilcrow">¶</a></p>
 </section>
 </section>
 <div id="contributors">
-<section id="section-appendix.f">
+<section id="appendix-F">
       <h2 id="name-contributors">
 <a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<p id="section-appendix.f-1">
-    Foo bar.<a href="#section-appendix.f-1" class="pilcrow">¶</a></p>
+<p id="appendix-F-1">
+    Foo bar.<a href="#appendix-F-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-appendix.g">
+<section id="appendix-G">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.g-1">
+<p id="appendix-G-1">
         <a href="#rfc.index.u36" class="xref">$</a>
         <a href="#rfc.index.u37" class="xref">%</a>
         <a href="#rfc.index.u91" class="xref">[</a>
@@ -5083,147 +5083,147 @@ foo = bar
         <a href="#rfc.index.u66" class="xref">B</a>
         <a href="#rfc.index.u77" class="xref">M</a>
         <a href="#rfc.index.u82" class="xref">R</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.g-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-G-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.g-2.1">
+<li class="ulEmpty normal" id="appendix-G-2.1">
           <div id="rfc.index.u36">
-<p id="section-appendix.g-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u36" class="xref">$</a><a href="#section-appendix.g-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u36" class="xref">$</a><a href="#appendix-G-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.1.2.1.1">
-                <dt id="section-appendix.g-2.1.2.1.1.1">$Dollar item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.1.2.1.1.2">
-                  <p id="section-appendix.g-2.1.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.1.2.1.1">
+                <dt id="appendix-G-2.1.2.1.1.1">$Dollar item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.1.2.1.1.2">
+                  <p id="appendix-G-2.1.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.2">
+        <li class="ulEmpty normal" id="appendix-G-2.2">
           <div id="rfc.index.u37">
-<p id="section-appendix.g-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u37" class="xref">%</a><a href="#section-appendix.g-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u37" class="xref">%</a><a href="#appendix-G-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.2.2.1.1">
-                <dt id="section-appendix.g-2.2.2.1.1.1">%</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.2.2.1.1.2">
-                  <p id="section-appendix.g-2.2.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.2.2.1.1">
+                <dt id="appendix-G-2.2.2.1.1.1">%</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.2.2.1.1.2">
+                  <p id="appendix-G-2.2.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.3">
+        <li class="ulEmpty normal" id="appendix-G-2.3">
           <div id="rfc.index.u91">
-<p id="section-appendix.g-2.3.1" class="keepWithNext">
-            <a href="#rfc.index.u91" class="xref">[</a><a href="#section-appendix.g-2.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.3.1" class="keepWithNext">
+            <a href="#rfc.index.u91" class="xref">[</a><a href="#appendix-G-2.3.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.3.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.3.2.1.1">
-                <dt id="section-appendix.g-2.3.2.1.1.1">[Bracket item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.3.2.1.1.2">
-                  <p id="section-appendix.g-2.3.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.3.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.3.2.1.1">
+                <dt id="appendix-G-2.3.2.1.1.1">[Bracket item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.3.2.1.1.2">
+                  <p id="appendix-G-2.3.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.4">
+        <li class="ulEmpty normal" id="appendix-G-2.4">
           <div id="rfc.index.u92">
-<p id="section-appendix.g-2.4.1" class="keepWithNext">
-            <a href="#rfc.index.u92" class="xref">\</a><a href="#section-appendix.g-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.4.1" class="keepWithNext">
+            <a href="#rfc.index.u92" class="xref">\</a><a href="#appendix-G-2.4.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.4.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.4.2.1.1">
-                <dt id="section-appendix.g-2.4.2.1.1.1">\Backslash item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.4.2.1.1.2">
-                  <p id="section-appendix.g-2.4.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.4.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.4.2.1.1">
+                <dt id="appendix-G-2.4.2.1.1.1">\Backslash item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.4.2.1.1.2">
+                  <p id="appendix-G-2.4.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.5">
+        <li class="ulEmpty normal" id="appendix-G-2.5">
           <div id="rfc.index.u66">
-<p id="section-appendix.g-2.5.1" class="keepWithNext">
-            <a href="#rfc.index.u66" class="xref">B</a><a href="#section-appendix.g-2.5.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.5.1" class="keepWithNext">
+            <a href="#rfc.index.u66" class="xref">B</a><a href="#appendix-G-2.5.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.5.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.5.2.1.1">
-                <dt id="section-appendix.g-2.5.2.1.1.1">Bare Table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.5.2.1.1.2">
-                  <p id="section-appendix.g-2.5.2.1.1.2.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.g-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.5.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.5.2.1.1">
+                <dt id="appendix-G-2.5.2.1.1.1">Bare Table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.5.2.1.1.2">
+                  <p id="appendix-G-2.5.2.1.1.2.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-G-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.6">
+        <li class="ulEmpty normal" id="appendix-G-2.6">
           <div id="rfc.index.u77">
-<p id="section-appendix.g-2.6.1" class="keepWithNext">
-            <a href="#rfc.index.u77" class="xref">M</a><a href="#section-appendix.g-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.6.1" class="keepWithNext">
+            <a href="#rfc.index.u77" class="xref">M</a><a href="#appendix-G-2.6.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.6.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.6.2.1.1">
-                <dt id="section-appendix.g-2.6.2.1.1.1">Markup in titles</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.6.2.1.1.2">
-                  <p id="section-appendix.g-2.6.2.1.1.2.1">
-                    <a href="#section-2" class="xref">Section 2</a><a href="#section-appendix.g-2.6.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.6.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.6.2.1.1">
+                <dt id="appendix-G-2.6.2.1.1.1">Markup in titles</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.6.2.1.1.2">
+                  <p id="appendix-G-2.6.2.1.1.2.1">
+                    <a href="#section-2" class="xref">Section 2</a><a href="#appendix-G-2.6.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.7">
+        <li class="ulEmpty normal" id="appendix-G-2.7">
           <div id="rfc.index.u82">
-<p id="section-appendix.g-2.7.1" class="keepWithNext">
-            <a href="#rfc.index.u82" class="xref">R</a><a href="#section-appendix.g-2.7.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.7.1" class="keepWithNext">
+            <a href="#rfc.index.u82" class="xref">R</a><a href="#appendix-G-2.7.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.7.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.7.2.1.1">
-                <dt id="section-appendix.g-2.7.2.1.1.1">Reference renaming</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.7.2.1.1.2">
-                  <p id="section-appendix.g-2.7.2.1.1.2.1">
-                    <a href="#section-3" class="xref">Section 3</a><a href="#section-appendix.g-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.7.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.7.2.1.1">
+                <dt id="appendix-G-2.7.2.1.1.1">Reference renaming</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.7.2.1.1.2">
+                  <p id="appendix-G-2.7.2.1.1.2.1">
+                    <a href="#section-3" class="xref">Section 3</a><a href="#appendix-G-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.8">
+        <li class="ulEmpty normal" id="appendix-G-2.8">
           <div id="rfc.index.u84">
-<p id="section-appendix.g-2.8.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.g-2.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.8.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-G-2.8.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.8.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.8.2.1.1">
-                <dt id="section-appendix.g-2.8.2.1.1.1">Text Styles</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.8.2.1.1.2">
-                  <p id="section-appendix.g-2.8.2.1.1.2.1">
-                    <a href="#section-1" class="xref">Section 1</a><a href="#section-appendix.g-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.8.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.8.2.1.1">
+                <dt id="appendix-G-2.8.2.1.1.1">Text Styles</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.8.2.1.1.2">
+                  <p id="appendix-G-2.8.2.1.1.2.1">
+                    <a href="#section-1" class="xref">Section 1</a><a href="#appendix-G-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
@@ -5233,7 +5233,7 @@ foo = bar
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.h">
+<section id="appendix-H">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/draft-v3-features.v3.py37.html
+++ b/cli/tests/valid/draft-v3-features.v3.py37.html
@@ -302,38 +302,38 @@
             <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-some-references" class="xref">Some References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-change-log" class="xref">Change Log</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-change-log" class="xref">Change Log</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-another-change-log-only-con" class="xref">Another Change Log only containing Subsections</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-another-change-log-only-con" class="xref">Another Change Log only containing Subsections</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-test" class="xref">Test</a></p>
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-test" class="xref">Test</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-test-removeinrfc-duplicatio" class="xref">Test removeInRFC duplication</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-test-removeinrfc-duplicatio" class="xref">Test removeInRFC duplication</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#section-appendix.d" class="xref">Appendix D</a>.  <a href="#name-test-removeinrfc-duplication" class="xref">Test removeInRFC duplication again</a></p>
+            <p id="section-toc.1-1.16.1"><a href="#appendix-D" class="xref">Appendix D</a>.  <a href="#name-test-removeinrfc-duplication" class="xref">Test removeInRFC duplication again</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#section-appendix.e" class="xref">Appendix E</a>.  <a href="#name-test-removeinrfc-without-na" class="xref">Test removeInRFC without name</a></p>
+            <p id="section-toc.1-1.17.1"><a href="#appendix-E" class="xref">Appendix E</a>.  <a href="#name-test-removeinrfc-without-na" class="xref">Test removeInRFC without name</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.17.2.1">
-                <p id="section-toc.1-1.17.2.1.1"><a href="#section-e.1" class="xref">E.1</a>.  <a href="#name-section-as-first-child" class="xref">section as first child</a></p>
+                <p id="section-toc.1-1.17.2.1.1"><a href="#appendix-E.1" class="xref">E.1</a>.  <a href="#name-section-as-first-child" class="xref">section as first child</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#section-appendix.f" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.18.1"><a href="#appendix-F" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.g" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-G" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.h" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-H" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -5008,74 +5008,74 @@ foo = bar
 </dl>
 </section>
 </div>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-change-log">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
       </h2>
-<p id="section-appendix.a-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-2">
-    Foo bar.<a href="#section-appendix.a-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-3">
+<p id="appendix-A-1">This section is to be removed before publishing as an RFC.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">
+    Foo bar.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">
     <span id="iref-backslash-item-5" class="iref"></span>
         <span id="iref-dollar-item-6" class="iref"></span>
         <span id="iref-bracket-item-7" class="iref"></span>
-        <span id="iref-8" class="iref"></span><a href="#section-appendix.a-3" class="pilcrow">¶</a></p>
+        <span id="iref-8" class="iref"></span><a href="#appendix-A-3" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-another-change-log-only-con">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-another-change-log-only-con" class="section-name selfRef">Another Change Log only containing Subsections</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-another-change-log-only-con" class="section-name selfRef">Another Change Log only containing Subsections</a>
       </h2>
-<p id="section-appendix.b-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
-<section id="section-b.1">
-        <h2 id="name-test">
-<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-test" class="section-name selfRef">Test</a>
-        </h2>
-<p id="section-b.1-1">Foo<a href="#section-b.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This section is to be removed before publishing as an RFC.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<section id="appendix-B.1">
+        <h3 id="name-test">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-test" class="section-name selfRef">Test</a>
+        </h3>
+<p id="appendix-B.1-1">Foo<a href="#appendix-B.1-1" class="pilcrow">¶</a></p>
 </section>
 </section>
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-test-removeinrfc-duplicatio">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-test-removeinrfc-duplicatio" class="section-name selfRef">Test removeInRFC duplication</a>
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-test-removeinrfc-duplicatio" class="section-name selfRef">Test removeInRFC duplication</a>
       </h2>
-<p id="section-appendix.c-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.c-2">The above note should NOT appear twice.<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
+<p id="appendix-C-1">This section is to be removed before publishing as an RFC.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">The above note should NOT appear twice.<a href="#appendix-C-2" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.d">
+<section id="appendix-D">
       <h2 id="name-test-removeinrfc-duplication">
-<a href="#section-appendix.d" class="section-number selfRef">Appendix D. </a><a href="#name-test-removeinrfc-duplication" class="section-name selfRef">Test removeInRFC duplication again</a>
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-test-removeinrfc-duplication" class="section-name selfRef">Test removeInRFC duplication again</a>
       </h2>
-<p id="section-appendix.d-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-2">Since it is not the first paragraph in the source XML,<a href="#section-appendix.d-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-3">This section is to be removed before publishing as an RFC.<a href="#section-appendix.d-3" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-4">should appear twice this time.<a href="#section-appendix.d-4" class="pilcrow">¶</a></p>
+<p id="appendix-D-1">This section is to be removed before publishing as an RFC.<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<p id="appendix-D-2">Since it is not the first paragraph in the source XML,<a href="#appendix-D-2" class="pilcrow">¶</a></p>
+<p id="appendix-D-3">This section is to be removed before publishing as an RFC.<a href="#appendix-D-3" class="pilcrow">¶</a></p>
+<p id="appendix-D-4">should appear twice this time.<a href="#appendix-D-4" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.e">
+<section id="appendix-E">
       <h2 id="name-test-removeinrfc-without-na">
-<a href="#section-appendix.e" class="section-number selfRef">Appendix E. </a><a href="#name-test-removeinrfc-without-na" class="section-name selfRef">Test removeInRFC without name</a>
+<a href="#appendix-E" class="section-number selfRef">Appendix E. </a><a href="#name-test-removeinrfc-without-na" class="section-name selfRef">Test removeInRFC without name</a>
       </h2>
-<p id="section-appendix.e-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.e-1" class="pilcrow">¶</a></p>
-<section id="section-e.1">
-        <h2 id="name-section-as-first-child">
-<a href="#section-e.1" class="section-number selfRef">E.1. </a><a href="#name-section-as-first-child" class="section-name selfRef">section as first child</a>
-        </h2>
-<p id="section-e.1-1">The warning should still appear.<a href="#section-e.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-E-1">This section is to be removed before publishing as an RFC.<a href="#appendix-E-1" class="pilcrow">¶</a></p>
+<section id="appendix-E.1">
+        <h3 id="name-section-as-first-child">
+<a href="#appendix-E.1" class="section-number selfRef">E.1. </a><a href="#name-section-as-first-child" class="section-name selfRef">section as first child</a>
+        </h3>
+<p id="appendix-E.1-1">The warning should still appear.<a href="#appendix-E.1-1" class="pilcrow">¶</a></p>
 </section>
 </section>
 <div id="contributors">
-<section id="section-appendix.f">
+<section id="appendix-F">
       <h2 id="name-contributors">
 <a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<p id="section-appendix.f-1">
-    Foo bar.<a href="#section-appendix.f-1" class="pilcrow">¶</a></p>
+<p id="appendix-F-1">
+    Foo bar.<a href="#appendix-F-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-appendix.g">
+<section id="appendix-G">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.g-1">
+<p id="appendix-G-1">
         <a href="#rfc.index.u36" class="xref">$</a>
         <a href="#rfc.index.u37" class="xref">%</a>
         <a href="#rfc.index.u91" class="xref">[</a>
@@ -5083,147 +5083,147 @@ foo = bar
         <a href="#rfc.index.u66" class="xref">B</a>
         <a href="#rfc.index.u77" class="xref">M</a>
         <a href="#rfc.index.u82" class="xref">R</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.g-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-G-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.g-2.1">
+<li class="ulEmpty normal" id="appendix-G-2.1">
           <div id="rfc.index.u36">
-<p id="section-appendix.g-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u36" class="xref">$</a><a href="#section-appendix.g-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u36" class="xref">$</a><a href="#appendix-G-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.1.2.1.1">
-                <dt id="section-appendix.g-2.1.2.1.1.1">$Dollar item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.1.2.1.1.2">
-                  <p id="section-appendix.g-2.1.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.1.2.1.1">
+                <dt id="appendix-G-2.1.2.1.1.1">$Dollar item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.1.2.1.1.2">
+                  <p id="appendix-G-2.1.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.2">
+        <li class="ulEmpty normal" id="appendix-G-2.2">
           <div id="rfc.index.u37">
-<p id="section-appendix.g-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u37" class="xref">%</a><a href="#section-appendix.g-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u37" class="xref">%</a><a href="#appendix-G-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.2.2.1.1">
-                <dt id="section-appendix.g-2.2.2.1.1.1">%</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.2.2.1.1.2">
-                  <p id="section-appendix.g-2.2.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.2.2.1.1">
+                <dt id="appendix-G-2.2.2.1.1.1">%</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.2.2.1.1.2">
+                  <p id="appendix-G-2.2.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.3">
+        <li class="ulEmpty normal" id="appendix-G-2.3">
           <div id="rfc.index.u91">
-<p id="section-appendix.g-2.3.1" class="keepWithNext">
-            <a href="#rfc.index.u91" class="xref">[</a><a href="#section-appendix.g-2.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.3.1" class="keepWithNext">
+            <a href="#rfc.index.u91" class="xref">[</a><a href="#appendix-G-2.3.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.3.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.3.2.1.1">
-                <dt id="section-appendix.g-2.3.2.1.1.1">[Bracket item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.3.2.1.1.2">
-                  <p id="section-appendix.g-2.3.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.3.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.3.2.1.1">
+                <dt id="appendix-G-2.3.2.1.1.1">[Bracket item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.3.2.1.1.2">
+                  <p id="appendix-G-2.3.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.4">
+        <li class="ulEmpty normal" id="appendix-G-2.4">
           <div id="rfc.index.u92">
-<p id="section-appendix.g-2.4.1" class="keepWithNext">
-            <a href="#rfc.index.u92" class="xref">\</a><a href="#section-appendix.g-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.4.1" class="keepWithNext">
+            <a href="#rfc.index.u92" class="xref">\</a><a href="#appendix-G-2.4.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.4.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.4.2.1.1">
-                <dt id="section-appendix.g-2.4.2.1.1.1">\Backslash item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.4.2.1.1.2">
-                  <p id="section-appendix.g-2.4.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.4.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.4.2.1.1">
+                <dt id="appendix-G-2.4.2.1.1.1">\Backslash item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.4.2.1.1.2">
+                  <p id="appendix-G-2.4.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.5">
+        <li class="ulEmpty normal" id="appendix-G-2.5">
           <div id="rfc.index.u66">
-<p id="section-appendix.g-2.5.1" class="keepWithNext">
-            <a href="#rfc.index.u66" class="xref">B</a><a href="#section-appendix.g-2.5.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.5.1" class="keepWithNext">
+            <a href="#rfc.index.u66" class="xref">B</a><a href="#appendix-G-2.5.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.5.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.5.2.1.1">
-                <dt id="section-appendix.g-2.5.2.1.1.1">Bare Table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.5.2.1.1.2">
-                  <p id="section-appendix.g-2.5.2.1.1.2.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.g-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.5.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.5.2.1.1">
+                <dt id="appendix-G-2.5.2.1.1.1">Bare Table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.5.2.1.1.2">
+                  <p id="appendix-G-2.5.2.1.1.2.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-G-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.6">
+        <li class="ulEmpty normal" id="appendix-G-2.6">
           <div id="rfc.index.u77">
-<p id="section-appendix.g-2.6.1" class="keepWithNext">
-            <a href="#rfc.index.u77" class="xref">M</a><a href="#section-appendix.g-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.6.1" class="keepWithNext">
+            <a href="#rfc.index.u77" class="xref">M</a><a href="#appendix-G-2.6.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.6.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.6.2.1.1">
-                <dt id="section-appendix.g-2.6.2.1.1.1">Markup in titles</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.6.2.1.1.2">
-                  <p id="section-appendix.g-2.6.2.1.1.2.1">
-                    <a href="#section-2" class="xref">Section 2</a><a href="#section-appendix.g-2.6.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.6.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.6.2.1.1">
+                <dt id="appendix-G-2.6.2.1.1.1">Markup in titles</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.6.2.1.1.2">
+                  <p id="appendix-G-2.6.2.1.1.2.1">
+                    <a href="#section-2" class="xref">Section 2</a><a href="#appendix-G-2.6.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.7">
+        <li class="ulEmpty normal" id="appendix-G-2.7">
           <div id="rfc.index.u82">
-<p id="section-appendix.g-2.7.1" class="keepWithNext">
-            <a href="#rfc.index.u82" class="xref">R</a><a href="#section-appendix.g-2.7.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.7.1" class="keepWithNext">
+            <a href="#rfc.index.u82" class="xref">R</a><a href="#appendix-G-2.7.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.7.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.7.2.1.1">
-                <dt id="section-appendix.g-2.7.2.1.1.1">Reference renaming</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.7.2.1.1.2">
-                  <p id="section-appendix.g-2.7.2.1.1.2.1">
-                    <a href="#section-3" class="xref">Section 3</a><a href="#section-appendix.g-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.7.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.7.2.1.1">
+                <dt id="appendix-G-2.7.2.1.1.1">Reference renaming</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.7.2.1.1.2">
+                  <p id="appendix-G-2.7.2.1.1.2.1">
+                    <a href="#section-3" class="xref">Section 3</a><a href="#appendix-G-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.8">
+        <li class="ulEmpty normal" id="appendix-G-2.8">
           <div id="rfc.index.u84">
-<p id="section-appendix.g-2.8.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.g-2.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.8.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-G-2.8.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.8.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.8.2.1.1">
-                <dt id="section-appendix.g-2.8.2.1.1.1">Text Styles</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.8.2.1.1.2">
-                  <p id="section-appendix.g-2.8.2.1.1.2.1">
-                    <a href="#section-1" class="xref">Section 1</a><a href="#section-appendix.g-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.8.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.8.2.1.1">
+                <dt id="appendix-G-2.8.2.1.1.1">Text Styles</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.8.2.1.1.2">
+                  <p id="appendix-G-2.8.2.1.1.2.1">
+                    <a href="#section-1" class="xref">Section 1</a><a href="#appendix-G-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
@@ -5233,7 +5233,7 @@ foo = bar
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.h">
+<section id="appendix-H">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/draft-v3-features.v3.py38.html
+++ b/cli/tests/valid/draft-v3-features.v3.py38.html
@@ -302,38 +302,38 @@
             <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-some-references" class="xref">Some References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-change-log" class="xref">Change Log</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-change-log" class="xref">Change Log</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-another-change-log-only-con" class="xref">Another Change Log only containing Subsections</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-another-change-log-only-con" class="xref">Another Change Log only containing Subsections</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-test" class="xref">Test</a></p>
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-test" class="xref">Test</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#section-appendix.c" class="xref">Appendix C</a>.  <a href="#name-test-removeinrfc-duplicatio" class="xref">Test removeInRFC duplication</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-test-removeinrfc-duplicatio" class="xref">Test removeInRFC duplication</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#section-appendix.d" class="xref">Appendix D</a>.  <a href="#name-test-removeinrfc-duplication" class="xref">Test removeInRFC duplication again</a></p>
+            <p id="section-toc.1-1.16.1"><a href="#appendix-D" class="xref">Appendix D</a>.  <a href="#name-test-removeinrfc-duplication" class="xref">Test removeInRFC duplication again</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#section-appendix.e" class="xref">Appendix E</a>.  <a href="#name-test-removeinrfc-without-na" class="xref">Test removeInRFC without name</a></p>
+            <p id="section-toc.1-1.17.1"><a href="#appendix-E" class="xref">Appendix E</a>.  <a href="#name-test-removeinrfc-without-na" class="xref">Test removeInRFC without name</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.17.2.1">
-                <p id="section-toc.1-1.17.2.1.1"><a href="#section-e.1" class="xref">E.1</a>.  <a href="#name-section-as-first-child" class="xref">section as first child</a></p>
+                <p id="section-toc.1-1.17.2.1.1"><a href="#appendix-E.1" class="xref">E.1</a>.  <a href="#name-section-as-first-child" class="xref">section as first child</a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#section-appendix.f" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.18.1"><a href="#appendix-F" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.g" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-G" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.h" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-H" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -5008,74 +5008,74 @@ foo = bar
 </dl>
 </section>
 </div>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-change-log">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
       </h2>
-<p id="section-appendix.a-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-2">
-    Foo bar.<a href="#section-appendix.a-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-3">
+<p id="appendix-A-1">This section is to be removed before publishing as an RFC.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">
+    Foo bar.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">
     <span id="iref-backslash-item-5" class="iref"></span>
         <span id="iref-dollar-item-6" class="iref"></span>
         <span id="iref-bracket-item-7" class="iref"></span>
-        <span id="iref-8" class="iref"></span><a href="#section-appendix.a-3" class="pilcrow">¶</a></p>
+        <span id="iref-8" class="iref"></span><a href="#appendix-A-3" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-another-change-log-only-con">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-another-change-log-only-con" class="section-name selfRef">Another Change Log only containing Subsections</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-another-change-log-only-con" class="section-name selfRef">Another Change Log only containing Subsections</a>
       </h2>
-<p id="section-appendix.b-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.b-1" class="pilcrow">¶</a></p>
-<section id="section-b.1">
-        <h2 id="name-test">
-<a href="#section-b.1" class="section-number selfRef">B.1. </a><a href="#name-test" class="section-name selfRef">Test</a>
-        </h2>
-<p id="section-b.1-1">Foo<a href="#section-b.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">This section is to be removed before publishing as an RFC.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<section id="appendix-B.1">
+        <h3 id="name-test">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-test" class="section-name selfRef">Test</a>
+        </h3>
+<p id="appendix-B.1-1">Foo<a href="#appendix-B.1-1" class="pilcrow">¶</a></p>
 </section>
 </section>
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-test-removeinrfc-duplicatio">
-<a href="#section-appendix.c" class="section-number selfRef">Appendix C. </a><a href="#name-test-removeinrfc-duplicatio" class="section-name selfRef">Test removeInRFC duplication</a>
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-test-removeinrfc-duplicatio" class="section-name selfRef">Test removeInRFC duplication</a>
       </h2>
-<p id="section-appendix.c-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.c-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.c-2">The above note should NOT appear twice.<a href="#section-appendix.c-2" class="pilcrow">¶</a></p>
+<p id="appendix-C-1">This section is to be removed before publishing as an RFC.<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">The above note should NOT appear twice.<a href="#appendix-C-2" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.d">
+<section id="appendix-D">
       <h2 id="name-test-removeinrfc-duplication">
-<a href="#section-appendix.d" class="section-number selfRef">Appendix D. </a><a href="#name-test-removeinrfc-duplication" class="section-name selfRef">Test removeInRFC duplication again</a>
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-test-removeinrfc-duplication" class="section-name selfRef">Test removeInRFC duplication again</a>
       </h2>
-<p id="section-appendix.d-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.d-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-2">Since it is not the first paragraph in the source XML,<a href="#section-appendix.d-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-3">This section is to be removed before publishing as an RFC.<a href="#section-appendix.d-3" class="pilcrow">¶</a></p>
-<p id="section-appendix.d-4">should appear twice this time.<a href="#section-appendix.d-4" class="pilcrow">¶</a></p>
+<p id="appendix-D-1">This section is to be removed before publishing as an RFC.<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+<p id="appendix-D-2">Since it is not the first paragraph in the source XML,<a href="#appendix-D-2" class="pilcrow">¶</a></p>
+<p id="appendix-D-3">This section is to be removed before publishing as an RFC.<a href="#appendix-D-3" class="pilcrow">¶</a></p>
+<p id="appendix-D-4">should appear twice this time.<a href="#appendix-D-4" class="pilcrow">¶</a></p>
 </section>
-<section id="section-appendix.e">
+<section id="appendix-E">
       <h2 id="name-test-removeinrfc-without-na">
-<a href="#section-appendix.e" class="section-number selfRef">Appendix E. </a><a href="#name-test-removeinrfc-without-na" class="section-name selfRef">Test removeInRFC without name</a>
+<a href="#appendix-E" class="section-number selfRef">Appendix E. </a><a href="#name-test-removeinrfc-without-na" class="section-name selfRef">Test removeInRFC without name</a>
       </h2>
-<p id="section-appendix.e-1">This section is to be removed before publishing as an RFC.<a href="#section-appendix.e-1" class="pilcrow">¶</a></p>
-<section id="section-e.1">
-        <h2 id="name-section-as-first-child">
-<a href="#section-e.1" class="section-number selfRef">E.1. </a><a href="#name-section-as-first-child" class="section-name selfRef">section as first child</a>
-        </h2>
-<p id="section-e.1-1">The warning should still appear.<a href="#section-e.1-1" class="pilcrow">¶</a></p>
+<p id="appendix-E-1">This section is to be removed before publishing as an RFC.<a href="#appendix-E-1" class="pilcrow">¶</a></p>
+<section id="appendix-E.1">
+        <h3 id="name-section-as-first-child">
+<a href="#appendix-E.1" class="section-number selfRef">E.1. </a><a href="#name-section-as-first-child" class="section-name selfRef">section as first child</a>
+        </h3>
+<p id="appendix-E.1-1">The warning should still appear.<a href="#appendix-E.1-1" class="pilcrow">¶</a></p>
 </section>
 </section>
 <div id="contributors">
-<section id="section-appendix.f">
+<section id="appendix-F">
       <h2 id="name-contributors">
 <a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<p id="section-appendix.f-1">
-    Foo bar.<a href="#section-appendix.f-1" class="pilcrow">¶</a></p>
+<p id="appendix-F-1">
+    Foo bar.<a href="#appendix-F-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-appendix.g">
+<section id="appendix-G">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.g-1">
+<p id="appendix-G-1">
         <a href="#rfc.index.u36" class="xref">$</a>
         <a href="#rfc.index.u37" class="xref">%</a>
         <a href="#rfc.index.u91" class="xref">[</a>
@@ -5083,147 +5083,147 @@ foo = bar
         <a href="#rfc.index.u66" class="xref">B</a>
         <a href="#rfc.index.u77" class="xref">M</a>
         <a href="#rfc.index.u82" class="xref">R</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.g-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-G-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.g-2.1">
+<li class="ulEmpty normal" id="appendix-G-2.1">
           <div id="rfc.index.u36">
-<p id="section-appendix.g-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u36" class="xref">$</a><a href="#section-appendix.g-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u36" class="xref">$</a><a href="#appendix-G-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.1.2.1.1">
-                <dt id="section-appendix.g-2.1.2.1.1.1">$Dollar item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.1.2.1.1.2">
-                  <p id="section-appendix.g-2.1.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.1.2.1.1">
+                <dt id="appendix-G-2.1.2.1.1.1">$Dollar item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.1.2.1.1.2">
+                  <p id="appendix-G-2.1.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.2">
+        <li class="ulEmpty normal" id="appendix-G-2.2">
           <div id="rfc.index.u37">
-<p id="section-appendix.g-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u37" class="xref">%</a><a href="#section-appendix.g-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u37" class="xref">%</a><a href="#appendix-G-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.2.2.1.1">
-                <dt id="section-appendix.g-2.2.2.1.1.1">%</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.2.2.1.1.2">
-                  <p id="section-appendix.g-2.2.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.2.2.1.1">
+                <dt id="appendix-G-2.2.2.1.1.1">%</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.2.2.1.1.2">
+                  <p id="appendix-G-2.2.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.3">
+        <li class="ulEmpty normal" id="appendix-G-2.3">
           <div id="rfc.index.u91">
-<p id="section-appendix.g-2.3.1" class="keepWithNext">
-            <a href="#rfc.index.u91" class="xref">[</a><a href="#section-appendix.g-2.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.3.1" class="keepWithNext">
+            <a href="#rfc.index.u91" class="xref">[</a><a href="#appendix-G-2.3.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.3.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.3.2.1.1">
-                <dt id="section-appendix.g-2.3.2.1.1.1">[Bracket item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.3.2.1.1.2">
-                  <p id="section-appendix.g-2.3.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.3.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.3.2.1.1">
+                <dt id="appendix-G-2.3.2.1.1.1">[Bracket item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.3.2.1.1.2">
+                  <p id="appendix-G-2.3.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.4">
+        <li class="ulEmpty normal" id="appendix-G-2.4">
           <div id="rfc.index.u92">
-<p id="section-appendix.g-2.4.1" class="keepWithNext">
-            <a href="#rfc.index.u92" class="xref">\</a><a href="#section-appendix.g-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.4.1" class="keepWithNext">
+            <a href="#rfc.index.u92" class="xref">\</a><a href="#appendix-G-2.4.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.4.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.4.2.1.1">
-                <dt id="section-appendix.g-2.4.2.1.1.1">\Backslash item</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.4.2.1.1.2">
-                  <p id="section-appendix.g-2.4.2.1.1.2.1">
-                    <a href="#section-appendix.a-3" class="xref">Section Appendix.A, Paragraph 3</a><a href="#section-appendix.g-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.4.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.4.2.1.1">
+                <dt id="appendix-G-2.4.2.1.1.1">\Backslash item</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.4.2.1.1.2">
+                  <p id="appendix-G-2.4.2.1.1.2.1">
+                    <a href="#appendix-A-3" class="xref">Appendix A, Paragraph 3</a><a href="#appendix-G-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.5">
+        <li class="ulEmpty normal" id="appendix-G-2.5">
           <div id="rfc.index.u66">
-<p id="section-appendix.g-2.5.1" class="keepWithNext">
-            <a href="#rfc.index.u66" class="xref">B</a><a href="#section-appendix.g-2.5.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.5.1" class="keepWithNext">
+            <a href="#rfc.index.u66" class="xref">B</a><a href="#appendix-G-2.5.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.5.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.5.2.1.1">
-                <dt id="section-appendix.g-2.5.2.1.1.1">Bare Table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.5.2.1.1.2">
-                  <p id="section-appendix.g-2.5.2.1.1.2.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.g-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.5.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.5.2.1.1">
+                <dt id="appendix-G-2.5.2.1.1.1">Bare Table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.5.2.1.1.2">
+                  <p id="appendix-G-2.5.2.1.1.2.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-G-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.6">
+        <li class="ulEmpty normal" id="appendix-G-2.6">
           <div id="rfc.index.u77">
-<p id="section-appendix.g-2.6.1" class="keepWithNext">
-            <a href="#rfc.index.u77" class="xref">M</a><a href="#section-appendix.g-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.6.1" class="keepWithNext">
+            <a href="#rfc.index.u77" class="xref">M</a><a href="#appendix-G-2.6.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.6.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.6.2.1.1">
-                <dt id="section-appendix.g-2.6.2.1.1.1">Markup in titles</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.6.2.1.1.2">
-                  <p id="section-appendix.g-2.6.2.1.1.2.1">
-                    <a href="#section-2" class="xref">Section 2</a><a href="#section-appendix.g-2.6.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.6.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.6.2.1.1">
+                <dt id="appendix-G-2.6.2.1.1.1">Markup in titles</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.6.2.1.1.2">
+                  <p id="appendix-G-2.6.2.1.1.2.1">
+                    <a href="#section-2" class="xref">Section 2</a><a href="#appendix-G-2.6.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.7">
+        <li class="ulEmpty normal" id="appendix-G-2.7">
           <div id="rfc.index.u82">
-<p id="section-appendix.g-2.7.1" class="keepWithNext">
-            <a href="#rfc.index.u82" class="xref">R</a><a href="#section-appendix.g-2.7.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.7.1" class="keepWithNext">
+            <a href="#rfc.index.u82" class="xref">R</a><a href="#appendix-G-2.7.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.7.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.7.2.1.1">
-                <dt id="section-appendix.g-2.7.2.1.1.1">Reference renaming</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.7.2.1.1.2">
-                  <p id="section-appendix.g-2.7.2.1.1.2.1">
-                    <a href="#section-3" class="xref">Section 3</a><a href="#section-appendix.g-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.7.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.7.2.1.1">
+                <dt id="appendix-G-2.7.2.1.1.1">Reference renaming</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.7.2.1.1.2">
+                  <p id="appendix-G-2.7.2.1.1.2.1">
+                    <a href="#section-3" class="xref">Section 3</a><a href="#appendix-G-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.g-2.8">
+        <li class="ulEmpty normal" id="appendix-G-2.8">
           <div id="rfc.index.u84">
-<p id="section-appendix.g-2.8.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.g-2.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-G-2.8.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-G-2.8.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.g-2.8.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.g-2.8.2.1.1">
-                <dt id="section-appendix.g-2.8.2.1.1.1">Text Styles</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.g-2.8.2.1.1.2">
-                  <p id="section-appendix.g-2.8.2.1.1.2.1">
-                    <a href="#section-1" class="xref">Section 1</a><a href="#section-appendix.g-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-G-2.8.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-G-2.8.2.1.1">
+                <dt id="appendix-G-2.8.2.1.1.1">Text Styles</dt>
+                <dd style="margin-left: 1.5em" id="appendix-G-2.8.2.1.1.2">
+                  <p id="appendix-G-2.8.2.1.1.2.1">
+                    <a href="#section-1" class="xref">Section 1</a><a href="#appendix-G-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
@@ -5233,7 +5233,7 @@ foo = bar
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.h">
+<section id="appendix-H">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/elements.prepped.xml
+++ b/cli/tests/valid/elements.prepped.xml
@@ -235,10 +235,10 @@
             <t indent="0" pn="section-toc.1-1.19.1"><xref derivedContent="Appendix A" format="default" sectionFormat="of" target="section-appendix.a"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-some-back-matter">Some Back Matter</xref></t>
             <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.19.2">
               <li pn="section-toc.1-1.19.2.1">
-                <t indent="0" pn="section-toc.1-1.19.2.1.1"><xref derivedContent="A.1" format="counter" sectionFormat="of" target="section-a.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-contributors">Contributors</xref></t>
+                <t indent="0" pn="section-toc.1-1.19.2.1.1"><xref derivedContent="A.1" format="counter" sectionFormat="of" target="section-appendix.a.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-contributors">Contributors</xref></t>
               </li>
               <li pn="section-toc.1-1.19.2.2">
-                <t indent="0" pn="section-toc.1-1.19.2.2.1"><xref derivedContent="A.2" format="counter" sectionFormat="of" target="section-a.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-arbitrary-superscript-in-se">Arbitrary<sup>superscript</sup> in section <em>title</em></xref></t>
+                <t indent="0" pn="section-toc.1-1.19.2.2.1"><xref derivedContent="A.2" format="counter" sectionFormat="of" target="section-appendix.a.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-arbitrary-superscript-in-se">Arbitrary<sup>superscript</sup> in section <em>title</em></xref></t>
               </li>
             </ul>
           </li>
@@ -1777,9 +1777,9 @@ for opt, value in opts:
 
             <cref display="true"> This is a long comment line which extends well beyond the 72-character page width. </cref>
       </t>
-      <section numbered="true" removeInRFC="false" toc="include" pn="section-a.1">
+      <section numbered="true" removeInRFC="false" toc="include" pn="section-appendix.a.1">
         <name slugifiedName="name-contributors">Contributors</name>
-        <t indent="0" pn="section-a.1-1">We'd like to thank these contributors:</t>
+        <t indent="0" pn="section-appendix.a.1-1">We'd like to thank these contributors:</t>
         <contact asciiFullname="Roni Even" fullname="רוני אבן">
           <organization ascii="Huawei" showOnFrontPage="true">וואווי</organization>
           <address>
@@ -1792,14 +1792,14 @@ for opt, value in opts:
             <email/>
           </address>
         </contact>
-        <t indent="0" pn="section-a.1-2">
+        <t indent="0" pn="section-appendix.a.1-2">
                Reviews and helpful comments have also been received from
                <contact asciiFullname="Ana Kikabidze" fullname="ანა კიკაბიძე"/>.
         </t>
       </section>
-      <section numbered="true" removeInRFC="false" toc="include" pn="section-a.2">
+      <section numbered="true" removeInRFC="false" toc="include" pn="section-appendix.a.2">
         <name slugifiedName="name-arbitrary-superscript-in-se">Arbitrary<sup>superscript</sup> in section <em>title</em></name>
-        <t indent="0" pn="section-a.2-1">Arbitrary text</t>
+        <t indent="0" pn="section-appendix.a.2-1">Arbitrary text</t>
       </section>
     </section>
     <section anchor="authors-addresses" numbered="false" removeInRFC="false" toc="include" pn="section-appendix.b">

--- a/cli/tests/valid/elements.v3.py36.html
+++ b/cli/tests/valid/elements.v3.py36.html
@@ -230,18 +230,18 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-some-back-matter" class="xref">Some Back Matter</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-some-back-matter" class="xref">Some Back Matter</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.19.2.1">
-                <p id="section-toc.1-1.19.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
+                <p id="section-toc.1-1.19.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.19.2.2">
-                <p id="section-toc.1-1.19.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-arbitrary-superscript-in-se" class="xref">Arbitrary<sup>superscript</sup> in section <em>title</em></a></p>
+                <p id="section-toc.1-1.19.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-arbitrary-superscript-in-se" class="xref">Arbitrary<sup>superscript</sup> in section <em>title</em></a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1763,11 +1763,11 @@ for opt, value in opts:
 </section>
 </div>
 <div id="back-matter">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-some-back-matter">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-some-back-matter" class="section-name selfRef">Some Back Matter</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-some-back-matter" class="section-name selfRef">Some Back Matter</a>
       </h2>
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
 
             Fusce viverra ipsum tempor finibus pharetra. Vestibulum fermentum
             porta neque et maximus. Aliquam tristique nibh in neque aliquam
@@ -1778,12 +1778,12 @@ for opt, value in opts:
             at ligula nec magna molestie eleifend: <br>
         <span class="contact-name"><span class="non-ascii">トヨタ 自動車 株式会社</span> (<span class="ascii">Toyota Jidōsha KK</span>)</span>.
 
-            <span class="cref"> This is a long comment line which extends well beyond the 72-character page width. </span><a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<section id="section-a.1">
-        <h2 id="name-contributors">
-<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
-        </h2>
-<p id="section-a.1-1">We'd like to thank these contributors:<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+            <span class="cref"> This is a long comment line which extends well beyond the 72-character page width. </span><a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.1">
+        <h3 id="name-contributors">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
+        </h3>
+<p id="appendix-A.1-1">We'd like to thank these contributors:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <address class="vcard">
           <div class="ascii">
 <div dir="auto" class="left"><span class="fn nameRole">Roni Even</span></div>
@@ -1805,20 +1805,20 @@ for opt, value in opts:
 <div dir="auto" class="right"><span class="country-name">ישראל</span></div>
 </div>
 </address>
-<p id="section-a.1-2">
+<p id="appendix-A.1-2">
                Reviews and helpful comments have also been received from
-               <span class="contact-name"><span class="non-ascii">ანა კიკაბიძე</span> (<span class="ascii">Ana Kikabidze</span>)</span>.<a href="#section-a.1-2" class="pilcrow">¶</a></p>
+               <span class="contact-name"><span class="non-ascii">ანა კიკაბიძე</span> (<span class="ascii">Ana Kikabidze</span>)</span>.<a href="#appendix-A.1-2" class="pilcrow">¶</a></p>
 </section>
-<section id="section-a.2">
-        <h2 id="name-arbitrary-superscript-in-se">
-<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-arbitrary-superscript-in-se" class="section-name selfRef">Arbitrary<sup>superscript</sup> in section <em>title</em></a>
-        </h2>
-<p id="section-a.2-1">Arbitrary text<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.2">
+        <h3 id="name-arbitrary-superscript-in-se">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-arbitrary-superscript-in-se" class="section-name selfRef">Arbitrary<sup>superscript</sup> in section <em>title</em></a>
+        </h3>
+<p id="appendix-A.2-1">Arbitrary text<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
 </section>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/elements.v3.py37.html
+++ b/cli/tests/valid/elements.v3.py37.html
@@ -230,18 +230,18 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-some-back-matter" class="xref">Some Back Matter</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-some-back-matter" class="xref">Some Back Matter</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.19.2.1">
-                <p id="section-toc.1-1.19.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
+                <p id="section-toc.1-1.19.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.19.2.2">
-                <p id="section-toc.1-1.19.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-arbitrary-superscript-in-se" class="xref">Arbitrary<sup>superscript</sup> in section <em>title</em></a></p>
+                <p id="section-toc.1-1.19.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-arbitrary-superscript-in-se" class="xref">Arbitrary<sup>superscript</sup> in section <em>title</em></a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1763,11 +1763,11 @@ for opt, value in opts:
 </section>
 </div>
 <div id="back-matter">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-some-back-matter">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-some-back-matter" class="section-name selfRef">Some Back Matter</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-some-back-matter" class="section-name selfRef">Some Back Matter</a>
       </h2>
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
 
             Fusce viverra ipsum tempor finibus pharetra. Vestibulum fermentum
             porta neque et maximus. Aliquam tristique nibh in neque aliquam
@@ -1778,12 +1778,12 @@ for opt, value in opts:
             at ligula nec magna molestie eleifend: <br>
         <span class="contact-name"><span class="non-ascii">トヨタ 自動車 株式会社</span> (<span class="ascii">Toyota Jidōsha KK</span>)</span>.
 
-            <span class="cref"> This is a long comment line which extends well beyond the 72-character page width. </span><a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<section id="section-a.1">
-        <h2 id="name-contributors">
-<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
-        </h2>
-<p id="section-a.1-1">We'd like to thank these contributors:<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+            <span class="cref"> This is a long comment line which extends well beyond the 72-character page width. </span><a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.1">
+        <h3 id="name-contributors">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
+        </h3>
+<p id="appendix-A.1-1">We'd like to thank these contributors:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <address class="vcard">
           <div class="ascii">
 <div dir="auto" class="left"><span class="fn nameRole">Roni Even</span></div>
@@ -1805,20 +1805,20 @@ for opt, value in opts:
 <div dir="auto" class="right"><span class="country-name">ישראל</span></div>
 </div>
 </address>
-<p id="section-a.1-2">
+<p id="appendix-A.1-2">
                Reviews and helpful comments have also been received from
-               <span class="contact-name"><span class="non-ascii">ანა კიკაბიძე</span> (<span class="ascii">Ana Kikabidze</span>)</span>.<a href="#section-a.1-2" class="pilcrow">¶</a></p>
+               <span class="contact-name"><span class="non-ascii">ანა კიკაბიძე</span> (<span class="ascii">Ana Kikabidze</span>)</span>.<a href="#appendix-A.1-2" class="pilcrow">¶</a></p>
 </section>
-<section id="section-a.2">
-        <h2 id="name-arbitrary-superscript-in-se">
-<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-arbitrary-superscript-in-se" class="section-name selfRef">Arbitrary<sup>superscript</sup> in section <em>title</em></a>
-        </h2>
-<p id="section-a.2-1">Arbitrary text<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.2">
+        <h3 id="name-arbitrary-superscript-in-se">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-arbitrary-superscript-in-se" class="section-name selfRef">Arbitrary<sup>superscript</sup> in section <em>title</em></a>
+        </h3>
+<p id="appendix-A.2-1">Arbitrary text<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
 </section>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/elements.v3.py38.html
+++ b/cli/tests/valid/elements.v3.py38.html
@@ -230,18 +230,18 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-some-back-matter" class="xref">Some Back Matter</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-some-back-matter" class="xref">Some Back Matter</a></p>
 <ul class="ulEmpty compact toc">
 <li class="ulEmpty compact toc" id="section-toc.1-1.19.2.1">
-                <p id="section-toc.1-1.19.2.1.1"><a href="#section-a.1" class="xref">A.1</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
+                <p id="section-toc.1-1.19.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
               <li class="ulEmpty compact toc" id="section-toc.1-1.19.2.2">
-                <p id="section-toc.1-1.19.2.2.1"><a href="#section-a.2" class="xref">A.2</a>.  <a href="#name-arbitrary-superscript-in-se" class="xref">Arbitrary<sup>superscript</sup> in section <em>title</em></a></p>
+                <p id="section-toc.1-1.19.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-arbitrary-superscript-in-se" class="xref">Arbitrary<sup>superscript</sup> in section <em>title</em></a></p>
 </li>
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1763,11 +1763,11 @@ for opt, value in opts:
 </section>
 </div>
 <div id="back-matter">
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-some-back-matter">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-some-back-matter" class="section-name selfRef">Some Back Matter</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-some-back-matter" class="section-name selfRef">Some Back Matter</a>
       </h2>
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
 
             Fusce viverra ipsum tempor finibus pharetra. Vestibulum fermentum
             porta neque et maximus. Aliquam tristique nibh in neque aliquam
@@ -1778,12 +1778,12 @@ for opt, value in opts:
             at ligula nec magna molestie eleifend: <br>
         <span class="contact-name"><span class="non-ascii">トヨタ 自動車 株式会社</span> (<span class="ascii">Toyota Jidōsha KK</span>)</span>.
 
-            <span class="cref"> This is a long comment line which extends well beyond the 72-character page width. </span><a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<section id="section-a.1">
-        <h2 id="name-contributors">
-<a href="#section-a.1" class="section-number selfRef">A.1. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
-        </h2>
-<p id="section-a.1-1">We'd like to thank these contributors:<a href="#section-a.1-1" class="pilcrow">¶</a></p>
+            <span class="cref"> This is a long comment line which extends well beyond the 72-character page width. </span><a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.1">
+        <h3 id="name-contributors">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
+        </h3>
+<p id="appendix-A.1-1">We'd like to thank these contributors:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
 <address class="vcard">
           <div class="ascii">
 <div dir="auto" class="left"><span class="fn nameRole">Roni Even</span></div>
@@ -1805,20 +1805,20 @@ for opt, value in opts:
 <div dir="auto" class="right"><span class="country-name">ישראל</span></div>
 </div>
 </address>
-<p id="section-a.1-2">
+<p id="appendix-A.1-2">
                Reviews and helpful comments have also been received from
-               <span class="contact-name"><span class="non-ascii">ანა კიკაბიძე</span> (<span class="ascii">Ana Kikabidze</span>)</span>.<a href="#section-a.1-2" class="pilcrow">¶</a></p>
+               <span class="contact-name"><span class="non-ascii">ანა კიკაბიძე</span> (<span class="ascii">Ana Kikabidze</span>)</span>.<a href="#appendix-A.1-2" class="pilcrow">¶</a></p>
 </section>
-<section id="section-a.2">
-        <h2 id="name-arbitrary-superscript-in-se">
-<a href="#section-a.2" class="section-number selfRef">A.2. </a><a href="#name-arbitrary-superscript-in-se" class="section-name selfRef">Arbitrary<sup>superscript</sup> in section <em>title</em></a>
-        </h2>
-<p id="section-a.2-1">Arbitrary text<a href="#section-a.2-1" class="pilcrow">¶</a></p>
+<section id="appendix-A.2">
+        <h3 id="name-arbitrary-superscript-in-se">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-arbitrary-superscript-in-se" class="section-name selfRef">Arbitrary<sup>superscript</sup> in section <em>title</em></a>
+        </h3>
+<p id="appendix-A.2-1">Arbitrary text<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
 </section>
 </section>
 </div>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/indexes.pages.text
+++ b/cli/tests/valid/indexes.pages.text
@@ -110,6 +110,7 @@ Index
 
 
 Person                  Expires November 12, 2021               [Page 2]
+Person                  Expires November 1, 2021                [Page 2]
 
 Internet-Draft             xml2rfc index tests                  May 2021
 
@@ -166,3 +167,4 @@ Author's Address
 
 
 Person                  Expires November 12, 2021               [Page 3]
+Person                  Expires November 1, 2021                [Page 3]

--- a/cli/tests/valid/indexes.pages.text
+++ b/cli/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              June 7, 2021
+Internet-Draft                                              June 8, 2021
 Intended status: Experimental                                           
-Expires: December 9, 2021
+Expires: December 10, 2021
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 9, 2021.
+   This Internet-Draft will expire on December 10, 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Person                  Expires December 9, 2021                [Page 1]
+Person                  Expires December 10, 2021                [Page 1]
 
 Internet-Draft             xml2rfc index tests                 June 2021
 
@@ -109,7 +109,7 @@ Index
 
 
 
-Person                  Expires December 9, 2021                [Page 2]
+Person                  Expires December 10, 2021                [Page 2]
 
 Internet-Draft             xml2rfc index tests                 June 2021
 
@@ -165,4 +165,4 @@ Author's Address
 
 
 
-Person                  Expires December 9, 2021                [Page 3]
+Person                  Expires December 10, 2021                [Page 3]

--- a/cli/tests/valid/indexes.pages.text
+++ b/cli/tests/valid/indexes.pages.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              May 11, 2021
+Internet-Draft                                              June 7, 2021
 Intended status: Experimental                                           
-Expires: November 12, 2021
+Expires: December 9, 2021
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 12, 2021.
+   This Internet-Draft will expire on December 9, 2021.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Person                  Expires November 12, 2021               [Page 1]
+Person                  Expires December 9, 2021                [Page 1]
 
-Internet-Draft             xml2rfc index tests                  May 2021
+Internet-Draft             xml2rfc index tests                 June 2021
 
 
    This is another section!
@@ -109,10 +109,9 @@ Index
 
 
 
-Person                  Expires November 12, 2021               [Page 2]
-Person                  Expires November 1, 2021                [Page 2]
+Person                  Expires December 9, 2021                [Page 2]
 
-Internet-Draft             xml2rfc index tests                  May 2021
+Internet-Draft             xml2rfc index tests                 June 2021
 
 
          em  Section 1, Paragraph 1
@@ -166,5 +165,4 @@ Author's Address
 
 
 
-Person                  Expires November 12, 2021               [Page 3]
-Person                  Expires November 1, 2021                [Page 3]
+Person                  Expires December 9, 2021                [Page 3]

--- a/cli/tests/valid/indexes.prepped.xml
+++ b/cli/tests/valid/indexes.prepped.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2021-06-07T14:03:32" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2021-06-08T13:33:27" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
   <!-- xml2rfc v2v3 conversion 3.8.0 -->
   
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="07" month="06" year="2021"/>
+    <date day="08" month="06" year="2021"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 9 December 2021.
+        This Internet-Draft will expire on 10 December 2021.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/cli/tests/valid/indexes.prepped.xml
+++ b/cli/tests/valid/indexes.prepped.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2021-05-11T15:18:30" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
-  <!-- xml2rfc v2v3 conversion 3.7.0 -->
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="exp" docName="indexes-00" indexInclude="true" ipr="trust200902" prepTime="2021-06-07T14:03:32" scripts="Common,Latin" sortRefs="true" submissionType="independent" symRefs="true" tocDepth="3" tocInclude="true">
+  <!-- xml2rfc v2v3 conversion 3.8.0 -->
   
     
     
@@ -20,7 +20,7 @@
         </postal>
       </address>
     </author>
-    <date day="11" month="05" year="2021"/>
+    <date day="07" month="06" year="2021"/>
     <boilerplate>
       <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
         <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
@@ -41,7 +41,7 @@
         material or to cite them other than as "work in progress."
         </t>
         <t indent="0" pn="section-boilerplate.1-4">
-        This Internet-Draft will expire on 12 November 2021.
+        This Internet-Draft will expire on 9 December 2021.
         </t>
       </section>
       <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">

--- a/cli/tests/valid/indexes.text
+++ b/cli/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              May 11, 2021
+Internet-Draft                                              June 7, 2021
 Intended status: Experimental                                           
-Expires: November 12, 2021
+Expires: December 9, 2021
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 12, 2021.
+   This Internet-Draft will expire on December 9, 2021.
 
 Copyright Notice
 

--- a/cli/tests/valid/indexes.text
+++ b/cli/tests/valid/indexes.text
@@ -3,9 +3,9 @@
 
 
 Network Working Group                                     H. Person, Ed.
-Internet-Draft                                              June 7, 2021
+Internet-Draft                                              June 8, 2021
 Intended status: Experimental                                           
-Expires: December 9, 2021
+Expires: December 10, 2021
 
 
                           xml2rfc index tests
@@ -26,7 +26,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 9, 2021.
+   This Internet-Draft will expire on December 10, 2021.
 
 Copyright Notice
 

--- a/cli/tests/valid/indexes.v3.py36.html
+++ b/cli/tests/valid/indexes.v3.py36.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.7.0" name="generator">
+<meta content="xml2rfc 3.8.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">May 2021</td>
+<td class="right">June 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 12, 2021</td>
+<td class="center">Expires December 9, 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-05-11" class="published">May 11, 2021</time>
+<time datetime="2021-06-07" class="published">June 7, 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-11-12">November 12, 2021</time></dd>
+<dd class="expires"><time datetime="2021-12-09">December 9, 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 12, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 9, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/cli/tests/valid/indexes.v3.py36.html
+++ b/cli/tests/valid/indexes.v3.py36.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 9, 2021</td>
+<td class="center">Expires December 10, 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-06-07" class="published">June 7, 2021</time>
+<time datetime="2021-06-08" class="published">June 8, 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-12-09">December 9, 2021</time></dd>
+<dd class="expires"><time datetime="2021-12-10">December 10, 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 9, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 10, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/cli/tests/valid/indexes.v3.py36.html
+++ b/cli/tests/valid/indexes.v3.py36.html
@@ -104,10 +104,10 @@
             <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-references" class="xref">References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-appendix.a" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#appendix-A" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -225,12 +225,12 @@
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
         <a href="#rfc.index.u65" class="xref">A</a>
         <a href="#rfc.index.u66" class="xref">B</a>
         <a href="#rfc.index.u68" class="xref">D</a>
@@ -238,30 +238,30 @@
         <a href="#rfc.index.u70" class="xref">F</a>
         <a href="#rfc.index.u76" class="xref">L</a>
         <a href="#rfc.index.u83" class="xref">S</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.a-2.1">
+<li class="ulEmpty normal" id="appendix-A-2.1">
           <div id="rfc.index.u65">
-<p id="section-appendix.a-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u65" class="xref">A</a><a href="#section-appendix.a-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u65" class="xref">A</a><a href="#appendix-A-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.1.2.1.1">
-                <dt id="section-appendix.a-2.1.2.1.1.1">annotation</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.2">
-                  <p id="section-appendix.a-2.1.2.1.1.2.1">
-                    <span><a href="#ref0" class="xref">Reference</a> [<a href="#ref0" class="xref">ref0</a>]</span><a href="#section-appendix.a-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.1.2.1.1">
+                <dt id="appendix-A-2.1.2.1.1.1">annotation</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.2">
+                  <p id="appendix-A-2.1.2.1.1.2.1">
+                    <span><a href="#ref0" class="xref">Reference</a> [<a href="#ref0" class="xref">ref0</a>]</span><a href="#appendix-A-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.1.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.1.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.1.2.1.1.4.1.1">in reference group</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.1.2.1.1.4.1.2.1">
-                        <span><a href="#refgroup0" class="xref">Reference</a> [<a href="#refgroup0" class="xref">refgroup0</a>]</span><a href="#section-appendix.a-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.1.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.1.2.1.1.4.1">
+                    <dt id="appendix-A-2.1.2.1.1.4.1.1">in reference group</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.4.1.2">
+                      <p id="appendix-A-2.1.2.1.1.4.1.2.1">
+                        <span><a href="#refgroup0" class="xref">Reference</a> [<a href="#refgroup0" class="xref">refgroup0</a>]</span><a href="#appendix-A-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -271,108 +271,108 @@
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.2">
+        <li class="ulEmpty normal" id="appendix-A-2.2">
           <div id="rfc.index.u66">
-<p id="section-appendix.a-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u66" class="xref">B</a><a href="#section-appendix.a-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u66" class="xref">B</a><a href="#appendix-A-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.2.2.1.1">
-                <dt id="section-appendix.a-2.2.2.1.1.1">blockquote</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.2.2.1.1.2">
-                  <p id="section-appendix.a-2.2.2.1.1.2.1">
-                    <a href="#section-1-7" class="xref">Section 1</a><a href="#section-appendix.a-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.2.2.1.1">
+                <dt id="appendix-A-2.2.2.1.1.1">blockquote</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.2.2.1.1.2">
+                  <p id="appendix-A-2.2.2.1.1.2.1">
+                    <a href="#section-1-7" class="xref">Section 1</a><a href="#appendix-A-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.3">
+        <li class="ulEmpty normal" id="appendix-A-2.3">
           <div id="rfc.index.u68">
-<p id="section-appendix.a-2.3.1" class="keepWithNext">
-            <a href="#rfc.index.u68" class="xref">D</a><a href="#section-appendix.a-2.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.3.1" class="keepWithNext">
+            <a href="#rfc.index.u68" class="xref">D</a><a href="#appendix-A-2.3.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.3.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.3.2.1.1">
-                <dt id="section-appendix.a-2.3.2.1.1.1">dd</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.3.2.1.1.2">
-                  <p id="section-appendix.a-2.3.2.1.1.2.1">
-                    <a href="#section-1-3.2" class="xref">Section 1</a><a href="#section-appendix.a-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.3.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.3.2.1.1">
+                <dt id="appendix-A-2.3.2.1.1.1">dd</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.3.2.1.1.2">
+                  <p id="appendix-A-2.3.2.1.1.2.1">
+                    <a href="#section-1-3.2" class="xref">Section 1</a><a href="#appendix-A-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.3.2.1.1.3">dt</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.3.2.1.1.4">
-                  <p id="section-appendix.a-2.3.2.1.1.4.1">
-                    <a href="#section-1-3.1" class="xref">Section 1</a><a href="#section-appendix.a-2.3.2.1.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.3.2.1.1.3">dt</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.3.2.1.1.4">
+                  <p id="appendix-A-2.3.2.1.1.4.1">
+                    <a href="#section-1-3.1" class="xref">Section 1</a><a href="#appendix-A-2.3.2.1.1.4.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.4">
+        <li class="ulEmpty normal" id="appendix-A-2.4">
           <div id="rfc.index.u69">
-<p id="section-appendix.a-2.4.1" class="keepWithNext">
-            <a href="#rfc.index.u69" class="xref">E</a><a href="#section-appendix.a-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.4.1" class="keepWithNext">
+            <a href="#rfc.index.u69" class="xref">E</a><a href="#appendix-A-2.4.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.4.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.4.2.1.1">
-                <dt id="section-appendix.a-2.4.2.1.1.1">em</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.4.2.1.1.2">
-                  <p id="section-appendix.a-2.4.2.1.1.2.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.4.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.4.2.1.1">
+                <dt id="appendix-A-2.4.2.1.1.1">em</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.4.2.1.1.2">
+                  <p id="appendix-A-2.4.2.1.1.2.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.5">
+        <li class="ulEmpty normal" id="appendix-A-2.5">
           <div id="rfc.index.u70">
-<p id="section-appendix.a-2.5.1" class="keepWithNext">
-            <a href="#rfc.index.u70" class="xref">F</a><a href="#section-appendix.a-2.5.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.5.1" class="keepWithNext">
+            <a href="#rfc.index.u70" class="xref">F</a><a href="#appendix-A-2.5.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.5.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.5.2.1.1">
-                <dt id="section-appendix.a-2.5.2.1.1.1">figure</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.5.2.1.1.2">
-                  <p id="section-appendix.a-2.5.2.1.1.2.1">
-                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#section-appendix.a-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.5.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.5.2.1.1">
+                <dt id="appendix-A-2.5.2.1.1.1">figure</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.5.2.1.1.2">
+                  <p id="appendix-A-2.5.2.1.1.2.1">
+                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#appendix-A-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.6">
+        <li class="ulEmpty normal" id="appendix-A-2.6">
           <div id="rfc.index.u76">
-<p id="section-appendix.a-2.6.1" class="keepWithNext">
-            <a href="#rfc.index.u76" class="xref">L</a><a href="#section-appendix.a-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.6.1" class="keepWithNext">
+            <a href="#rfc.index.u76" class="xref">L</a><a href="#appendix-A-2.6.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.6.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.6.2.1.1">
-                <dt id="section-appendix.a-2.6.2.1.1.1">li</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-A-2.6.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.6.2.1.1">
+                <dt id="appendix-A-2.6.2.1.1.1">li</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.6.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.6.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.6.2.1.1.4.1.1">ol</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.6.2.1.1.4.1.2.1">
-                        <a href="#section-1-5.1" class="xref">Section 1, Paragraph 5, Item 1</a><a href="#section-appendix.a-2.6.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.6.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.6.2.1.1.4.1">
+                    <dt id="appendix-A-2.6.2.1.1.4.1.1">ol</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4.1.2">
+                      <p id="appendix-A-2.6.2.1.1.4.1.2.1">
+                        <a href="#section-1-5.1" class="xref">Section 1, Paragraph 5, Item 1</a><a href="#appendix-A-2.6.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.a-2.6.2.1.1.4.1.3">ul</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4.1.4">
-                      <p id="section-appendix.a-2.6.2.1.1.4.1.4.1">
-                        <a href="#section-1-4.1" class="xref">Section 1, Paragraph 4, Item 1</a><a href="#section-appendix.a-2.6.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.6.2.1.1.4.1.3">ul</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4.1.4">
+                      <p id="appendix-A-2.6.2.1.1.4.1.4.1">
+                        <a href="#section-1-4.1" class="xref">Section 1, Paragraph 4, Item 1</a><a href="#appendix-A-2.6.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -382,91 +382,91 @@
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.7">
+        <li class="ulEmpty normal" id="appendix-A-2.7">
           <div id="rfc.index.u83">
-<p id="section-appendix.a-2.7.1" class="keepWithNext">
-            <a href="#rfc.index.u83" class="xref">S</a><a href="#section-appendix.a-2.7.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.7.1" class="keepWithNext">
+            <a href="#rfc.index.u83" class="xref">S</a><a href="#appendix-A-2.7.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.7.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.7.2.1.1">
-                <dt id="section-appendix.a-2.7.2.1.1.1">section</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.2">
-                  <p id="section-appendix.a-2.7.2.1.1.2.1">
-                    <a href="#section-1" class="xref">Section 1</a><a href="#section-appendix.a-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.7.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.7.2.1.1">
+                <dt id="appendix-A-2.7.2.1.1.1">section</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.2">
+                  <p id="appendix-A-2.7.2.1.1.2.1">
+                    <a href="#section-1" class="xref">Section 1</a><a href="#appendix-A-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.3">strong</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.4">
-                  <p id="section-appendix.a-2.7.2.1.1.4.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.3">strong</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.4">
+                  <p id="appendix-A-2.7.2.1.1.4.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.5">sub</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.6">
-                  <p id="section-appendix.a-2.7.2.1.1.6.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.6.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.5">sub</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.6">
+                  <p id="appendix-A-2.7.2.1.1.6.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.6.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.7">sup</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.8">
-                  <p id="section-appendix.a-2.7.2.1.1.8.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.8.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.7">sup</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.8">
+                  <p id="appendix-A-2.7.2.1.1.8.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.8.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.8">
+        <li class="ulEmpty normal" id="appendix-A-2.8">
           <div id="rfc.index.u84">
-<p id="section-appendix.a-2.8.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.a-2.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.8.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-A-2.8.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.8.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.8.2.1.1">
-                <dt id="section-appendix.a-2.8.2.1.1.1">t</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.2">
-                  <p id="section-appendix.a-2.8.2.1.1.2.1">
+<li class="ulEmpty compact normal" id="appendix-A-2.8.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.8.2.1.1">
+                <dt id="appendix-A-2.8.2.1.1.1">t</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.2">
+                  <p id="appendix-A-2.8.2.1.1.2.1">
                     <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a>; 
-<a href="#section-1-2" class="xref">Section 1, Paragraph 2</a><a href="#section-appendix.a-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
+<a href="#section-1-2" class="xref">Section 1, Paragraph 2</a><a href="#appendix-A-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.8.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.8.2.1.1.4.1.1">in an aside tag</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.8.2.1.1.4.1.2.1">
-                        <a href="#section-1-6.1" class="xref">Section 1, Paragraph 6.1</a><a href="#section-appendix.a-2.8.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.8.2.1.1.4.1">
+                    <dt id="appendix-A-2.8.2.1.1.4.1.1">in an aside tag</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.4.1.2">
+                      <p id="appendix-A-2.8.2.1.1.4.1.2.1">
+                        <a href="#section-1-6.1" class="xref">Section 1, Paragraph 6.1</a><a href="#appendix-A-2.8.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.5">table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.6">
-                  <p id="section-appendix.a-2.8.2.1.1.6.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.a-2.8.2.1.1.6.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.5">table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.6">
+                  <p id="appendix-A-2.8.2.1.1.6.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-A-2.8.2.1.1.6.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.7">td</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.8">
-                  <p id="section-appendix.a-2.8.2.1.1.8.1">
-                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#section-appendix.a-2.8.2.1.1.8.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.7">td</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.8">
+                  <p id="appendix-A-2.8.2.1.1.8.1">
+                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#appendix-A-2.8.2.1.1.8.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.9">th</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.10">
-                  <p id="section-appendix.a-2.8.2.1.1.10.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.a-2.8.2.1.1.10.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.9">th</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.10">
+                  <p id="appendix-A-2.8.2.1.1.10.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-A-2.8.2.1.1.10.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.11">tt</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.12">
-                  <p id="section-appendix.a-2.8.2.1.1.12.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.8.2.1.1.12.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.11">tt</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.12">
+                  <p id="appendix-A-2.8.2.1.1.12.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.8.2.1.1.12.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
@@ -476,7 +476,7 @@
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/indexes.v3.py37.html
+++ b/cli/tests/valid/indexes.v3.py37.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.7.0" name="generator">
+<meta content="xml2rfc 3.8.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">May 2021</td>
+<td class="right">June 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 12, 2021</td>
+<td class="center">Expires December 9, 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-05-11" class="published">May 11, 2021</time>
+<time datetime="2021-06-07" class="published">June 7, 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-11-12">November 12, 2021</time></dd>
+<dd class="expires"><time datetime="2021-12-09">December 9, 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 12, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 9, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/cli/tests/valid/indexes.v3.py37.html
+++ b/cli/tests/valid/indexes.v3.py37.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 9, 2021</td>
+<td class="center">Expires December 10, 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-06-07" class="published">June 7, 2021</time>
+<time datetime="2021-06-08" class="published">June 8, 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-12-09">December 9, 2021</time></dd>
+<dd class="expires"><time datetime="2021-12-10">December 10, 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 9, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 10, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/cli/tests/valid/indexes.v3.py37.html
+++ b/cli/tests/valid/indexes.v3.py37.html
@@ -104,10 +104,10 @@
             <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-references" class="xref">References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-appendix.a" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#appendix-A" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -225,12 +225,12 @@
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
         <a href="#rfc.index.u65" class="xref">A</a>
         <a href="#rfc.index.u66" class="xref">B</a>
         <a href="#rfc.index.u68" class="xref">D</a>
@@ -238,30 +238,30 @@
         <a href="#rfc.index.u70" class="xref">F</a>
         <a href="#rfc.index.u76" class="xref">L</a>
         <a href="#rfc.index.u83" class="xref">S</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.a-2.1">
+<li class="ulEmpty normal" id="appendix-A-2.1">
           <div id="rfc.index.u65">
-<p id="section-appendix.a-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u65" class="xref">A</a><a href="#section-appendix.a-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u65" class="xref">A</a><a href="#appendix-A-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.1.2.1.1">
-                <dt id="section-appendix.a-2.1.2.1.1.1">annotation</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.2">
-                  <p id="section-appendix.a-2.1.2.1.1.2.1">
-                    <span><a href="#ref0" class="xref">Reference</a> [<a href="#ref0" class="xref">ref0</a>]</span><a href="#section-appendix.a-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.1.2.1.1">
+                <dt id="appendix-A-2.1.2.1.1.1">annotation</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.2">
+                  <p id="appendix-A-2.1.2.1.1.2.1">
+                    <span><a href="#ref0" class="xref">Reference</a> [<a href="#ref0" class="xref">ref0</a>]</span><a href="#appendix-A-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.1.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.1.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.1.2.1.1.4.1.1">in reference group</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.1.2.1.1.4.1.2.1">
-                        <span><a href="#refgroup0" class="xref">Reference</a> [<a href="#refgroup0" class="xref">refgroup0</a>]</span><a href="#section-appendix.a-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.1.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.1.2.1.1.4.1">
+                    <dt id="appendix-A-2.1.2.1.1.4.1.1">in reference group</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.4.1.2">
+                      <p id="appendix-A-2.1.2.1.1.4.1.2.1">
+                        <span><a href="#refgroup0" class="xref">Reference</a> [<a href="#refgroup0" class="xref">refgroup0</a>]</span><a href="#appendix-A-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -271,108 +271,108 @@
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.2">
+        <li class="ulEmpty normal" id="appendix-A-2.2">
           <div id="rfc.index.u66">
-<p id="section-appendix.a-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u66" class="xref">B</a><a href="#section-appendix.a-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u66" class="xref">B</a><a href="#appendix-A-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.2.2.1.1">
-                <dt id="section-appendix.a-2.2.2.1.1.1">blockquote</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.2.2.1.1.2">
-                  <p id="section-appendix.a-2.2.2.1.1.2.1">
-                    <a href="#section-1-7" class="xref">Section 1</a><a href="#section-appendix.a-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.2.2.1.1">
+                <dt id="appendix-A-2.2.2.1.1.1">blockquote</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.2.2.1.1.2">
+                  <p id="appendix-A-2.2.2.1.1.2.1">
+                    <a href="#section-1-7" class="xref">Section 1</a><a href="#appendix-A-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.3">
+        <li class="ulEmpty normal" id="appendix-A-2.3">
           <div id="rfc.index.u68">
-<p id="section-appendix.a-2.3.1" class="keepWithNext">
-            <a href="#rfc.index.u68" class="xref">D</a><a href="#section-appendix.a-2.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.3.1" class="keepWithNext">
+            <a href="#rfc.index.u68" class="xref">D</a><a href="#appendix-A-2.3.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.3.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.3.2.1.1">
-                <dt id="section-appendix.a-2.3.2.1.1.1">dd</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.3.2.1.1.2">
-                  <p id="section-appendix.a-2.3.2.1.1.2.1">
-                    <a href="#section-1-3.2" class="xref">Section 1</a><a href="#section-appendix.a-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.3.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.3.2.1.1">
+                <dt id="appendix-A-2.3.2.1.1.1">dd</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.3.2.1.1.2">
+                  <p id="appendix-A-2.3.2.1.1.2.1">
+                    <a href="#section-1-3.2" class="xref">Section 1</a><a href="#appendix-A-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.3.2.1.1.3">dt</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.3.2.1.1.4">
-                  <p id="section-appendix.a-2.3.2.1.1.4.1">
-                    <a href="#section-1-3.1" class="xref">Section 1</a><a href="#section-appendix.a-2.3.2.1.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.3.2.1.1.3">dt</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.3.2.1.1.4">
+                  <p id="appendix-A-2.3.2.1.1.4.1">
+                    <a href="#section-1-3.1" class="xref">Section 1</a><a href="#appendix-A-2.3.2.1.1.4.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.4">
+        <li class="ulEmpty normal" id="appendix-A-2.4">
           <div id="rfc.index.u69">
-<p id="section-appendix.a-2.4.1" class="keepWithNext">
-            <a href="#rfc.index.u69" class="xref">E</a><a href="#section-appendix.a-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.4.1" class="keepWithNext">
+            <a href="#rfc.index.u69" class="xref">E</a><a href="#appendix-A-2.4.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.4.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.4.2.1.1">
-                <dt id="section-appendix.a-2.4.2.1.1.1">em</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.4.2.1.1.2">
-                  <p id="section-appendix.a-2.4.2.1.1.2.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.4.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.4.2.1.1">
+                <dt id="appendix-A-2.4.2.1.1.1">em</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.4.2.1.1.2">
+                  <p id="appendix-A-2.4.2.1.1.2.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.5">
+        <li class="ulEmpty normal" id="appendix-A-2.5">
           <div id="rfc.index.u70">
-<p id="section-appendix.a-2.5.1" class="keepWithNext">
-            <a href="#rfc.index.u70" class="xref">F</a><a href="#section-appendix.a-2.5.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.5.1" class="keepWithNext">
+            <a href="#rfc.index.u70" class="xref">F</a><a href="#appendix-A-2.5.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.5.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.5.2.1.1">
-                <dt id="section-appendix.a-2.5.2.1.1.1">figure</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.5.2.1.1.2">
-                  <p id="section-appendix.a-2.5.2.1.1.2.1">
-                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#section-appendix.a-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.5.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.5.2.1.1">
+                <dt id="appendix-A-2.5.2.1.1.1">figure</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.5.2.1.1.2">
+                  <p id="appendix-A-2.5.2.1.1.2.1">
+                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#appendix-A-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.6">
+        <li class="ulEmpty normal" id="appendix-A-2.6">
           <div id="rfc.index.u76">
-<p id="section-appendix.a-2.6.1" class="keepWithNext">
-            <a href="#rfc.index.u76" class="xref">L</a><a href="#section-appendix.a-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.6.1" class="keepWithNext">
+            <a href="#rfc.index.u76" class="xref">L</a><a href="#appendix-A-2.6.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.6.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.6.2.1.1">
-                <dt id="section-appendix.a-2.6.2.1.1.1">li</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-A-2.6.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.6.2.1.1">
+                <dt id="appendix-A-2.6.2.1.1.1">li</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.6.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.6.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.6.2.1.1.4.1.1">ol</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.6.2.1.1.4.1.2.1">
-                        <a href="#section-1-5.1" class="xref">Section 1, Paragraph 5, Item 1</a><a href="#section-appendix.a-2.6.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.6.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.6.2.1.1.4.1">
+                    <dt id="appendix-A-2.6.2.1.1.4.1.1">ol</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4.1.2">
+                      <p id="appendix-A-2.6.2.1.1.4.1.2.1">
+                        <a href="#section-1-5.1" class="xref">Section 1, Paragraph 5, Item 1</a><a href="#appendix-A-2.6.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.a-2.6.2.1.1.4.1.3">ul</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4.1.4">
-                      <p id="section-appendix.a-2.6.2.1.1.4.1.4.1">
-                        <a href="#section-1-4.1" class="xref">Section 1, Paragraph 4, Item 1</a><a href="#section-appendix.a-2.6.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.6.2.1.1.4.1.3">ul</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4.1.4">
+                      <p id="appendix-A-2.6.2.1.1.4.1.4.1">
+                        <a href="#section-1-4.1" class="xref">Section 1, Paragraph 4, Item 1</a><a href="#appendix-A-2.6.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -382,91 +382,91 @@
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.7">
+        <li class="ulEmpty normal" id="appendix-A-2.7">
           <div id="rfc.index.u83">
-<p id="section-appendix.a-2.7.1" class="keepWithNext">
-            <a href="#rfc.index.u83" class="xref">S</a><a href="#section-appendix.a-2.7.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.7.1" class="keepWithNext">
+            <a href="#rfc.index.u83" class="xref">S</a><a href="#appendix-A-2.7.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.7.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.7.2.1.1">
-                <dt id="section-appendix.a-2.7.2.1.1.1">section</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.2">
-                  <p id="section-appendix.a-2.7.2.1.1.2.1">
-                    <a href="#section-1" class="xref">Section 1</a><a href="#section-appendix.a-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.7.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.7.2.1.1">
+                <dt id="appendix-A-2.7.2.1.1.1">section</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.2">
+                  <p id="appendix-A-2.7.2.1.1.2.1">
+                    <a href="#section-1" class="xref">Section 1</a><a href="#appendix-A-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.3">strong</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.4">
-                  <p id="section-appendix.a-2.7.2.1.1.4.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.3">strong</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.4">
+                  <p id="appendix-A-2.7.2.1.1.4.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.5">sub</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.6">
-                  <p id="section-appendix.a-2.7.2.1.1.6.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.6.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.5">sub</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.6">
+                  <p id="appendix-A-2.7.2.1.1.6.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.6.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.7">sup</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.8">
-                  <p id="section-appendix.a-2.7.2.1.1.8.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.8.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.7">sup</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.8">
+                  <p id="appendix-A-2.7.2.1.1.8.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.8.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.8">
+        <li class="ulEmpty normal" id="appendix-A-2.8">
           <div id="rfc.index.u84">
-<p id="section-appendix.a-2.8.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.a-2.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.8.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-A-2.8.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.8.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.8.2.1.1">
-                <dt id="section-appendix.a-2.8.2.1.1.1">t</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.2">
-                  <p id="section-appendix.a-2.8.2.1.1.2.1">
+<li class="ulEmpty compact normal" id="appendix-A-2.8.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.8.2.1.1">
+                <dt id="appendix-A-2.8.2.1.1.1">t</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.2">
+                  <p id="appendix-A-2.8.2.1.1.2.1">
                     <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a>; 
-<a href="#section-1-2" class="xref">Section 1, Paragraph 2</a><a href="#section-appendix.a-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
+<a href="#section-1-2" class="xref">Section 1, Paragraph 2</a><a href="#appendix-A-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.8.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.8.2.1.1.4.1.1">in an aside tag</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.8.2.1.1.4.1.2.1">
-                        <a href="#section-1-6.1" class="xref">Section 1, Paragraph 6.1</a><a href="#section-appendix.a-2.8.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.8.2.1.1.4.1">
+                    <dt id="appendix-A-2.8.2.1.1.4.1.1">in an aside tag</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.4.1.2">
+                      <p id="appendix-A-2.8.2.1.1.4.1.2.1">
+                        <a href="#section-1-6.1" class="xref">Section 1, Paragraph 6.1</a><a href="#appendix-A-2.8.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.5">table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.6">
-                  <p id="section-appendix.a-2.8.2.1.1.6.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.a-2.8.2.1.1.6.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.5">table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.6">
+                  <p id="appendix-A-2.8.2.1.1.6.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-A-2.8.2.1.1.6.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.7">td</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.8">
-                  <p id="section-appendix.a-2.8.2.1.1.8.1">
-                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#section-appendix.a-2.8.2.1.1.8.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.7">td</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.8">
+                  <p id="appendix-A-2.8.2.1.1.8.1">
+                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#appendix-A-2.8.2.1.1.8.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.9">th</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.10">
-                  <p id="section-appendix.a-2.8.2.1.1.10.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.a-2.8.2.1.1.10.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.9">th</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.10">
+                  <p id="appendix-A-2.8.2.1.1.10.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-A-2.8.2.1.1.10.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.11">tt</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.12">
-                  <p id="section-appendix.a-2.8.2.1.1.12.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.8.2.1.1.12.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.11">tt</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.12">
+                  <p id="appendix-A-2.8.2.1.1.12.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.8.2.1.1.12.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
@@ -476,7 +476,7 @@
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/indexes.v3.py38.html
+++ b/cli/tests/valid/indexes.v3.py38.html
@@ -6,7 +6,7 @@
 <meta content="initial-scale=1.0" name="viewport">
 <title>xml2rfc index tests</title>
 <meta content="Human Person" name="author">
-<meta content="xml2rfc 3.7.0" name="generator">
+<meta content="xml2rfc 3.8.0" name="generator">
 <meta content="indexes-00" name="ietf.draft">
 <link href="tests/input/indexes.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -19,11 +19,11 @@
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">xml2rfc index tests</td>
-<td class="right">May 2021</td>
+<td class="right">June 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires November 12, 2021</td>
+<td class="center">Expires December 9, 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-05-11" class="published">May 11, 2021</time>
+<time datetime="2021-06-07" class="published">June 7, 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-11-12">November 12, 2021</time></dd>
+<dd class="expires"><time datetime="2021-12-09">December 9, 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on November 12, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 9, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/cli/tests/valid/indexes.v3.py38.html
+++ b/cli/tests/valid/indexes.v3.py38.html
@@ -23,7 +23,7 @@
 </tr></thead>
 <tfoot><tr>
 <td class="left">Person</td>
-<td class="center">Expires December 9, 2021</td>
+<td class="center">Expires December 10, 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -36,12 +36,12 @@
 <dd class="internet-draft">indexes-00</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-06-07" class="published">June 7, 2021</time>
+<time datetime="2021-06-08" class="published">June 8, 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Experimental</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-12-09">December 9, 2021</time></dd>
+<dd class="expires"><time datetime="2021-12-10">December 10, 2021</time></dd>
 <dt class="label-authors">Author:</dt>
 <dd class="authors">
 <div class="author">
@@ -71,7 +71,7 @@
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on December 9, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on December 10, 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">

--- a/cli/tests/valid/indexes.v3.py38.html
+++ b/cli/tests/valid/indexes.v3.py38.html
@@ -104,10 +104,10 @@
             <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-references" class="xref">References</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-appendix.a" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#appendix-A" class="xref"></a><a href="#name-index" class="xref">Index</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-address" class="xref">Author's Address</a></p>
 </li>
         </ul>
 </nav>
@@ -225,12 +225,12 @@
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-index">
 <a href="#name-index" class="section-name selfRef">Index</a>
       </h2>
 <div id="rfc.index.index">
-<p id="section-appendix.a-1">
+<p id="appendix-A-1">
         <a href="#rfc.index.u65" class="xref">A</a>
         <a href="#rfc.index.u66" class="xref">B</a>
         <a href="#rfc.index.u68" class="xref">D</a>
@@ -238,30 +238,30 @@
         <a href="#rfc.index.u70" class="xref">F</a>
         <a href="#rfc.index.u76" class="xref">L</a>
         <a href="#rfc.index.u83" class="xref">S</a>
-        <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
+        <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-A-1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty normal">
-<li class="ulEmpty normal" id="section-appendix.a-2.1">
+<li class="ulEmpty normal" id="appendix-A-2.1">
           <div id="rfc.index.u65">
-<p id="section-appendix.a-2.1.1" class="keepWithNext">
-            <a href="#rfc.index.u65" class="xref">A</a><a href="#section-appendix.a-2.1.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.1.1" class="keepWithNext">
+            <a href="#rfc.index.u65" class="xref">A</a><a href="#appendix-A-2.1.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.1.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.1.2.1.1">
-                <dt id="section-appendix.a-2.1.2.1.1.1">annotation</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.2">
-                  <p id="section-appendix.a-2.1.2.1.1.2.1">
-                    <span><a href="#ref0" class="xref">Reference</a> [<a href="#ref0" class="xref">ref0</a>]</span><a href="#section-appendix.a-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.1.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.1.2.1.1">
+                <dt id="appendix-A-2.1.2.1.1.1">annotation</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.2">
+                  <p id="appendix-A-2.1.2.1.1.2.1">
+                    <span><a href="#ref0" class="xref">Reference</a> [<a href="#ref0" class="xref">ref0</a>]</span><a href="#appendix-A-2.1.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.1.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.1.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.1.2.1.1.4.1.1">in reference group</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.1.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.1.2.1.1.4.1.2.1">
-                        <span><a href="#refgroup0" class="xref">Reference</a> [<a href="#refgroup0" class="xref">refgroup0</a>]</span><a href="#section-appendix.a-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.1.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.1.2.1.1.4.1">
+                    <dt id="appendix-A-2.1.2.1.1.4.1.1">in reference group</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.1.2.1.1.4.1.2">
+                      <p id="appendix-A-2.1.2.1.1.4.1.2.1">
+                        <span><a href="#refgroup0" class="xref">Reference</a> [<a href="#refgroup0" class="xref">refgroup0</a>]</span><a href="#appendix-A-2.1.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -271,108 +271,108 @@
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.2">
+        <li class="ulEmpty normal" id="appendix-A-2.2">
           <div id="rfc.index.u66">
-<p id="section-appendix.a-2.2.1" class="keepWithNext">
-            <a href="#rfc.index.u66" class="xref">B</a><a href="#section-appendix.a-2.2.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.2.1" class="keepWithNext">
+            <a href="#rfc.index.u66" class="xref">B</a><a href="#appendix-A-2.2.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.2.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.2.2.1.1">
-                <dt id="section-appendix.a-2.2.2.1.1.1">blockquote</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.2.2.1.1.2">
-                  <p id="section-appendix.a-2.2.2.1.1.2.1">
-                    <a href="#section-1-7" class="xref">Section 1</a><a href="#section-appendix.a-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.2.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.2.2.1.1">
+                <dt id="appendix-A-2.2.2.1.1.1">blockquote</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.2.2.1.1.2">
+                  <p id="appendix-A-2.2.2.1.1.2.1">
+                    <a href="#section-1-7" class="xref">Section 1</a><a href="#appendix-A-2.2.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.3">
+        <li class="ulEmpty normal" id="appendix-A-2.3">
           <div id="rfc.index.u68">
-<p id="section-appendix.a-2.3.1" class="keepWithNext">
-            <a href="#rfc.index.u68" class="xref">D</a><a href="#section-appendix.a-2.3.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.3.1" class="keepWithNext">
+            <a href="#rfc.index.u68" class="xref">D</a><a href="#appendix-A-2.3.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.3.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.3.2.1.1">
-                <dt id="section-appendix.a-2.3.2.1.1.1">dd</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.3.2.1.1.2">
-                  <p id="section-appendix.a-2.3.2.1.1.2.1">
-                    <a href="#section-1-3.2" class="xref">Section 1</a><a href="#section-appendix.a-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.3.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.3.2.1.1">
+                <dt id="appendix-A-2.3.2.1.1.1">dd</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.3.2.1.1.2">
+                  <p id="appendix-A-2.3.2.1.1.2.1">
+                    <a href="#section-1-3.2" class="xref">Section 1</a><a href="#appendix-A-2.3.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.3.2.1.1.3">dt</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.3.2.1.1.4">
-                  <p id="section-appendix.a-2.3.2.1.1.4.1">
-                    <a href="#section-1-3.1" class="xref">Section 1</a><a href="#section-appendix.a-2.3.2.1.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.3.2.1.1.3">dt</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.3.2.1.1.4">
+                  <p id="appendix-A-2.3.2.1.1.4.1">
+                    <a href="#section-1-3.1" class="xref">Section 1</a><a href="#appendix-A-2.3.2.1.1.4.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.4">
+        <li class="ulEmpty normal" id="appendix-A-2.4">
           <div id="rfc.index.u69">
-<p id="section-appendix.a-2.4.1" class="keepWithNext">
-            <a href="#rfc.index.u69" class="xref">E</a><a href="#section-appendix.a-2.4.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.4.1" class="keepWithNext">
+            <a href="#rfc.index.u69" class="xref">E</a><a href="#appendix-A-2.4.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.4.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.4.2.1.1">
-                <dt id="section-appendix.a-2.4.2.1.1.1">em</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.4.2.1.1.2">
-                  <p id="section-appendix.a-2.4.2.1.1.2.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.4.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.4.2.1.1">
+                <dt id="appendix-A-2.4.2.1.1.1">em</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.4.2.1.1.2">
+                  <p id="appendix-A-2.4.2.1.1.2.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.4.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.5">
+        <li class="ulEmpty normal" id="appendix-A-2.5">
           <div id="rfc.index.u70">
-<p id="section-appendix.a-2.5.1" class="keepWithNext">
-            <a href="#rfc.index.u70" class="xref">F</a><a href="#section-appendix.a-2.5.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.5.1" class="keepWithNext">
+            <a href="#rfc.index.u70" class="xref">F</a><a href="#appendix-A-2.5.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.5.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.5.2.1.1">
-                <dt id="section-appendix.a-2.5.2.1.1.1">figure</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.5.2.1.1.2">
-                  <p id="section-appendix.a-2.5.2.1.1.2.1">
-                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#section-appendix.a-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.5.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.5.2.1.1">
+                <dt id="appendix-A-2.5.2.1.1.1">figure</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.5.2.1.1.2">
+                  <p id="appendix-A-2.5.2.1.1.2.1">
+                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#appendix-A-2.5.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.6">
+        <li class="ulEmpty normal" id="appendix-A-2.6">
           <div id="rfc.index.u76">
-<p id="section-appendix.a-2.6.1" class="keepWithNext">
-            <a href="#rfc.index.u76" class="xref">L</a><a href="#section-appendix.a-2.6.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.6.1" class="keepWithNext">
+            <a href="#rfc.index.u76" class="xref">L</a><a href="#appendix-A-2.6.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.6.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.6.2.1.1">
-                <dt id="section-appendix.a-2.6.2.1.1.1">li</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.2"></dd>
+<li class="ulEmpty compact normal" id="appendix-A-2.6.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.6.2.1.1">
+                <dt id="appendix-A-2.6.2.1.1.1">li</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.2"></dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.6.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.6.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.6.2.1.1.4.1.1">ol</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.6.2.1.1.4.1.2.1">
-                        <a href="#section-1-5.1" class="xref">Section 1, Paragraph 5, Item 1</a><a href="#section-appendix.a-2.6.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.6.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.6.2.1.1.4.1">
+                    <dt id="appendix-A-2.6.2.1.1.4.1.1">ol</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4.1.2">
+                      <p id="appendix-A-2.6.2.1.1.4.1.2.1">
+                        <a href="#section-1-5.1" class="xref">Section 1, Paragraph 5, Item 1</a><a href="#appendix-A-2.6.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                     <dd class="break"></dd>
-<dt id="section-appendix.a-2.6.2.1.1.4.1.3">ul</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.6.2.1.1.4.1.4">
-                      <p id="section-appendix.a-2.6.2.1.1.4.1.4.1">
-                        <a href="#section-1-4.1" class="xref">Section 1, Paragraph 4, Item 1</a><a href="#section-appendix.a-2.6.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.6.2.1.1.4.1.3">ul</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.6.2.1.1.4.1.4">
+                      <p id="appendix-A-2.6.2.1.1.4.1.4.1">
+                        <a href="#section-1-4.1" class="xref">Section 1, Paragraph 4, Item 1</a><a href="#appendix-A-2.6.2.1.1.4.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
@@ -382,91 +382,91 @@
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.7">
+        <li class="ulEmpty normal" id="appendix-A-2.7">
           <div id="rfc.index.u83">
-<p id="section-appendix.a-2.7.1" class="keepWithNext">
-            <a href="#rfc.index.u83" class="xref">S</a><a href="#section-appendix.a-2.7.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.7.1" class="keepWithNext">
+            <a href="#rfc.index.u83" class="xref">S</a><a href="#appendix-A-2.7.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.7.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.7.2.1.1">
-                <dt id="section-appendix.a-2.7.2.1.1.1">section</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.2">
-                  <p id="section-appendix.a-2.7.2.1.1.2.1">
-                    <a href="#section-1" class="xref">Section 1</a><a href="#section-appendix.a-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
+<li class="ulEmpty compact normal" id="appendix-A-2.7.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.7.2.1.1">
+                <dt id="appendix-A-2.7.2.1.1.1">section</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.2">
+                  <p id="appendix-A-2.7.2.1.1.2.1">
+                    <a href="#section-1" class="xref">Section 1</a><a href="#appendix-A-2.7.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.3">strong</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.4">
-                  <p id="section-appendix.a-2.7.2.1.1.4.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.4.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.3">strong</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.4">
+                  <p id="appendix-A-2.7.2.1.1.4.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.4.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.5">sub</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.6">
-                  <p id="section-appendix.a-2.7.2.1.1.6.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.6.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.5">sub</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.6">
+                  <p id="appendix-A-2.7.2.1.1.6.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.6.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.7.2.1.1.7">sup</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.7.2.1.1.8">
-                  <p id="section-appendix.a-2.7.2.1.1.8.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.7.2.1.1.8.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.7.2.1.1.7">sup</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.7.2.1.1.8">
+                  <p id="appendix-A-2.7.2.1.1.8.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.7.2.1.1.8.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
 </li>
           </ul>
 </li>
-        <li class="ulEmpty normal" id="section-appendix.a-2.8">
+        <li class="ulEmpty normal" id="appendix-A-2.8">
           <div id="rfc.index.u84">
-<p id="section-appendix.a-2.8.1" class="keepWithNext">
-            <a href="#rfc.index.u84" class="xref">T</a><a href="#section-appendix.a-2.8.1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2.8.1" class="keepWithNext">
+            <a href="#rfc.index.u84" class="xref">T</a><a href="#appendix-A-2.8.1" class="pilcrow">¶</a></p>
 </div>
 <ul class="ulEmpty compact normal">
-<li class="ulEmpty compact normal" id="section-appendix.a-2.8.2.1">
-              <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.8.2.1.1">
-                <dt id="section-appendix.a-2.8.2.1.1.1">t</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.2">
-                  <p id="section-appendix.a-2.8.2.1.1.2.1">
+<li class="ulEmpty compact normal" id="appendix-A-2.8.2.1">
+              <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.8.2.1.1">
+                <dt id="appendix-A-2.8.2.1.1.1">t</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.2">
+                  <p id="appendix-A-2.8.2.1.1.2.1">
                     <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a>; 
-<a href="#section-1-2" class="xref">Section 1, Paragraph 2</a><a href="#section-appendix.a-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
+<a href="#section-1-2" class="xref">Section 1, Paragraph 2</a><a href="#appendix-A-2.8.2.1.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.3"></dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.4">
-                  <span class="break"></span><dl class="dlParallel dlCompact" id="section-appendix.a-2.8.2.1.1.4.1">
-                    <dt id="section-appendix.a-2.8.2.1.1.4.1.1">in an aside tag</dt>
-                    <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.4.1.2">
-                      <p id="section-appendix.a-2.8.2.1.1.4.1.2.1">
-                        <a href="#section-1-6.1" class="xref">Section 1, Paragraph 6.1</a><a href="#section-appendix.a-2.8.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.3"></dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.4">
+                  <span class="break"></span><dl class="dlParallel dlCompact" id="appendix-A-2.8.2.1.1.4.1">
+                    <dt id="appendix-A-2.8.2.1.1.4.1.1">in an aside tag</dt>
+                    <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.4.1.2">
+                      <p id="appendix-A-2.8.2.1.1.4.1.2.1">
+                        <a href="#section-1-6.1" class="xref">Section 1, Paragraph 6.1</a><a href="#appendix-A-2.8.2.1.1.4.1.2.1" class="pilcrow">¶</a></p>
 </dd>
                   <dd class="break"></dd>
 </dl>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.5">table</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.6">
-                  <p id="section-appendix.a-2.8.2.1.1.6.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.a-2.8.2.1.1.6.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.5">table</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.6">
+                  <p id="appendix-A-2.8.2.1.1.6.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-A-2.8.2.1.1.6.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.7">td</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.8">
-                  <p id="section-appendix.a-2.8.2.1.1.8.1">
-                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#section-appendix.a-2.8.2.1.1.8.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.7">td</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.8">
+                  <p id="appendix-A-2.8.2.1.1.8.1">
+                    <a href="#section-1-8.1.2.1.1" class="xref">Section 1, Paragraph 8.1.2.1.1</a><a href="#appendix-A-2.8.2.1.1.8.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.9">th</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.10">
-                  <p id="section-appendix.a-2.8.2.1.1.10.1">
-                    <a href="#table-1" class="xref">Table 1</a><a href="#section-appendix.a-2.8.2.1.1.10.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.9">th</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.10">
+                  <p id="appendix-A-2.8.2.1.1.10.1">
+                    <a href="#table-1" class="xref">Table 1</a><a href="#appendix-A-2.8.2.1.1.10.1" class="pilcrow">¶</a></p>
 </dd>
                 <dd class="break"></dd>
-<dt id="section-appendix.a-2.8.2.1.1.11">tt</dt>
-                <dd style="margin-left: 1.5em" id="section-appendix.a-2.8.2.1.1.12">
-                  <p id="section-appendix.a-2.8.2.1.1.12.1">
-                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#section-appendix.a-2.8.2.1.1.12.1" class="pilcrow">¶</a></p>
+<dt id="appendix-A-2.8.2.1.1.11">tt</dt>
+                <dd style="margin-left: 1.5em" id="appendix-A-2.8.2.1.1.12">
+                  <p id="appendix-A-2.8.2.1.1.12.1">
+                    <a href="#section-1-1" class="xref">Section 1, Paragraph 1</a><a href="#appendix-A-2.8.2.1.1.12.1" class="pilcrow">¶</a></p>
 </dd>
               <dd class="break"></dd>
 </dl>
@@ -476,7 +476,7 @@
       </ul>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-address">
 <a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
       </h2>

--- a/cli/tests/valid/manpage.txt
+++ b/cli/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                             20 May 2021
+                                                             7 June 2021
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/cli/tests/valid/manpage.txt
+++ b/cli/tests/valid/manpage.txt
@@ -1,5 +1,5 @@
 xml2rfc(1)                                                    xml2rfc(1)
-                                                             7 June 2021
+                                                             8 June 2021
 
 
                   Xml2rfc Vocabulary Version 3 Schema

--- a/cli/tests/valid/rfc6787.v3.py36.html
+++ b/cli/tests/valid/rfc6787.v3.py36.html
@@ -21,7 +21,7 @@
       established above, allowing the client to control the media processing
       resources on the speech resource server. 
     ' name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="mrcp, speechsc, asr, tts, speech services, speech recognition, speech synthesis, nlsml, speaker authentication, speaker verification, speaker identification" name="keyword">
 <meta content="6787" name="rfc.number">
 <link href="tests/input/rfc6787.xml" rel="alternate" type="application/rfc+xml">
@@ -1034,13 +1034,13 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.18.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -12825,11 +12825,11 @@ identification-tag =    token
 <dd class="break"></dd>
 <dt id="W3C.REC-speech-grammar-20040316">[W3C.REC-speech-grammar-20040316]</dt>
         <dd>
-<span class="refAuthor">Hunt, A.</span> and <span class="refAuthor">S. McGlashan</span>, <span class="refTitle">"Speech Recognition Grammar Specification Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-grammar-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-speech-grammar-20040316">http://www.w3.org/TR/2004/REC-speech-grammar-20040316</a>&gt;</span>. </dd>
+<span class="refAuthor">Hunt, A.</span> and <span class="refAuthor">S. McGlashan</span>, <span class="refTitle">"Speech Recognition Grammar Specification Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-grammar-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-speech-grammar-20040316">https://www.w3.org/TR/2004/REC-speech-grammar-20040316</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="W3C.REC-speech-synthesis-20040907">[W3C.REC-speech-synthesis-20040907]</dt>
         <dd>
-<span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Walker, M.</span>, and <span class="refAuthor">A. Hunt</span>, <span class="refTitle">"Speech Synthesis Markup Language (SSML) Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-synthesis-20040907</span>, <time datetime="2004-09-07" class="refDate">September 7, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-speech-synthesis-20040907">http://www.w3.org/TR/2004/REC-speech-synthesis-20040907</a>&gt;</span>. </dd>
+<span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Walker, M.</span>, and <span class="refAuthor">A. Hunt</span>, <span class="refTitle">"Speech Synthesis Markup Language (SSML) Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-synthesis-20040907</span>, <time datetime="2004-09-07" class="refDate">September 7, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-speech-synthesis-20040907">https://www.w3.org/TR/2004/REC-speech-synthesis-20040907</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="W3C.REC-xml-names11-20040204">[W3C.REC-xml-names11-20040204]</dt>
       <dd>
@@ -12912,16 +12912,16 @@ identification-tag =    token
 <dd class="break"></dd>
 <dt id="W3C.REC-voicexml20-20040316">[W3C.REC-voicexml20-20040316]</dt>
       <dd>
-<span class="refAuthor">McGlashan, S.</span>, <span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Carter, J.</span>, <span class="refAuthor">Danielsen, P.</span>, <span class="refAuthor">Ferrans, J.</span>, <span class="refAuthor">Hunt, A.</span>, <span class="refAuthor">Lucas, B.</span>, <span class="refAuthor">Porter, B.</span>, <span class="refAuthor">Rehor, K.</span>, and <span class="refAuthor">S. Tryphonas</span>, <span class="refTitle">"Voice Extensible Markup Language (VoiceXML) Version 2.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-voicexml20-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-voicexml20-20040316">http://www.w3.org/TR/2004/REC-voicexml20-20040316</a>&gt;</span>. </dd>
+<span class="refAuthor">McGlashan, S.</span>, <span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Carter, J.</span>, <span class="refAuthor">Danielsen, P.</span>, <span class="refAuthor">Ferrans, J.</span>, <span class="refAuthor">Hunt, A.</span>, <span class="refAuthor">Lucas, B.</span>, <span class="refAuthor">Porter, B.</span>, <span class="refAuthor">Rehor, K.</span>, and <span class="refAuthor">S. Tryphonas</span>, <span class="refTitle">"Voice Extensible Markup Language (VoiceXML) Version 2.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-voicexml20-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-voicexml20-20040316">https://www.w3.org/TR/2004/REC-voicexml20-20040316</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-contributors">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<div class="artwork art-text alignLeft" id="section-appendix.a-1">
+<div class="artwork art-text alignLeft" id="appendix-A-1">
 <pre>
 Pierre Forgues
 Nuance Communications Ltd.
@@ -12950,14 +12950,14 @@ Building D
 Belgium
 
 EMail: klaus.reifenrath@scansoft.com
-</pre><a href="#section-appendix.a-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-A-1" class="pilcrow">¶</a>
 </div>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-acknowledgements">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<div class="artwork art-text alignLeft" id="section-appendix.b-1">
+<div class="artwork art-text alignLeft" id="appendix-B-1">
 <pre>
 Andre Gillet (Nuance Communications)
 Andrew Hunt (ScanSoft)
@@ -12979,16 +12979,16 @@ Ran Zilca (IBM Corp)
 Suresh Kaliannan (Cisco Systems, Inc.)
 Skip Cave (Intervoice, Inc.)
 Thomas Gal (LumenVox)
-</pre><a href="#section-appendix.b-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-B-1" class="pilcrow">¶</a>
 </div>
-<p id="section-appendix.b-2">The chairs of the SPEECHSC work group are Eric Burger (Georgetown
-      University) and Dave Oran (Cisco Systems, Inc.).<a href="#section-appendix.b-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.b-3">Many thanks go in particular to Robert Sparks, Alex Agranovsky, and
+<p id="appendix-B-2">The chairs of the SPEECHSC work group are Eric Burger (Georgetown
+      University) and Dave Oran (Cisco Systems, Inc.).<a href="#appendix-B-2" class="pilcrow">¶</a></p>
+<p id="appendix-B-3">Many thanks go in particular to Robert Sparks, Alex Agranovsky, and
       Henry Phan, who were there at the end to dot all the i's and cross all
-      the t's.<a href="#section-appendix.b-3" class="pilcrow">¶</a></p>
+      the t's.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/rfc6787.v3.py37.html
+++ b/cli/tests/valid/rfc6787.v3.py37.html
@@ -21,7 +21,7 @@
       established above, allowing the client to control the media processing
       resources on the speech resource server. 
     ' name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="mrcp, speechsc, asr, tts, speech services, speech recognition, speech synthesis, nlsml, speaker authentication, speaker verification, speaker identification" name="keyword">
 <meta content="6787" name="rfc.number">
 <link href="tests/input/rfc6787.xml" rel="alternate" type="application/rfc+xml">
@@ -1034,13 +1034,13 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.18.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -12825,11 +12825,11 @@ identification-tag =    token
 <dd class="break"></dd>
 <dt id="W3C.REC-speech-grammar-20040316">[W3C.REC-speech-grammar-20040316]</dt>
         <dd>
-<span class="refAuthor">Hunt, A.</span> and <span class="refAuthor">S. McGlashan</span>, <span class="refTitle">"Speech Recognition Grammar Specification Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-grammar-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-speech-grammar-20040316">http://www.w3.org/TR/2004/REC-speech-grammar-20040316</a>&gt;</span>. </dd>
+<span class="refAuthor">Hunt, A.</span> and <span class="refAuthor">S. McGlashan</span>, <span class="refTitle">"Speech Recognition Grammar Specification Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-grammar-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-speech-grammar-20040316">https://www.w3.org/TR/2004/REC-speech-grammar-20040316</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="W3C.REC-speech-synthesis-20040907">[W3C.REC-speech-synthesis-20040907]</dt>
         <dd>
-<span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Walker, M.</span>, and <span class="refAuthor">A. Hunt</span>, <span class="refTitle">"Speech Synthesis Markup Language (SSML) Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-synthesis-20040907</span>, <time datetime="2004-09-07" class="refDate">September 7, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-speech-synthesis-20040907">http://www.w3.org/TR/2004/REC-speech-synthesis-20040907</a>&gt;</span>. </dd>
+<span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Walker, M.</span>, and <span class="refAuthor">A. Hunt</span>, <span class="refTitle">"Speech Synthesis Markup Language (SSML) Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-synthesis-20040907</span>, <time datetime="2004-09-07" class="refDate">September 7, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-speech-synthesis-20040907">https://www.w3.org/TR/2004/REC-speech-synthesis-20040907</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="W3C.REC-xml-names11-20040204">[W3C.REC-xml-names11-20040204]</dt>
       <dd>
@@ -12912,16 +12912,16 @@ identification-tag =    token
 <dd class="break"></dd>
 <dt id="W3C.REC-voicexml20-20040316">[W3C.REC-voicexml20-20040316]</dt>
       <dd>
-<span class="refAuthor">McGlashan, S.</span>, <span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Carter, J.</span>, <span class="refAuthor">Danielsen, P.</span>, <span class="refAuthor">Ferrans, J.</span>, <span class="refAuthor">Hunt, A.</span>, <span class="refAuthor">Lucas, B.</span>, <span class="refAuthor">Porter, B.</span>, <span class="refAuthor">Rehor, K.</span>, and <span class="refAuthor">S. Tryphonas</span>, <span class="refTitle">"Voice Extensible Markup Language (VoiceXML) Version 2.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-voicexml20-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-voicexml20-20040316">http://www.w3.org/TR/2004/REC-voicexml20-20040316</a>&gt;</span>. </dd>
+<span class="refAuthor">McGlashan, S.</span>, <span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Carter, J.</span>, <span class="refAuthor">Danielsen, P.</span>, <span class="refAuthor">Ferrans, J.</span>, <span class="refAuthor">Hunt, A.</span>, <span class="refAuthor">Lucas, B.</span>, <span class="refAuthor">Porter, B.</span>, <span class="refAuthor">Rehor, K.</span>, and <span class="refAuthor">S. Tryphonas</span>, <span class="refTitle">"Voice Extensible Markup Language (VoiceXML) Version 2.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-voicexml20-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-voicexml20-20040316">https://www.w3.org/TR/2004/REC-voicexml20-20040316</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-contributors">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<div class="artwork art-text alignLeft" id="section-appendix.a-1">
+<div class="artwork art-text alignLeft" id="appendix-A-1">
 <pre>
 Pierre Forgues
 Nuance Communications Ltd.
@@ -12950,14 +12950,14 @@ Building D
 Belgium
 
 EMail: klaus.reifenrath@scansoft.com
-</pre><a href="#section-appendix.a-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-A-1" class="pilcrow">¶</a>
 </div>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-acknowledgements">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<div class="artwork art-text alignLeft" id="section-appendix.b-1">
+<div class="artwork art-text alignLeft" id="appendix-B-1">
 <pre>
 Andre Gillet (Nuance Communications)
 Andrew Hunt (ScanSoft)
@@ -12979,16 +12979,16 @@ Ran Zilca (IBM Corp)
 Suresh Kaliannan (Cisco Systems, Inc.)
 Skip Cave (Intervoice, Inc.)
 Thomas Gal (LumenVox)
-</pre><a href="#section-appendix.b-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-B-1" class="pilcrow">¶</a>
 </div>
-<p id="section-appendix.b-2">The chairs of the SPEECHSC work group are Eric Burger (Georgetown
-      University) and Dave Oran (Cisco Systems, Inc.).<a href="#section-appendix.b-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.b-3">Many thanks go in particular to Robert Sparks, Alex Agranovsky, and
+<p id="appendix-B-2">The chairs of the SPEECHSC work group are Eric Burger (Georgetown
+      University) and Dave Oran (Cisco Systems, Inc.).<a href="#appendix-B-2" class="pilcrow">¶</a></p>
+<p id="appendix-B-3">Many thanks go in particular to Robert Sparks, Alex Agranovsky, and
       Henry Phan, who were there at the end to dot all the i's and cross all
-      the t's.<a href="#section-appendix.b-3" class="pilcrow">¶</a></p>
+      the t's.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/rfc6787.v3.py38.html
+++ b/cli/tests/valid/rfc6787.v3.py38.html
@@ -21,7 +21,7 @@
       established above, allowing the client to control the media processing
       resources on the speech resource server. 
     ' name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="mrcp, speechsc, asr, tts, speech services, speech recognition, speech synthesis, nlsml, speaker authentication, speaker verification, speaker identification" name="keyword">
 <meta content="6787" name="rfc.number">
 <link href="tests/input/rfc6787.xml" rel="alternate" type="application/rfc+xml">
@@ -1034,13 +1034,13 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.18">
-            <p id="section-toc.1-1.18.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
+            <p id="section-toc.1-1.18.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-contributors" class="xref">Contributors</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.19">
-            <p id="section-toc.1-1.19.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.19.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.20">
-            <p id="section-toc.1-1.20.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.20.1"><a href="#appendix-C" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -12825,11 +12825,11 @@ identification-tag =    token
 <dd class="break"></dd>
 <dt id="W3C.REC-speech-grammar-20040316">[W3C.REC-speech-grammar-20040316]</dt>
         <dd>
-<span class="refAuthor">Hunt, A.</span> and <span class="refAuthor">S. McGlashan</span>, <span class="refTitle">"Speech Recognition Grammar Specification Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-grammar-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-speech-grammar-20040316">http://www.w3.org/TR/2004/REC-speech-grammar-20040316</a>&gt;</span>. </dd>
+<span class="refAuthor">Hunt, A.</span> and <span class="refAuthor">S. McGlashan</span>, <span class="refTitle">"Speech Recognition Grammar Specification Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-grammar-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-speech-grammar-20040316">https://www.w3.org/TR/2004/REC-speech-grammar-20040316</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="W3C.REC-speech-synthesis-20040907">[W3C.REC-speech-synthesis-20040907]</dt>
         <dd>
-<span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Walker, M.</span>, and <span class="refAuthor">A. Hunt</span>, <span class="refTitle">"Speech Synthesis Markup Language (SSML) Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-synthesis-20040907</span>, <time datetime="2004-09-07" class="refDate">September 7, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-speech-synthesis-20040907">http://www.w3.org/TR/2004/REC-speech-synthesis-20040907</a>&gt;</span>. </dd>
+<span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Walker, M.</span>, and <span class="refAuthor">A. Hunt</span>, <span class="refTitle">"Speech Synthesis Markup Language (SSML) Version 1.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-speech-synthesis-20040907</span>, <time datetime="2004-09-07" class="refDate">September 7, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-speech-synthesis-20040907">https://www.w3.org/TR/2004/REC-speech-synthesis-20040907</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="W3C.REC-xml-names11-20040204">[W3C.REC-xml-names11-20040204]</dt>
       <dd>
@@ -12912,16 +12912,16 @@ identification-tag =    token
 <dd class="break"></dd>
 <dt id="W3C.REC-voicexml20-20040316">[W3C.REC-voicexml20-20040316]</dt>
       <dd>
-<span class="refAuthor">McGlashan, S.</span>, <span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Carter, J.</span>, <span class="refAuthor">Danielsen, P.</span>, <span class="refAuthor">Ferrans, J.</span>, <span class="refAuthor">Hunt, A.</span>, <span class="refAuthor">Lucas, B.</span>, <span class="refAuthor">Porter, B.</span>, <span class="refAuthor">Rehor, K.</span>, and <span class="refAuthor">S. Tryphonas</span>, <span class="refTitle">"Voice Extensible Markup Language (VoiceXML) Version 2.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-voicexml20-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="http://www.w3.org/TR/2004/REC-voicexml20-20040316">http://www.w3.org/TR/2004/REC-voicexml20-20040316</a>&gt;</span>. </dd>
+<span class="refAuthor">McGlashan, S.</span>, <span class="refAuthor">Burnett, D.</span>, <span class="refAuthor">Carter, J.</span>, <span class="refAuthor">Danielsen, P.</span>, <span class="refAuthor">Ferrans, J.</span>, <span class="refAuthor">Hunt, A.</span>, <span class="refAuthor">Lucas, B.</span>, <span class="refAuthor">Porter, B.</span>, <span class="refAuthor">Rehor, K.</span>, and <span class="refAuthor">S. Tryphonas</span>, <span class="refTitle">"Voice Extensible Markup Language (VoiceXML) Version 2.0"</span>, <span class="seriesInfo">World Wide Web Consortium Recommendation REC-voicexml20-20040316</span>, <time datetime="2004-03-16" class="refDate">March 16, 2004</time>, <span>&lt;<a href="https://www.w3.org/TR/2004/REC-voicexml20-20040316">https://www.w3.org/TR/2004/REC-voicexml20-20040316</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-contributors">
-<a href="#section-appendix.a" class="section-number selfRef">Appendix A. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-contributors" class="section-name selfRef">Contributors</a>
       </h2>
-<div class="artwork art-text alignLeft" id="section-appendix.a-1">
+<div class="artwork art-text alignLeft" id="appendix-A-1">
 <pre>
 Pierre Forgues
 Nuance Communications Ltd.
@@ -12950,14 +12950,14 @@ Building D
 Belgium
 
 EMail: klaus.reifenrath@scansoft.com
-</pre><a href="#section-appendix.a-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-A-1" class="pilcrow">¶</a>
 </div>
 </section>
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-acknowledgements">
-<a href="#section-appendix.b" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<div class="artwork art-text alignLeft" id="section-appendix.b-1">
+<div class="artwork art-text alignLeft" id="appendix-B-1">
 <pre>
 Andre Gillet (Nuance Communications)
 Andrew Hunt (ScanSoft)
@@ -12979,16 +12979,16 @@ Ran Zilca (IBM Corp)
 Suresh Kaliannan (Cisco Systems, Inc.)
 Skip Cave (Intervoice, Inc.)
 Thomas Gal (LumenVox)
-</pre><a href="#section-appendix.b-1" class="pilcrow">¶</a>
+</pre><a href="#appendix-B-1" class="pilcrow">¶</a>
 </div>
-<p id="section-appendix.b-2">The chairs of the SPEECHSC work group are Eric Burger (Georgetown
-      University) and Dave Oran (Cisco Systems, Inc.).<a href="#section-appendix.b-2" class="pilcrow">¶</a></p>
-<p id="section-appendix.b-3">Many thanks go in particular to Robert Sparks, Alex Agranovsky, and
+<p id="appendix-B-2">The chairs of the SPEECHSC work group are Eric Burger (Georgetown
+      University) and Dave Oran (Cisco Systems, Inc.).<a href="#appendix-B-2" class="pilcrow">¶</a></p>
+<p id="appendix-B-3">Many thanks go in particular to Robert Sparks, Alex Agranovsky, and
       Henry Phan, who were there at the end to dot all the i's and cross all
-      the t's.<a href="#section-appendix.b-3" class="pilcrow">¶</a></p>
+      the t's.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.c">
+<section id="appendix-C">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/rfc7911.v3.py36.html
+++ b/cli/tests/valid/rfc7911.v3.py36.html
@@ -16,7 +16,7 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="7911" name="rfc.number">
 <link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -173,10 +173,10 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-acknowledgments" class="xref">Acknowledgments</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="xref"></a><a href="#name-acknowledgments" class="xref">Acknowledgments</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -463,20 +463,20 @@
 </dl>
 </section>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-acknowledgments">
 <a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
-<p id="section-appendix.a-1">We would like to thank David Cook and Naiming Shen for their
-      contributions to the design and development of the extension.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-2">Many people have made valuable comments and suggestions, including
+<p id="appendix-A-1">We would like to thank David Cook and Naiming Shen for their
+      contributions to the design and development of the extension.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">Many people have made valuable comments and suggestions, including
       Rex Fernando, Eugene Kim, Danny McPherson, Dave Meyer, Pradosh
       Mohapatra, Keyur Patel, Robert Raszuk, Eric Rosen, Srihari Sangli, Dan
       Tappan, Mark Turner, Jeff Haas, Jay Borkenhagen, Mach Chen, Denis Ovsienko,
-      Carlos Pignataro, Meral Shirazipour, and Kathleen Moriarty.<a href="#section-appendix.a-2" class="pilcrow">¶</a></p>
+      Carlos Pignataro, Meral Shirazipour, and Kathleen Moriarty.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/rfc7911.v3.py37.html
+++ b/cli/tests/valid/rfc7911.v3.py37.html
@@ -16,7 +16,7 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="7911" name="rfc.number">
 <link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -173,10 +173,10 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-acknowledgments" class="xref">Acknowledgments</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="xref"></a><a href="#name-acknowledgments" class="xref">Acknowledgments</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -463,20 +463,20 @@
 </dl>
 </section>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-acknowledgments">
 <a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
-<p id="section-appendix.a-1">We would like to thank David Cook and Naiming Shen for their
-      contributions to the design and development of the extension.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-2">Many people have made valuable comments and suggestions, including
+<p id="appendix-A-1">We would like to thank David Cook and Naiming Shen for their
+      contributions to the design and development of the extension.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">Many people have made valuable comments and suggestions, including
       Rex Fernando, Eugene Kim, Danny McPherson, Dave Meyer, Pradosh
       Mohapatra, Keyur Patel, Robert Raszuk, Eric Rosen, Srihari Sangli, Dan
       Tappan, Mark Turner, Jeff Haas, Jay Borkenhagen, Mach Chen, Denis Ovsienko,
-      Carlos Pignataro, Meral Shirazipour, and Kathleen Moriarty.<a href="#section-appendix.a-2" class="pilcrow">¶</a></p>
+      Carlos Pignataro, Meral Shirazipour, and Kathleen Moriarty.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/tests/valid/rfc7911.v3.py38.html
+++ b/cli/tests/valid/rfc7911.v3.py38.html
@@ -16,7 +16,7 @@
       that each path is identified by a Path Identifier in addition to the
       address prefix. 
     " name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="7911" name="rfc.number">
 <link href="tests/input/rfc7911.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -173,10 +173,10 @@
             </ul>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-acknowledgments" class="xref">Acknowledgments</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="xref"></a><a href="#name-acknowledgments" class="xref">Acknowledgments</a></p>
 </li>
           <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-appendix.b" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -463,20 +463,20 @@
 </dl>
 </section>
 </section>
-<section id="section-appendix.a">
+<section id="appendix-A">
       <h2 id="name-acknowledgments">
 <a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
-<p id="section-appendix.a-1">We would like to thank David Cook and Naiming Shen for their
-      contributions to the design and development of the extension.<a href="#section-appendix.a-1" class="pilcrow">¶</a></p>
-<p id="section-appendix.a-2">Many people have made valuable comments and suggestions, including
+<p id="appendix-A-1">We would like to thank David Cook and Naiming Shen for their
+      contributions to the design and development of the extension.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">Many people have made valuable comments and suggestions, including
       Rex Fernando, Eugene Kim, Danny McPherson, Dave Meyer, Pradosh
       Mohapatra, Keyur Patel, Robert Raszuk, Eric Rosen, Srihari Sangli, Dan
       Tappan, Mark Turner, Jeff Haas, Jay Borkenhagen, Mach Chen, Denis Ovsienko,
-      Carlos Pignataro, Meral Shirazipour, and Kathleen Moriarty.<a href="#section-appendix.a-2" class="pilcrow">¶</a></p>
+      Carlos Pignataro, Meral Shirazipour, and Kathleen Moriarty.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
 </section>
 <div id="authors-addresses">
-<section id="section-appendix.b">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/cli/xml2rfc/writers/base.py
+++ b/cli/xml2rfc/writers/base.py
@@ -2240,9 +2240,11 @@ class BaseV3Writer(object):
 
         Top level items have level 1. N.B., num is a string.
         """
-        if num[-1] == '.':
-            num = num[:-1]  # chop off trailing '.'
-        return len(num.split('.'))
+        num_with_no_trailing_dot = num.rstrip('.')
+        components = num_with_no_trailing_dot.split('.')
+        if any([len(cpt) == 0 for cpt in components]):
+            log.warn('Empty section number component in "{}"'.format(num))
+        return len(components)
 
     @classmethod
     def is_top_level_section(cls, num):

--- a/cli/xml2rfc/writers/base.py
+++ b/cli/xml2rfc/writers/base.py
@@ -2216,3 +2216,39 @@ class BaseV3Writer(object):
                 p.text = (p.text or '') + e.tail
         p.remove(e)
 
+    @staticmethod
+    def split_pn(pn):
+        """Split a pn into meaningful parts
+
+        Returns a tuple (element_type, section_number, paragraph_number).
+        If there is no paragraph number, it will be None.
+        """
+        parts = pn.split('-', 2)
+        elt_type = parts[0]
+        sect_num = parts[1]
+        paragraph_num = parts[2] if len(parts) > 2 else None
+
+        # see if section num needs special handling
+        components = sect_num.split('.', 1)
+        if components[0] in ['appendix', 'boilerplate', 'note', 'toc']:
+            sect_num = components[1]  # these always have a second component
+        return elt_type, sect_num, paragraph_num
+
+    @staticmethod
+    def level_of_section_num(num):
+        """Determine hierarchy level of a section number
+
+        Top level items have level 1. N.B., num is a string.
+        """
+        if num[-1] == '.':
+            num = num[:-1]  # chop off trailing '.'
+        return len(num.split('.'))
+
+    @classmethod
+    def is_top_level_section(cls, num):
+        return cls.level_of_section_num(num) == 1
+
+    @staticmethod
+    def is_appendix(pn):
+        """Is a section with this number an appendix?"""
+        return pn.startswith('section-appendix.')

--- a/cli/xml2rfc/writers/text.py
+++ b/cli/xml2rfc/writers/text.py
@@ -3306,9 +3306,10 @@ class TextWriter(BaseV3Writer):
         text = ''
         pn = e.get('pn', 'unknown-unknown')
         if e.get('numbered') == 'true':
-            text = pn.split('-',1)[1].replace('-', ' ').title() +'.'
-            if text.startswith('Appendix'):
-                text = text.replace('.', ' ', 1)
+            _, num, _ = self.split_pn(pn)
+            text = num.title() + '.'
+            if self.is_appendix(pn) and self.is_top_level_section(num):
+                text = 'Appendix %s' % text
             kwargs['joiners'].update({
                 'name':     Joiner('  ', len(text)+2, 0, False, False),
             })


### PR DESCRIPTION
The fragments used in cross-document references have historically been things like "section-1" or "appendix-A". In recent versions, the anchors actually defined for appendixes have not agreed with these, breaking cross-references in the generated output. This refactors the handling of "part number" (`pn`) and returns to the consistent format.

The internal changes try to bring a little order to the handling of `pn` values and to make more explicit the various flavors. There are "section-1", "section-appendix.a", "section-boilerplate.1", etc. Previously, subsections in the appendix were labeled simply as "section-a.1". I've changed these to keep the "appendix" label in the middle. I've created some helpers to deal with this - my aim is to centralize the creation / parsing of these values. There's a long way to go on that road, though.

N.B., all the code changes are in writers/, the rest is all test updates.