### PR TITLE
Allow old prepped RFCs to be rendered

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -128,6 +128,11 @@ tests/out/%.prepped.xml: tests/input/%.xml tests/out/%.v3.$(py).html tests/out/%
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --out $(basename $@).text --text --no-pagination --external-css --external-js --legacy-date-format $@" 2> /dev/null || { err=$$?; echo "Error output when generating .text from prepped .xml"; exit $$err; }
 	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' -I '$(generator_regex)' -I 'rel="alternate"' tests/out/$(notdir $(basename $(basename $@))).text $(basename $@).text || { echo "Diff failed for $(basename $@).text output (3)"; exit 1; }
 
+tests/out/%.canonical.html: tests/input/%.canonical.xml install
+	@echo " Checking generation of .html from canonical prepped .xml"
+	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --out $(basename $@).$(py).html --html --external-css --external-js --legacy-date-format --no-inline-version $<" 2> /dev/null || { err=$$?; echo "Error output when generating .html from canonical prepped .xml"; exit $$err; }
+	@diff -u -I '$(datetime_regex)' -I '$(version_regex)' -I '$(date_regex)' -I '$(generator_regex)' -I 'rel="alternate"' tests/valid/$(notdir $(basename $(basename $@))).html $(basename $@).$(py).html || { echo "Diff failed for $(basename $@).$(py).html output (2)"; exit 1; }
+
 tests/out/docfile.xml:
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache \"$${IETF_TEST_CACHE_PATH}\" --no-network --doc --out $@"
 
@@ -204,7 +209,7 @@ cachetest: cleantmp install
 	@PS4=" " /bin/bash -cx "xml2rfc --skip-config --cache .cache tests/input/rfc6787.xml --no-network --base tmp/ --raw --legacy"
 
 
-rfctest: cleantmp env/bin/python install $(rfctests)
+rfctest: cleantmp env/bin/python install $(rfctests) tests/out/rfc9001.canonical.html
 
 drafttest: cleantmp env/bin/python install $(drafttests) dateshifttest
 

--- a/cli/tests/input/rfc9001.canonical.xml
+++ b/cli/tests/input/rfc9001.canonical.xml
@@ -1,0 +1,2996 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" version="3" category="std" consensus="true" docName="draft-ietf-quic-tls-34" indexInclude="true" ipr="trust200902" number="9001" prepTime="2021-05-27T14:13:42" scripts="Common,Latin" sortRefs="true" submissionType="IETF" symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
+  <link href="https://dx.doi.org/10.17487/rfc9001" rel="alternate"/>
+  <link href="urn:issn:2070-1721" rel="alternate"/>
+  <link href="https://datatracker.ietf.org/doc/draft-ietf-quic-tls-34" rel="prev"/>
+  <front>
+    <title>Using TLS to Secure QUIC</title>
+    <seriesInfo name="RFC" value="9001" stream="IETF"/>
+    <author initials="M." surname="Thomson" fullname="Martin Thomson" role="editor">
+      <organization showOnFrontPage="true">Mozilla</organization>
+      <address>
+        <email>mt@lowentropy.net</email>
+      </address>
+    </author>
+    <author initials="S." surname="Turner" fullname="Sean Turner" role="editor">
+      <organization showOnFrontPage="true">sn3rd</organization>
+      <address>
+        <email>sean@sn3rd.com</email>
+      </address>
+    </author>
+    <date month="05" year="2021"/>
+    <area>Transport</area>
+    <workgroup>QUIC</workgroup>
+    <keyword>crypto</keyword>
+    <keyword>opportunistic encryption</keyword>
+    <keyword>plaintext quic</keyword>
+    <abstract pn="section-abstract">
+      <t indent="0" pn="section-abstract-1">This document describes how Transport Layer Security (TLS) is used to secure
+QUIC.</t>
+    </abstract>
+    <boilerplate>
+      <section anchor="status-of-memo" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.1">
+        <name slugifiedName="name-status-of-this-memo">Status of This Memo</name>
+        <t indent="0" pn="section-boilerplate.1-1">
+            This is an Internet Standards Track document.
+        </t>
+        <t indent="0" pn="section-boilerplate.1-2">
+            This document is a product of the Internet Engineering Task Force
+            (IETF).  It represents the consensus of the IETF community.  It has
+            received public review and has been approved for publication by
+            the Internet Engineering Steering Group (IESG).  Further
+            information on Internet Standards is available in Section 2 of 
+            RFC 7841.
+        </t>
+        <t indent="0" pn="section-boilerplate.1-3">
+            Information about the current status of this document, any
+            errata, and how to provide feedback on it may be obtained at
+            <eref target="https://www.rfc-editor.org/info/rfc9001" brackets="none"/>.
+        </t>
+      </section>
+      <section anchor="copyright" numbered="false" removeInRFC="false" toc="exclude" pn="section-boilerplate.2">
+        <name slugifiedName="name-copyright-notice">Copyright Notice</name>
+        <t indent="0" pn="section-boilerplate.2-1">
+            Copyright (c) 2021 IETF Trust and the persons identified as the
+            document authors. All rights reserved.
+        </t>
+        <t indent="0" pn="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<eref target="https://trustee.ietf.org/license-info" brackets="none"/>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Simplified BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Simplified BSD License.
+        </t>
+      </section>
+    </boilerplate>
+    <toc>
+      <section anchor="toc" numbered="false" removeInRFC="false" toc="exclude" pn="section-toc.1">
+        <name slugifiedName="name-table-of-contents">Table of Contents</name>
+        <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1">
+          <li pn="section-toc.1-1.1">
+            <t indent="0" keepWithNext="true" pn="section-toc.1-1.1.1"><xref derivedContent="1" format="counter" sectionFormat="of" target="section-1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-introduction">Introduction</xref></t>
+          </li>
+          <li pn="section-toc.1-1.2">
+            <t indent="0" keepWithNext="true" pn="section-toc.1-1.2.1"><xref derivedContent="2" format="counter" sectionFormat="of" target="section-2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-notational-conventions">Notational Conventions</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.2.2">
+              <li pn="section-toc.1-1.2.2.1">
+                <t indent="0" keepWithNext="true" pn="section-toc.1-1.2.2.1.1"><xref derivedContent="2.1" format="counter" sectionFormat="of" target="section-2.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-tls-overview">TLS Overview</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.3">
+            <t indent="0" pn="section-toc.1-1.3.1"><xref derivedContent="3" format="counter" sectionFormat="of" target="section-3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-protocol-overview">Protocol Overview</xref></t>
+          </li>
+          <li pn="section-toc.1-1.4">
+            <t indent="0" pn="section-toc.1-1.4.1"><xref derivedContent="4" format="counter" sectionFormat="of" target="section-4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-carrying-tls-messages">Carrying TLS Messages</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.4.2">
+              <li pn="section-toc.1-1.4.2.1">
+                <t indent="0" pn="section-toc.1-1.4.2.1.1"><xref derivedContent="4.1" format="counter" sectionFormat="of" target="section-4.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-interface-to-tls">Interface to TLS</xref></t>
+                <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.4.2.1.2">
+                  <li pn="section-toc.1-1.4.2.1.2.1">
+                    <t indent="0" pn="section-toc.1-1.4.2.1.2.1.1"><xref derivedContent="4.1.1" format="counter" sectionFormat="of" target="section-4.1.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-handshake-complete">Handshake Complete</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.1.2.2">
+                    <t indent="0" pn="section-toc.1-1.4.2.1.2.2.1"><xref derivedContent="4.1.2" format="counter" sectionFormat="of" target="section-4.1.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-handshake-confirmed">Handshake Confirmed</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.1.2.3">
+                    <t indent="0" pn="section-toc.1-1.4.2.1.2.3.1"><xref derivedContent="4.1.3" format="counter" sectionFormat="of" target="section-4.1.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-sending-and-receiving-hands">Sending and Receiving Handshake Messages</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.1.2.4">
+                    <t indent="0" pn="section-toc.1-1.4.2.1.2.4.1"><xref derivedContent="4.1.4" format="counter" sectionFormat="of" target="section-4.1.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-encryption-level-changes">Encryption Level Changes</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.1.2.5">
+                    <t indent="0" pn="section-toc.1-1.4.2.1.2.5.1"><xref derivedContent="4.1.5" format="counter" sectionFormat="of" target="section-4.1.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-tls-interface-summary">TLS Interface Summary</xref></t>
+                  </li>
+                </ul>
+              </li>
+              <li pn="section-toc.1-1.4.2.2">
+                <t indent="0" pn="section-toc.1-1.4.2.2.1"><xref derivedContent="4.2" format="counter" sectionFormat="of" target="section-4.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-tls-version">TLS Version</xref></t>
+              </li>
+              <li pn="section-toc.1-1.4.2.3">
+                <t indent="0" pn="section-toc.1-1.4.2.3.1"><xref derivedContent="4.3" format="counter" sectionFormat="of" target="section-4.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-clienthello-size">ClientHello Size</xref></t>
+              </li>
+              <li pn="section-toc.1-1.4.2.4">
+                <t indent="0" pn="section-toc.1-1.4.2.4.1"><xref derivedContent="4.4" format="counter" sectionFormat="of" target="section-4.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-peer-authentication">Peer Authentication</xref></t>
+              </li>
+              <li pn="section-toc.1-1.4.2.5">
+                <t indent="0" pn="section-toc.1-1.4.2.5.1"><xref derivedContent="4.5" format="counter" sectionFormat="of" target="section-4.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-session-resumption">Session Resumption</xref></t>
+              </li>
+              <li pn="section-toc.1-1.4.2.6">
+                <t indent="0" pn="section-toc.1-1.4.2.6.1"><xref derivedContent="4.6" format="counter" sectionFormat="of" target="section-4.6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-0-rtt">0-RTT</xref></t>
+                <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.4.2.6.2">
+                  <li pn="section-toc.1-1.4.2.6.2.1">
+                    <t indent="0" pn="section-toc.1-1.4.2.6.2.1.1"><xref derivedContent="4.6.1" format="counter" sectionFormat="of" target="section-4.6.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-enabling-0-rtt">Enabling 0-RTT</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.6.2.2">
+                    <t indent="0" pn="section-toc.1-1.4.2.6.2.2.1"><xref derivedContent="4.6.2" format="counter" sectionFormat="of" target="section-4.6.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-accepting-and-rejecting-0-r">Accepting and Rejecting 0-RTT</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.6.2.3">
+                    <t indent="0" pn="section-toc.1-1.4.2.6.2.3.1"><xref derivedContent="4.6.3" format="counter" sectionFormat="of" target="section-4.6.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-validating-0-rtt-configurat">Validating 0-RTT Configuration</xref></t>
+                  </li>
+                </ul>
+              </li>
+              <li pn="section-toc.1-1.4.2.7">
+                <t indent="0" pn="section-toc.1-1.4.2.7.1"><xref derivedContent="4.7" format="counter" sectionFormat="of" target="section-4.7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-helloretryrequest">HelloRetryRequest</xref></t>
+              </li>
+              <li pn="section-toc.1-1.4.2.8">
+                <t indent="0" pn="section-toc.1-1.4.2.8.1"><xref derivedContent="4.8" format="counter" sectionFormat="of" target="section-4.8"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-tls-errors">TLS Errors</xref></t>
+              </li>
+              <li pn="section-toc.1-1.4.2.9">
+                <t indent="0" pn="section-toc.1-1.4.2.9.1"><xref derivedContent="4.9" format="counter" sectionFormat="of" target="section-4.9"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-discarding-unused-keys">Discarding Unused Keys</xref></t>
+                <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.4.2.9.2">
+                  <li pn="section-toc.1-1.4.2.9.2.1">
+                    <t indent="0" pn="section-toc.1-1.4.2.9.2.1.1"><xref derivedContent="4.9.1" format="counter" sectionFormat="of" target="section-4.9.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-discarding-initial-keys">Discarding Initial Keys</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.9.2.2">
+                    <t indent="0" pn="section-toc.1-1.4.2.9.2.2.1"><xref derivedContent="4.9.2" format="counter" sectionFormat="of" target="section-4.9.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-discarding-handshake-keys">Discarding Handshake Keys</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.4.2.9.2.3">
+                    <t indent="0" pn="section-toc.1-1.4.2.9.2.3.1"><xref derivedContent="4.9.3" format="counter" sectionFormat="of" target="section-4.9.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-discarding-0-rtt-keys">Discarding 0-RTT Keys</xref></t>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.5">
+            <t indent="0" pn="section-toc.1-1.5.1"><xref derivedContent="5" format="counter" sectionFormat="of" target="section-5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-packet-protection">Packet Protection</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.5.2">
+              <li pn="section-toc.1-1.5.2.1">
+                <t indent="0" pn="section-toc.1-1.5.2.1.1"><xref derivedContent="5.1" format="counter" sectionFormat="of" target="section-5.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-packet-protection-keys">Packet Protection Keys</xref></t>
+              </li>
+              <li pn="section-toc.1-1.5.2.2">
+                <t indent="0" pn="section-toc.1-1.5.2.2.1"><xref derivedContent="5.2" format="counter" sectionFormat="of" target="section-5.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-initial-secrets">Initial Secrets</xref></t>
+              </li>
+              <li pn="section-toc.1-1.5.2.3">
+                <t indent="0" pn="section-toc.1-1.5.2.3.1"><xref derivedContent="5.3" format="counter" sectionFormat="of" target="section-5.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-aead-usage">AEAD Usage</xref></t>
+              </li>
+              <li pn="section-toc.1-1.5.2.4">
+                <t indent="0" pn="section-toc.1-1.5.2.4.1"><xref derivedContent="5.4" format="counter" sectionFormat="of" target="section-5.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-header-protection">Header Protection</xref></t>
+                <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.5.2.4.2">
+                  <li pn="section-toc.1-1.5.2.4.2.1">
+                    <t indent="0" pn="section-toc.1-1.5.2.4.2.1.1"><xref derivedContent="5.4.1" format="counter" sectionFormat="of" target="section-5.4.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-header-protection-applicati">Header Protection Application</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.5.2.4.2.2">
+                    <t indent="0" pn="section-toc.1-1.5.2.4.2.2.1"><xref derivedContent="5.4.2" format="counter" sectionFormat="of" target="section-5.4.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-header-protection-sample">Header Protection Sample</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.5.2.4.2.3">
+                    <t indent="0" pn="section-toc.1-1.5.2.4.2.3.1"><xref derivedContent="5.4.3" format="counter" sectionFormat="of" target="section-5.4.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-aes-based-header-protection">AES-Based Header Protection</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.5.2.4.2.4">
+                    <t indent="0" pn="section-toc.1-1.5.2.4.2.4.1"><xref derivedContent="5.4.4" format="counter" sectionFormat="of" target="section-5.4.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-chacha20-based-header-prote">ChaCha20-Based Header Protection</xref></t>
+                  </li>
+                </ul>
+              </li>
+              <li pn="section-toc.1-1.5.2.5">
+                <t indent="0" pn="section-toc.1-1.5.2.5.1"><xref derivedContent="5.5" format="counter" sectionFormat="of" target="section-5.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-receiving-protected-packets">Receiving Protected Packets</xref></t>
+              </li>
+              <li pn="section-toc.1-1.5.2.6">
+                <t indent="0" pn="section-toc.1-1.5.2.6.1"><xref derivedContent="5.6" format="counter" sectionFormat="of" target="section-5.6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-use-of-0-rtt-keys">Use of 0-RTT Keys</xref></t>
+              </li>
+              <li pn="section-toc.1-1.5.2.7">
+                <t indent="0" pn="section-toc.1-1.5.2.7.1"><xref derivedContent="5.7" format="counter" sectionFormat="of" target="section-5.7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-receiving-out-of-order-prot">Receiving Out-of-Order Protected Packets</xref></t>
+              </li>
+              <li pn="section-toc.1-1.5.2.8">
+                <t indent="0" pn="section-toc.1-1.5.2.8.1"><xref derivedContent="5.8" format="counter" sectionFormat="of" target="section-5.8"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-retry-packet-integrity">Retry Packet Integrity</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.6">
+            <t indent="0" pn="section-toc.1-1.6.1"><xref derivedContent="6" format="counter" sectionFormat="of" target="section-6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-key-update">Key Update</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.6.2">
+              <li pn="section-toc.1-1.6.2.1">
+                <t indent="0" pn="section-toc.1-1.6.2.1.1"><xref derivedContent="6.1" format="counter" sectionFormat="of" target="section-6.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-initiating-a-key-update">Initiating a Key Update</xref></t>
+              </li>
+              <li pn="section-toc.1-1.6.2.2">
+                <t indent="0" pn="section-toc.1-1.6.2.2.1"><xref derivedContent="6.2" format="counter" sectionFormat="of" target="section-6.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-responding-to-a-key-update">Responding to a Key Update</xref></t>
+              </li>
+              <li pn="section-toc.1-1.6.2.3">
+                <t indent="0" pn="section-toc.1-1.6.2.3.1"><xref derivedContent="6.3" format="counter" sectionFormat="of" target="section-6.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-timing-of-receive-key-gener">Timing of Receive Key Generation</xref></t>
+              </li>
+              <li pn="section-toc.1-1.6.2.4">
+                <t indent="0" pn="section-toc.1-1.6.2.4.1"><xref derivedContent="6.4" format="counter" sectionFormat="of" target="section-6.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-sending-with-updated-keys">Sending with Updated Keys</xref></t>
+              </li>
+              <li pn="section-toc.1-1.6.2.5">
+                <t indent="0" pn="section-toc.1-1.6.2.5.1"><xref derivedContent="6.5" format="counter" sectionFormat="of" target="section-6.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-receiving-with-different-ke">Receiving with Different Keys</xref></t>
+              </li>
+              <li pn="section-toc.1-1.6.2.6">
+                <t indent="0" pn="section-toc.1-1.6.2.6.1"><xref derivedContent="6.6" format="counter" sectionFormat="of" target="section-6.6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-limits-on-aead-usage">Limits on AEAD Usage</xref></t>
+              </li>
+              <li pn="section-toc.1-1.6.2.7">
+                <t indent="0" pn="section-toc.1-1.6.2.7.1"><xref derivedContent="6.7" format="counter" sectionFormat="of" target="section-6.7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-key-update-error-code">Key Update Error Code</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.7">
+            <t indent="0" pn="section-toc.1-1.7.1"><xref derivedContent="7" format="counter" sectionFormat="of" target="section-7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-security-of-initial-message">Security of Initial Messages</xref></t>
+          </li>
+          <li pn="section-toc.1-1.8">
+            <t indent="0" pn="section-toc.1-1.8.1"><xref derivedContent="8" format="counter" sectionFormat="of" target="section-8"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-quic-specific-adjustments-t">QUIC-Specific Adjustments to the TLS Handshake</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.8.2">
+              <li pn="section-toc.1-1.8.2.1">
+                <t indent="0" pn="section-toc.1-1.8.2.1.1"><xref derivedContent="8.1" format="counter" sectionFormat="of" target="section-8.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-protocol-negotiation">Protocol Negotiation</xref></t>
+              </li>
+              <li pn="section-toc.1-1.8.2.2">
+                <t indent="0" pn="section-toc.1-1.8.2.2.1"><xref derivedContent="8.2" format="counter" sectionFormat="of" target="section-8.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-quic-transport-parameters-e">QUIC Transport Parameters Extension</xref></t>
+              </li>
+              <li pn="section-toc.1-1.8.2.3">
+                <t indent="0" pn="section-toc.1-1.8.2.3.1"><xref derivedContent="8.3" format="counter" sectionFormat="of" target="section-8.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-removing-the-endofearlydata">Removing the EndOfEarlyData Message</xref></t>
+              </li>
+              <li pn="section-toc.1-1.8.2.4">
+                <t indent="0" pn="section-toc.1-1.8.2.4.1"><xref derivedContent="8.4" format="counter" sectionFormat="of" target="section-8.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-prohibit-tls-middlebox-comp">Prohibit TLS Middlebox Compatibility Mode</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.9">
+            <t indent="0" pn="section-toc.1-1.9.1"><xref derivedContent="9" format="counter" sectionFormat="of" target="section-9"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-security-considerations">Security Considerations</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.9.2">
+              <li pn="section-toc.1-1.9.2.1">
+                <t indent="0" pn="section-toc.1-1.9.2.1.1"><xref derivedContent="9.1" format="counter" sectionFormat="of" target="section-9.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-session-linkability">Session Linkability</xref></t>
+              </li>
+              <li pn="section-toc.1-1.9.2.2">
+                <t indent="0" pn="section-toc.1-1.9.2.2.1"><xref derivedContent="9.2" format="counter" sectionFormat="of" target="section-9.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-replay-attacks-with-0-rtt">Replay Attacks with 0-RTT</xref></t>
+              </li>
+              <li pn="section-toc.1-1.9.2.3">
+                <t indent="0" pn="section-toc.1-1.9.2.3.1"><xref derivedContent="9.3" format="counter" sectionFormat="of" target="section-9.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-packet-reflection-attack-mi">Packet Reflection Attack Mitigation</xref></t>
+              </li>
+              <li pn="section-toc.1-1.9.2.4">
+                <t indent="0" pn="section-toc.1-1.9.2.4.1"><xref derivedContent="9.4" format="counter" sectionFormat="of" target="section-9.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-header-protection-analysis">Header Protection Analysis</xref></t>
+              </li>
+              <li pn="section-toc.1-1.9.2.5">
+                <t indent="0" pn="section-toc.1-1.9.2.5.1"><xref derivedContent="9.5" format="counter" sectionFormat="of" target="section-9.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-header-protection-timing-si">Header Protection Timing Side Channels</xref></t>
+              </li>
+              <li pn="section-toc.1-1.9.2.6">
+                <t indent="0" pn="section-toc.1-1.9.2.6.1"><xref derivedContent="9.6" format="counter" sectionFormat="of" target="section-9.6"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-key-diversity">Key Diversity</xref></t>
+              </li>
+              <li pn="section-toc.1-1.9.2.7">
+                <t indent="0" pn="section-toc.1-1.9.2.7.1"><xref derivedContent="9.7" format="counter" sectionFormat="of" target="section-9.7"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-randomness">Randomness</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.10">
+            <t indent="0" pn="section-toc.1-1.10.1"><xref derivedContent="10" format="counter" sectionFormat="of" target="section-10"/>. <xref derivedContent="" format="title" sectionFormat="of" target="name-iana-considerations">IANA Considerations</xref></t>
+          </li>
+          <li pn="section-toc.1-1.11">
+            <t indent="0" pn="section-toc.1-1.11.1"><xref derivedContent="11" format="counter" sectionFormat="of" target="section-11"/>. <xref derivedContent="" format="title" sectionFormat="of" target="name-references">References</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.11.2">
+              <li pn="section-toc.1-1.11.2.1">
+                <t indent="0" pn="section-toc.1-1.11.2.1.1"><xref derivedContent="11.1" format="counter" sectionFormat="of" target="section-11.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-normative-references">Normative References</xref></t>
+              </li>
+              <li pn="section-toc.1-1.11.2.2">
+                <t indent="0" pn="section-toc.1-1.11.2.2.1"><xref derivedContent="11.2" format="counter" sectionFormat="of" target="section-11.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-informative-references">Informative References</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.12">
+            <t indent="0" pn="section-toc.1-1.12.1"><xref derivedContent="Appendix A" format="default" sectionFormat="of" target="section-appendix.a"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-sample-packet-protection">Sample Packet Protection</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.12.2">
+              <li pn="section-toc.1-1.12.2.1">
+                <t indent="0" pn="section-toc.1-1.12.2.1.1"><xref derivedContent="A.1" format="counter" sectionFormat="of" target="section-a.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-keys">Keys</xref></t>
+              </li>
+              <li pn="section-toc.1-1.12.2.2">
+                <t indent="0" pn="section-toc.1-1.12.2.2.1"><xref derivedContent="A.2" format="counter" sectionFormat="of" target="section-a.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-client-initial">Client Initial</xref></t>
+              </li>
+              <li pn="section-toc.1-1.12.2.3">
+                <t indent="0" pn="section-toc.1-1.12.2.3.1"><xref derivedContent="A.3" format="counter" sectionFormat="of" target="section-a.3"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-server-initial">Server Initial</xref></t>
+              </li>
+              <li pn="section-toc.1-1.12.2.4">
+                <t indent="0" pn="section-toc.1-1.12.2.4.1"><xref derivedContent="A.4" format="counter" sectionFormat="of" target="section-a.4"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-retry">Retry</xref></t>
+              </li>
+              <li pn="section-toc.1-1.12.2.5">
+                <t indent="0" pn="section-toc.1-1.12.2.5.1"><xref derivedContent="A.5" format="counter" sectionFormat="of" target="section-a.5"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-chacha20-poly1305-short-hea">ChaCha20-Poly1305 Short Header Packet</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.13">
+            <t indent="0" pn="section-toc.1-1.13.1"><xref derivedContent="Appendix B" format="default" sectionFormat="of" target="section-appendix.b"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-aead-algorithm-analysis">AEAD Algorithm Analysis</xref></t>
+            <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.13.2">
+              <li pn="section-toc.1-1.13.2.1">
+                <t indent="0" pn="section-toc.1-1.13.2.1.1"><xref derivedContent="B.1" format="counter" sectionFormat="of" target="section-b.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-analysis-of-aead_aes_128_gc">Analysis of AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits</xref></t>
+                <ul bare="true" empty="true" indent="2" spacing="compact" pn="section-toc.1-1.13.2.1.2">
+                  <li pn="section-toc.1-1.13.2.1.2.1">
+                    <t indent="0" pn="section-toc.1-1.13.2.1.2.1.1"><xref derivedContent="B.1.1" format="counter" sectionFormat="of" target="section-b.1.1"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-confidentiality-limit">Confidentiality Limit</xref></t>
+                  </li>
+                  <li pn="section-toc.1-1.13.2.1.2.2">
+                    <t indent="0" pn="section-toc.1-1.13.2.1.2.2.1"><xref derivedContent="B.1.2" format="counter" sectionFormat="of" target="section-b.1.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-integrity-limit">Integrity Limit</xref></t>
+                  </li>
+                </ul>
+              </li>
+              <li pn="section-toc.1-1.13.2.2">
+                <t indent="0" pn="section-toc.1-1.13.2.2.1"><xref derivedContent="B.2" format="counter" sectionFormat="of" target="section-b.2"/>.  <xref derivedContent="" format="title" sectionFormat="of" target="name-analysis-of-aead_aes_128_cc">Analysis of AEAD_AES_128_CCM Usage Limits</xref></t>
+              </li>
+            </ul>
+          </li>
+          <li pn="section-toc.1-1.14">
+            <t indent="0" pn="section-toc.1-1.14.1"><xref derivedContent="" format="none" sectionFormat="of" target="section-appendix.c"/><xref derivedContent="" format="title" sectionFormat="of" target="name-contributors">Contributors</xref></t>
+          </li>
+          <li pn="section-toc.1-1.15">
+            <t indent="0" pn="section-toc.1-1.15.1"><xref derivedContent="" format="none" sectionFormat="of" target="section-appendix.d"/><xref derivedContent="" format="title" sectionFormat="of" target="name-authors-addresses">Authors' Addresses</xref></t>
+          </li>
+        </ul>
+      </section>
+    </toc>
+  </front>
+  <middle>
+    <section anchor="introduction" numbered="true" toc="include" removeInRFC="false" pn="section-1">
+      <name slugifiedName="name-introduction">Introduction</name>
+      <t indent="0" pn="section-1-1">This document describes how QUIC <xref target="QUIC-TRANSPORT" format="default" sectionFormat="of" derivedContent="QUIC-TRANSPORT"/> is secured using TLS
+<xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>.</t>
+      <t indent="0" pn="section-1-2">TLS 1.3 provides critical latency improvements for connection establishment over
+previous versions.  Absent packet loss, most new connections can be established
+and secured within a single round trip; on subsequent connections between the
+same client and server, the client can often send application data immediately,
+that is, using a zero round-trip setup.</t>
+      <t indent="0" pn="section-1-3">This document describes how TLS acts as a security component of QUIC.</t>
+    </section>
+    <section anchor="notational-conventions" numbered="true" toc="include" removeInRFC="false" pn="section-2">
+      <name slugifiedName="name-notational-conventions">Notational Conventions</name>
+      <t indent="0" pn="section-2-1">The key words "<bcp14>MUST</bcp14>", "<bcp14>MUST NOT</bcp14>", "<bcp14>REQUIRED</bcp14>", "<bcp14>SHALL</bcp14>", "<bcp14>SHALL NOT</bcp14>", "<bcp14>SHOULD</bcp14>",
+"<bcp14>SHOULD NOT</bcp14>", "<bcp14>RECOMMENDED</bcp14>", "<bcp14>NOT RECOMMENDED</bcp14>", "<bcp14>MAY</bcp14>", and "<bcp14>OPTIONAL</bcp14>" in this
+document are to be interpreted as described in BCP 14 <xref target="RFC2119" format="default" sectionFormat="of" derivedContent="RFC2119"/> <xref target="RFC8174" format="default" sectionFormat="of" derivedContent="RFC8174"/>
+when, and only when, they appear in all capitals, as shown here.</t>
+      <t indent="0" pn="section-2-2">This document uses the terminology established in <xref target="QUIC-TRANSPORT" format="default" sectionFormat="of" derivedContent="QUIC-TRANSPORT"/>.</t>
+      <t indent="0" pn="section-2-3">For brevity, the acronym TLS is used to refer to TLS 1.3, though a newer version
+could be used; see <xref target="tls-version" format="default" sectionFormat="of" derivedContent="Section 4.2"/>.</t>
+      <section anchor="tls-overview" numbered="true" toc="include" removeInRFC="false" pn="section-2.1">
+        <name slugifiedName="name-tls-overview">TLS Overview</name>
+        <t indent="0" pn="section-2.1-1">TLS provides two endpoints with a way to establish a means of communication over
+an untrusted medium (for example, the Internet). TLS enables authentication of
+peers and provides confidentiality and integrity protection for messages that
+endpoints exchange.</t>
+        <t indent="0" pn="section-2.1-2">Internally, TLS is a layered protocol, with the structure shown in
+<xref target="tls-layers" format="default" sectionFormat="of" derivedContent="Figure 1"/>.</t>
+        <figure anchor="tls-layers" align="left" suppress-title="false" pn="figure-1">
+          <name slugifiedName="name-tls-layers">TLS Layers</name>
+          <artwork name="" type="" align="left" alt="" pn="section-2.1-3.1">
+          +-------------+------------+--------------+---------+
+Content   |             |            |  Application |         |
+Layer     |  Handshake  |   Alerts   |     Data     |   ...   |
+          |             |            |              |         |
+          +-------------+------------+--------------+---------+
+Record    |                                                   |
+Layer     |                      Records                      |
+          |                                                   |
+          +---------------------------------------------------+
+</artwork>
+        </figure>
+        <t indent="0" pn="section-2.1-4">Each content-layer message (e.g., handshake, alerts, and application data) is
+carried as a series of typed TLS records by the record layer.  Records are
+individually cryptographically protected and then transmitted over a reliable
+transport (typically TCP), which provides sequencing and guaranteed delivery.</t>
+        <t indent="0" pn="section-2.1-5">The TLS authenticated key exchange occurs between two endpoints: client and
+server.  The client initiates the exchange and the server responds.  If the key
+exchange completes successfully, both client and server will agree on a secret.
+TLS supports both pre-shared key (PSK) and Diffie-Hellman over either finite
+fields or elliptic curves ((EC)DHE) key exchanges.  PSK is the basis for Early
+Data (0-RTT); the latter provides forward secrecy (FS) when the (EC)DHE
+keys are destroyed.  The two modes can also be combined to provide forward
+secrecy while using the PSK for authentication.</t>
+        <t indent="0" pn="section-2.1-6">After completing the TLS handshake, the client will have learned and
+authenticated an identity for the server, and the server is optionally able to
+learn and authenticate an identity for the client.  TLS supports X.509
+<xref target="RFC5280" format="default" sectionFormat="of" derivedContent="RFC5280"/> certificate-based authentication for both server and client.
+When PSK key exchange is used (as in resumption), knowledge of the PSK
+serves to authenticate the peer.</t>
+        <t indent="0" pn="section-2.1-7">The TLS key exchange is resistant to tampering by attackers, and it produces
+shared secrets that cannot be controlled by either participating peer.</t>
+        <t indent="0" pn="section-2.1-8">TLS provides two basic handshake modes of interest to QUIC:</t>
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-2.1-9">
+          <li pn="section-2.1-9.1">A full 1-RTT handshake, in which the client is able to send application data
+after one round trip and the server immediately responds after receiving the
+first handshake message from the client.</li>
+          <li pn="section-2.1-9.2">A 0-RTT handshake, in which the client uses information it has previously
+learned about the server to send application data immediately.  This
+application data can be replayed by an attacker, so 0-RTT is not suitable for
+carrying instructions that might initiate any action that could cause
+unwanted effects if replayed.</li>
+        </ul>
+        <t indent="0" pn="section-2.1-10">A simplified TLS handshake with 0-RTT application data is shown in <xref target="tls-full" format="default" sectionFormat="of" derivedContent="Figure 2"/>.</t>
+        <figure anchor="tls-full" align="left" suppress-title="false" pn="figure-2">
+          <name slugifiedName="name-tls-handshake-with-0-rtt">TLS Handshake with 0-RTT</name>
+          <artwork name="" type="" align="left" alt="" pn="section-2.1-11.1">
+    Client                                             Server
+
+    ClientHello
+   (0-RTT Application Data)  --------&gt;
+                                                  ServerHello
+                                         {EncryptedExtensions}
+                                                    {Finished}
+                             &lt;--------      [Application Data]
+   {Finished}                --------&gt;
+
+   [Application Data]        &lt;-------&gt;      [Application Data]
+
+    () Indicates messages protected by Early Data (0-RTT) Keys
+    {} Indicates messages protected using Handshake Keys
+    [] Indicates messages protected using Application Data
+       (1-RTT) Keys
+</artwork>
+        </figure>
+        <t indent="0" pn="section-2.1-12"><xref target="tls-full" format="default" sectionFormat="of" derivedContent="Figure 2"/> omits the EndOfEarlyData message, which is not used in QUIC; see
+<xref target="remove-eoed" format="default" sectionFormat="of" derivedContent="Section 8.3"/>. Likewise, neither ChangeCipherSpec nor KeyUpdate messages are
+used by QUIC. ChangeCipherSpec is redundant in TLS 1.3; see <xref target="compat-mode" format="default" sectionFormat="of" derivedContent="Section 8.4"/>.
+QUIC has its own key update mechanism; see <xref target="key-update" format="default" sectionFormat="of" derivedContent="Section 6"/>.</t>
+        <t indent="0" pn="section-2.1-13">Data is protected using a number of encryption levels:</t>
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-2.1-14">
+          <li pn="section-2.1-14.1">Initial keys</li>
+          <li pn="section-2.1-14.2">Early data (0-RTT) keys</li>
+          <li pn="section-2.1-14.3">Handshake keys</li>
+          <li pn="section-2.1-14.4">Application data (1-RTT) keys</li>
+        </ul>
+        <t indent="0" pn="section-2.1-15">Application data can only appear in the early data and application data
+levels. Handshake and alert messages may appear in any level.</t>
+        <t indent="0" pn="section-2.1-16">The 0-RTT handshake can be used if the client and server have previously
+communicated.  In the 1-RTT handshake, the client is unable to send protected
+application data until it has received all of the handshake messages sent by the
+server.</t>
+      </section>
+    </section>
+    <section anchor="protocol-overview" numbered="true" toc="include" removeInRFC="false" pn="section-3">
+      <name slugifiedName="name-protocol-overview">Protocol Overview</name>
+      <t indent="0" pn="section-3-1">QUIC <xref target="QUIC-TRANSPORT" format="default" sectionFormat="of" derivedContent="QUIC-TRANSPORT"/> assumes responsibility for the confidentiality and
+integrity protection of packets.  For this it uses keys derived from a TLS
+handshake <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>, but instead of carrying TLS records over QUIC (as with
+TCP), TLS handshake and alert messages are carried directly over the QUIC
+transport, which takes over the responsibilities of the TLS record layer, as
+shown in <xref target="quic-layers" format="default" sectionFormat="of" derivedContent="Figure 3"/>.</t>
+      <figure anchor="quic-layers" align="left" suppress-title="false" pn="figure-3">
+        <name slugifiedName="name-quic-layers">QUIC Layers</name>
+        <artwork name="" type="" align="left" alt="" pn="section-3-2.1">
++--------------+--------------+ +-------------+
+|     TLS      |     TLS      | |    QUIC     |
+|  Handshake   |    Alerts    | | Applications|
+|              |              | |  (h3, etc.) |
++--------------+--------------+-+-------------+
+|                                             |
+|                QUIC Transport               |
+|   (streams, reliability, congestion, etc.)  |
+|                                             |
++---------------------------------------------+
+|                                             |
+|            QUIC Packet Protection           |
+|                                             |
++---------------------------------------------+
+</artwork>
+      </figure>
+      <t indent="0" pn="section-3-3">QUIC also relies on TLS for authentication and negotiation of parameters that
+are critical to security and performance.</t>
+      <t indent="0" pn="section-3-4">Rather than a strict layering, these two protocols cooperate: QUIC uses the TLS
+handshake; TLS uses the reliability, ordered delivery, and record layer provided
+by QUIC.</t>
+      <t indent="0" pn="section-3-5">At a high level, there are two main interactions between the TLS and QUIC
+components:</t>
+      <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-3-6">
+        <li pn="section-3-6.1">The TLS component sends and receives messages via the QUIC component, with
+QUIC providing a reliable stream abstraction to TLS.</li>
+        <li pn="section-3-6.2">The TLS component provides a series of updates to the QUIC component,
+including (a) new packet protection keys to install and (b) state changes such
+as handshake completion, the server certificate, etc.</li>
+      </ul>
+      <t indent="0" pn="section-3-7"><xref target="schematic" format="default" sectionFormat="of" derivedContent="Figure 4"/> shows these interactions in more detail, with the QUIC packet
+protection being called out specially.</t>
+      <figure anchor="schematic" align="left" suppress-title="false" pn="figure-4">
+        <name slugifiedName="name-quic-and-tls-interactions">QUIC and TLS Interactions</name>
+        <artwork name="" type="" align="left" alt="" pn="section-3-8.1">
++------------+                               +------------+
+|            |&lt;---- Handshake Messages -----&gt;|            |
+|            |&lt;- Validate 0-RTT Parameters -&gt;|            |
+|            |&lt;--------- 0-RTT Keys ---------|            |
+|    QUIC    |&lt;------- Handshake Keys -------|    TLS     |
+|            |&lt;--------- 1-RTT Keys ---------|            |
+|            |&lt;------- Handshake Done -------|            |
++------------+                               +------------+
+ |         ^
+ | Protect | Protected
+ v         | Packet
++------------+
+|   QUIC     |
+|  Packet    |
+| Protection |
++------------+
+</artwork>
+      </figure>
+      <t indent="0" pn="section-3-9">Unlike TLS over TCP, QUIC applications that want to send data do not send it
+using TLS Application Data records. Rather, they send it as QUIC STREAM
+frames or other frame types, which are then carried in QUIC packets.</t>
+    </section>
+    <section anchor="carrying-tls" numbered="true" toc="include" removeInRFC="false" pn="section-4">
+      <name slugifiedName="name-carrying-tls-messages">Carrying TLS Messages</name>
+      <t indent="0" pn="section-4-1">QUIC carries TLS handshake data in CRYPTO frames, each of which consists of a
+contiguous block of handshake data identified by an offset and length. Those
+frames are packaged into QUIC packets and encrypted under the current
+encryption level.  As with TLS over TCP, once TLS handshake data has been
+delivered to QUIC, it is QUIC's responsibility to deliver it reliably. Each
+chunk of data that is produced by TLS is associated with the set of keys that
+TLS is currently using.  If QUIC needs to retransmit that data, it <bcp14>MUST</bcp14> use the
+same keys even if TLS has already updated to newer keys.</t>
+      <t indent="0" pn="section-4-2">Each encryption level corresponds to a packet number space. The packet number
+space that is used determines the semantics of frames. Some frames are
+prohibited in different packet number spaces; see <xref section="12.5" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-12.5" derivedContent="QUIC-TRANSPORT"/>.</t>
+      <t indent="0" pn="section-4-3">Because packets could be reordered on the wire, QUIC uses the packet type to
+indicate which keys were used to protect a given packet, as shown in
+<xref target="packet-types-keys" format="default" sectionFormat="of" derivedContent="Table 1"/>. When packets of different types need to be sent,
+endpoints <bcp14>SHOULD</bcp14> use coalesced packets to send them in the same UDP datagram.</t>
+      <table anchor="packet-types-keys" align="center" pn="table-1">
+        <name slugifiedName="name-encryption-keys-by-packet-t">Encryption Keys by Packet Type</name>
+        <thead>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">Packet Type</th>
+            <th align="left" colspan="1" rowspan="1">Encryption Keys</th>
+            <th align="left" colspan="1" rowspan="1">PN Space</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">Initial</th>
+            <td align="left" colspan="1" rowspan="1">Initial secrets</td>
+            <td align="left" colspan="1" rowspan="1">Initial</td>
+          </tr>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">0-RTT Protected</th>
+            <td align="left" colspan="1" rowspan="1">0-RTT</td>
+            <td align="left" colspan="1" rowspan="1">Application data</td>
+          </tr>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">Handshake</th>
+            <td align="left" colspan="1" rowspan="1">Handshake</td>
+            <td align="left" colspan="1" rowspan="1">Handshake</td>
+          </tr>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">Retry</th>
+            <td align="left" colspan="1" rowspan="1">Retry</td>
+            <td align="left" colspan="1" rowspan="1">N/A</td>
+          </tr>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">Version Negotiation</th>
+            <td align="left" colspan="1" rowspan="1">N/A</td>
+            <td align="left" colspan="1" rowspan="1">N/A</td>
+          </tr>
+          <tr>
+            <th align="left" colspan="1" rowspan="1">Short Header</th>
+            <td align="left" colspan="1" rowspan="1">1-RTT</td>
+            <td align="left" colspan="1" rowspan="1">Application data</td>
+          </tr>
+        </tbody>
+      </table>
+      <t indent="0" pn="section-4-5"><xref section="17" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-17" derivedContent="QUIC-TRANSPORT"/> shows how packets at the various encryption
+levels fit into the handshake process.</t>
+      <section anchor="interface-to-tls" numbered="true" toc="include" removeInRFC="false" pn="section-4.1">
+        <name slugifiedName="name-interface-to-tls">Interface to TLS</name>
+        <t indent="0" pn="section-4.1-1">As shown in <xref target="schematic" format="default" sectionFormat="of" derivedContent="Figure 4"/>, the interface from QUIC to TLS consists of four
+primary functions:</t>
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4.1-2">
+          <li pn="section-4.1-2.1">Sending and receiving handshake messages</li>
+          <li pn="section-4.1-2.2">Processing stored transport and application state from a resumed session
+and determining if it is valid to generate or accept 0-RTT data</li>
+          <li pn="section-4.1-2.3">Rekeying (both transmit and receive)</li>
+          <li pn="section-4.1-2.4">Updating handshake state</li>
+        </ul>
+        <t indent="0" pn="section-4.1-3">Additional functions might be needed to configure TLS.  In particular, QUIC and
+TLS need to agree on which is responsible for validation of peer credentials,
+such as certificate validation <xref target="RFC5280" format="default" sectionFormat="of" derivedContent="RFC5280"/>.</t>
+        <section anchor="handshake-complete" numbered="true" toc="include" removeInRFC="false" pn="section-4.1.1">
+          <name slugifiedName="name-handshake-complete">Handshake Complete</name>
+          <t indent="0" pn="section-4.1.1-1">In this document, the TLS handshake is considered complete when the TLS stack
+has reported that the handshake is complete.  This happens when the TLS stack
+has both sent a Finished message and verified the peer's Finished message.
+Verifying the peer's Finished message provides the endpoints with an assurance
+that previous handshake messages have not been modified.  Note that the
+handshake does not complete at both endpoints simultaneously.  Consequently, any
+requirement that is based on the completion of the handshake depends on the
+perspective of the endpoint in question.</t>
+        </section>
+        <section anchor="handshake-confirmed" numbered="true" toc="include" removeInRFC="false" pn="section-4.1.2">
+          <name slugifiedName="name-handshake-confirmed">Handshake Confirmed</name>
+          <t indent="0" pn="section-4.1.2-1">In this document, the TLS handshake is considered confirmed at the server when
+the handshake completes.  The server <bcp14>MUST</bcp14> send a HANDSHAKE_DONE frame as soon as
+the handshake is complete.  At the client, the handshake is considered confirmed
+when a HANDSHAKE_DONE frame is received.</t>
+          <t indent="0" pn="section-4.1.2-2">Additionally, a client <bcp14>MAY</bcp14> consider the handshake to be confirmed when it
+receives an acknowledgment for a 1-RTT packet.  This can be implemented by
+recording the lowest packet number sent with 1-RTT keys and comparing it to the
+Largest Acknowledged field in any received 1-RTT ACK frame: once the latter is
+greater than or equal to the former, the handshake is confirmed.</t>
+        </section>
+        <section anchor="sending-and-receiving-handshake-messages" numbered="true" toc="include" removeInRFC="false" pn="section-4.1.3">
+          <name slugifiedName="name-sending-and-receiving-hands">Sending and Receiving Handshake Messages</name>
+          <t indent="0" pn="section-4.1.3-1">In order to drive the handshake, TLS depends on being able to send and receive
+handshake messages. There are two basic functions on this interface: one where
+QUIC requests handshake messages and one where QUIC provides bytes that comprise
+handshake messages.</t>
+          <t indent="0" pn="section-4.1.3-2">Before starting the handshake, QUIC provides TLS with the transport parameters
+(see <xref target="quic_parameters" format="default" sectionFormat="of" derivedContent="Section 8.2"/>) that it wishes to carry.</t>
+          <t indent="0" pn="section-4.1.3-3">A QUIC client starts TLS by requesting TLS handshake bytes from TLS.  The client
+acquires handshake bytes before sending its first packet.  A QUIC server starts
+the process by providing TLS with the client's handshake bytes.</t>
+          <t indent="0" pn="section-4.1.3-4">At any time, the TLS stack at an endpoint will have a current sending encryption
+level and a receiving encryption level. TLS encryption levels determine the QUIC
+packet type and keys that are used for protecting data.</t>
+          <t indent="0" pn="section-4.1.3-5">Each encryption level is associated with a different sequence of bytes, which is
+reliably transmitted to the peer in CRYPTO frames. When TLS provides handshake
+bytes to be sent, they are appended to the handshake bytes for the current
+encryption level. The encryption level then determines the type of packet that
+the resulting CRYPTO frame is carried in; see <xref target="packet-types-keys" format="default" sectionFormat="of" derivedContent="Table 1"/>.</t>
+          <t indent="0" pn="section-4.1.3-6">Four encryption levels are used, producing keys for Initial, 0-RTT, Handshake,
+and 1-RTT packets. CRYPTO frames are carried in just three of these levels,
+omitting the 0-RTT level. These four levels correspond to three packet number
+spaces: Initial and Handshake encrypted packets use their own separate spaces;
+0-RTT and 1-RTT packets use the application data packet number space.</t>
+          <t indent="0" pn="section-4.1.3-7">QUIC takes the unprotected content of TLS handshake records as the content of
+CRYPTO frames. TLS record protection is not used by QUIC. QUIC assembles
+CRYPTO frames into QUIC packets, which are protected using QUIC packet
+protection.</t>
+          <t indent="0" pn="section-4.1.3-8">QUIC CRYPTO frames only carry TLS handshake messages.  TLS
+alerts are turned into QUIC CONNECTION_CLOSE error codes; see <xref target="tls-errors" format="default" sectionFormat="of" derivedContent="Section 4.8"/>.
+TLS application data and other content types cannot be carried by QUIC at any
+encryption level; it is an error if they are received from the TLS stack.</t>
+          <t indent="0" pn="section-4.1.3-9">When an endpoint receives a QUIC packet containing a CRYPTO frame from the
+network, it proceeds as follows:</t>
+          <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4.1.3-10">
+            <li pn="section-4.1.3-10.1">If the packet uses the current TLS receiving encryption level, sequence the
+data into the input flow as usual. As with STREAM frames, the offset is used
+to find the proper location in the data sequence.  If the result of this
+process is that new data is available, then it is delivered to TLS in order.</li>
+            <li pn="section-4.1.3-10.2">If the packet is from a previously installed encryption level, it <bcp14>MUST NOT</bcp14>
+contain data that extends past the end of previously received data in that
+flow. Implementations <bcp14>MUST</bcp14> treat any violations of this requirement as a
+connection error of type PROTOCOL_VIOLATION.</li>
+            <li pn="section-4.1.3-10.3">If the packet is from a new encryption level, it is saved for later processing
+by TLS.  Once TLS moves to receiving from this encryption level, saved data
+can be provided to TLS.  When TLS provides keys for a higher encryption level,
+if there is data from a previous encryption level that TLS has not consumed,
+this <bcp14>MUST</bcp14> be treated as a connection error of type PROTOCOL_VIOLATION.</li>
+          </ul>
+          <t indent="0" pn="section-4.1.3-11">Each time that TLS is provided with new data, new handshake bytes are requested
+from TLS.  TLS might not provide any bytes if the handshake messages it has
+received are incomplete or it has no data to send.</t>
+          <t indent="0" pn="section-4.1.3-12">The content of CRYPTO frames might either be processed incrementally by TLS or
+buffered until complete messages or flights are available.  TLS is responsible
+for buffering handshake bytes that have arrived in order.  QUIC is responsible
+for buffering handshake bytes that arrive out of order or for encryption levels
+that are not yet ready.  QUIC does not provide any means of flow control for
+CRYPTO frames; see <xref section="7.5" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-7.5" derivedContent="QUIC-TRANSPORT"/>.</t>
+          <t indent="0" pn="section-4.1.3-13">Once the TLS handshake is complete, this is indicated to QUIC along with any
+final handshake bytes that TLS needs to send.  At this stage, the transport
+parameters that the peer advertised during the handshake are authenticated;
+see <xref target="quic_parameters" format="default" sectionFormat="of" derivedContent="Section 8.2"/>.</t>
+          <t indent="0" pn="section-4.1.3-14">Once the handshake is complete, TLS becomes passive.  TLS can still receive data
+from its peer and respond in kind, but it will not need to send more data unless
+specifically requested -- either by an application or QUIC.  One reason to send
+data is that the server might wish to provide additional or updated session
+tickets to a client.</t>
+          <t indent="0" pn="section-4.1.3-15">When the handshake is complete, QUIC only needs to provide TLS with any data
+that arrives in CRYPTO streams.  In the same manner that is used during the
+handshake, new data is requested from TLS after providing received data.</t>
+        </section>
+        <section anchor="encryption-level-changes" numbered="true" toc="include" removeInRFC="false" pn="section-4.1.4">
+          <name slugifiedName="name-encryption-level-changes">Encryption Level Changes</name>
+          <t indent="0" pn="section-4.1.4-1">As keys at a given encryption level become available to TLS, TLS indicates to
+QUIC that reading or writing keys at that encryption level are available.</t>
+          <t indent="0" pn="section-4.1.4-2">The availability of new keys is always a result of providing inputs to TLS.  TLS
+only provides new keys after being initialized (by a client) or when provided
+with new handshake data.</t>
+          <t indent="0" pn="section-4.1.4-3">However, a TLS implementation could perform some of its processing
+asynchronously. In particular, the process of validating a certificate can take
+some time. While waiting for TLS processing to complete, an endpoint <bcp14>SHOULD</bcp14>
+buffer received packets if they might be processed using keys that are not yet
+available. These packets can be processed once keys are provided by TLS. An
+endpoint <bcp14>SHOULD</bcp14> continue to respond to packets that can be processed during this
+time.</t>
+          <t indent="0" pn="section-4.1.4-4">After processing inputs, TLS might produce handshake bytes, keys for new
+encryption levels, or both.</t>
+          <t indent="0" pn="section-4.1.4-5">TLS provides QUIC with three items as a new encryption level becomes available:</t>
+          <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-4.1.4-6">
+            <li pn="section-4.1.4-6.1">A secret</li>
+            <li pn="section-4.1.4-6.2">An Authenticated Encryption with Associated Data (AEAD) function</li>
+            <li pn="section-4.1.4-6.3">A Key Derivation Function (KDF)</li>
+          </ul>
+          <t indent="0" pn="section-4.1.4-7">These values are based on the values that TLS negotiates and are used by QUIC to
+generate packet and header protection keys; see <xref target="packet-protection" format="default" sectionFormat="of" derivedContent="Section 5"/> and
+<xref target="header-protect" format="default" sectionFormat="of" derivedContent="Section 5.4"/>.</t>
+          <t indent="0" pn="section-4.1.4-8">If 0-RTT is possible, it is ready after the client sends a TLS ClientHello
+message or the server receives that message.  After providing a QUIC client with
+the first handshake bytes, the TLS stack might signal the change to 0-RTT
+keys. On the server, after receiving handshake bytes that contain a ClientHello
+message, a TLS server might signal that 0-RTT keys are available.</t>
+          <t indent="0" pn="section-4.1.4-9">Although TLS only uses one encryption level at a time, QUIC may use more than
+one level. For instance, after sending its Finished message (using a CRYPTO
+frame at the Handshake encryption level) an endpoint can send STREAM data (in
+1-RTT encryption). If the Finished message is lost, the endpoint uses the
+Handshake encryption level to retransmit the lost message.  Reordering or loss
+of packets can mean that QUIC will need to handle packets at multiple encryption
+levels.  During the handshake, this means potentially handling packets at higher
+and lower encryption levels than the current encryption level used by TLS.</t>
+          <t indent="0" pn="section-4.1.4-10">In particular, server implementations need to be able to read packets at the
+Handshake encryption level at the same time as the 0-RTT encryption level.  A
+client could interleave ACK frames that are protected with Handshake keys with
+0-RTT data, and the server needs to process those acknowledgments in order to
+detect lost Handshake packets.</t>
+          <t indent="0" pn="section-4.1.4-11">QUIC also needs access to keys that might not ordinarily be available to a TLS
+implementation.  For instance, a client might need to acknowledge Handshake
+packets before it is ready to send CRYPTO frames at that encryption level.  TLS
+therefore needs to provide keys to QUIC before it might produce them for its own
+use.</t>
+        </section>
+        <section anchor="tls-interface-summary" numbered="true" toc="include" removeInRFC="false" pn="section-4.1.5">
+          <name slugifiedName="name-tls-interface-summary">TLS Interface Summary</name>
+          <t indent="0" pn="section-4.1.5-1"><xref target="exchange-summary" format="default" sectionFormat="of" derivedContent="Figure 5"/> summarizes the exchange between QUIC and TLS for both
+client and server. Solid arrows indicate packets that carry handshake data;
+dashed arrows show where application data can be sent.  Each arrow is tagged
+with the encryption level used for that transmission.</t>
+          <figure anchor="exchange-summary" align="left" suppress-title="false" pn="figure-5">
+            <name slugifiedName="name-interaction-summary-between">Interaction Summary between QUIC and TLS</name>
+            <artwork name="" type="" align="left" alt="" pn="section-4.1.5-2.1">
+Client                                                    Server
+======                                                    ======
+
+Get Handshake
+                     Initial -------------&gt;
+Install tx 0-RTT keys
+                     0-RTT - - - - - - - -&gt;
+
+                                              Handshake Received
+                                                   Get Handshake
+                     &lt;------------- Initial
+                                           Install rx 0-RTT keys
+                                          Install Handshake keys
+                                                   Get Handshake
+                     &lt;----------- Handshake
+                                           Install tx 1-RTT keys
+                     &lt;- - - - - - - - 1-RTT
+
+Handshake Received (Initial)
+Install Handshake keys
+Handshake Received (Handshake)
+Get Handshake
+                     Handshake -----------&gt;
+Handshake Complete
+Install 1-RTT keys
+                     1-RTT - - - - - - - -&gt;
+
+                                              Handshake Received
+                                              Handshake Complete
+                                             Handshake Confirmed
+                                           Install rx 1-RTT keys
+                     &lt;--------------- 1-RTT
+                           (HANDSHAKE_DONE)
+Handshake Confirmed
+</artwork>
+          </figure>
+          <t indent="0" pn="section-4.1.5-3"><xref target="exchange-summary" format="default" sectionFormat="of" derivedContent="Figure 5"/> shows the multiple packets that form a single "flight" of
+messages being processed individually, to show what incoming messages trigger
+different actions. This shows multiple "Get Handshake" invocations to retrieve
+handshake messages at different encryption levels. New handshake messages are
+requested after incoming packets have been processed.</t>
+          <t indent="0" pn="section-4.1.5-4"><xref target="exchange-summary" format="default" sectionFormat="of" derivedContent="Figure 5"/> shows one possible structure for a simple handshake
+exchange. The exact process varies based on the structure of endpoint
+implementations and the order in which packets arrive. Implementations could
+use a different number of operations or execute them in other orders.</t>
+        </section>
+      </section>
+      <section anchor="tls-version" numbered="true" toc="include" removeInRFC="false" pn="section-4.2">
+        <name slugifiedName="name-tls-version">TLS Version</name>
+        <t indent="0" pn="section-4.2-1">This document describes how TLS 1.3 <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> is used with QUIC.</t>
+        <t indent="0" pn="section-4.2-2">In practice, the TLS handshake will negotiate a version of TLS to use.  This
+could result in a version of TLS newer than 1.3 being negotiated if both
+endpoints support that version.  This is acceptable provided that the features
+of TLS 1.3 that are used by QUIC are supported by the newer version.</t>
+        <t indent="0" pn="section-4.2-3">Clients <bcp14>MUST NOT</bcp14> offer TLS versions older than 1.3.  A badly configured TLS
+implementation could negotiate TLS 1.2 or another older version of TLS.  An
+endpoint <bcp14>MUST</bcp14> terminate the connection if a version of TLS older than 1.3 is
+negotiated.</t>
+      </section>
+      <section anchor="clienthello-size" numbered="true" toc="include" removeInRFC="false" pn="section-4.3">
+        <name slugifiedName="name-clienthello-size">ClientHello Size</name>
+        <t indent="0" pn="section-4.3-1">The first Initial packet from a client contains the start or all of its first
+cryptographic handshake message, which for TLS is the ClientHello.  Servers
+might need to parse the entire ClientHello (e.g., to access extensions such as
+Server Name Identification (SNI) or Application-Layer Protocol Negotiation
+(ALPN)) in order to decide whether to accept the new incoming QUIC connection.
+If the ClientHello spans multiple Initial packets, such servers would need to
+buffer the first received fragments, which could consume excessive resources if
+the client's address has not yet been validated.  To avoid this, servers <bcp14>MAY</bcp14>
+use the Retry feature (see <xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>) to only buffer
+partial ClientHello messages from clients with a validated address.</t>
+        <t indent="0" pn="section-4.3-2">QUIC packet and framing add at least 36 bytes of overhead to the ClientHello
+message.  That overhead increases if the client chooses a Source Connection ID
+field longer than zero bytes.  Overheads also do not include the token or a
+Destination Connection ID longer than 8 bytes, both of which might be required
+if a server sends a Retry packet.</t>
+        <t indent="0" pn="section-4.3-3">A typical TLS ClientHello can easily fit into a 1200-byte packet.  However, in
+addition to the overheads added by QUIC, there are several variables that could
+cause this limit to be exceeded.  Large session tickets, multiple or large key
+shares, and long lists of supported ciphers, signature algorithms, versions,
+QUIC transport parameters, and other negotiable parameters and extensions could
+cause this message to grow.</t>
+        <t indent="0" pn="section-4.3-4">For servers, in addition to connection IDs and tokens, the size of TLS session
+tickets can have an effect on a client's ability to connect efficiently.
+Minimizing the size of these values increases the probability that clients can
+use them and still fit their entire ClientHello message in their first Initial
+packet.</t>
+        <t indent="0" pn="section-4.3-5">The TLS implementation does not need to ensure that the ClientHello is large
+enough to meet QUIC's requirements for datagrams that carry Initial packets; see
+<xref section="14.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-14.1" derivedContent="QUIC-TRANSPORT"/>. QUIC implementations use PADDING frames or
+packet coalescing to ensure that datagrams are large enough.</t>
+      </section>
+      <section anchor="peer-authentication" numbered="true" toc="include" removeInRFC="false" pn="section-4.4">
+        <name slugifiedName="name-peer-authentication">Peer Authentication</name>
+        <t indent="0" pn="section-4.4-1">The requirements for authentication depend on the application protocol that is
+in use.  TLS provides server authentication and permits the server to request
+client authentication.</t>
+        <t indent="0" pn="section-4.4-2">A client <bcp14>MUST</bcp14> authenticate the identity of the server.  This typically involves
+verification that the identity of the server is included in a certificate and
+that the certificate is issued by a trusted entity (see for example
+<xref target="RFC2818" format="default" sectionFormat="of" derivedContent="RFC2818"/>).</t>
+        <aside pn="section-4.4-3">
+          <t indent="0" pn="section-4.4-3.1">Note: Where servers provide certificates for authentication, the size of the
+  certificate chain can consume a large number of bytes.  Controlling the size
+  of certificate chains is critical to performance in QUIC as servers are
+  limited to sending 3 bytes for every byte received prior to validating the
+  client address; see <xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>.  The size of a
+  certificate chain can be managed by limiting the number of names or
+  extensions; using keys with small public key representations, like ECDSA; or
+  by using certificate compression <xref target="COMPRESS" format="default" sectionFormat="of" derivedContent="COMPRESS"/>.</t>
+        </aside>
+        <t indent="0" pn="section-4.4-4">A server <bcp14>MAY</bcp14> request that the client authenticate during the handshake. A server
+<bcp14>MAY</bcp14> refuse a connection if the client is unable to authenticate when requested.
+The requirements for client authentication vary based on application protocol
+and deployment.</t>
+        <t indent="0" pn="section-4.4-5">A server <bcp14>MUST NOT</bcp14> use post-handshake client authentication (as defined in
+<xref section="4.6.2" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.6.2" derivedContent="TLS13"/>) because the multiplexing offered by QUIC prevents
+clients from correlating the certificate request with the application-level
+event that triggered it (see <xref target="HTTP2-TLS13" format="default" sectionFormat="of" derivedContent="HTTP2-TLS13"/>).  More specifically,
+servers <bcp14>MUST NOT</bcp14> send post-handshake TLS CertificateRequest messages, and
+clients <bcp14>MUST</bcp14> treat receipt of such messages as a connection error of type
+PROTOCOL_VIOLATION.</t>
+      </section>
+      <section anchor="resumption" numbered="true" toc="include" removeInRFC="false" pn="section-4.5">
+        <name slugifiedName="name-session-resumption">Session Resumption</name>
+        <t indent="0" pn="section-4.5-1">QUIC can use the session resumption feature of TLS 1.3. It does this by
+carrying NewSessionTicket messages in CRYPTO frames after the handshake is
+complete. Session resumption can be used to provide 0-RTT and can also be
+used when 0-RTT is disabled.</t>
+        <t indent="0" pn="section-4.5-2">Endpoints that use session resumption might need to remember some information
+about the current connection when creating a resumed connection. TLS requires
+that some information be retained; see <xref section="4.6.1" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.6.1" derivedContent="TLS13"/>. QUIC itself
+does not depend on any state being retained when resuming a connection unless
+0-RTT is also used; see <xref section="7.4.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-7.4.1" derivedContent="QUIC-TRANSPORT"/> and
+<xref target="enable-0rtt" format="default" sectionFormat="of" derivedContent="Section 4.6.1"/>. Application protocols could depend on state that is retained
+between resumed connections.</t>
+        <t indent="0" pn="section-4.5-3">Clients can store any state required for resumption along with the session
+ticket. Servers can use the session ticket to help carry state.</t>
+        <t indent="0" pn="section-4.5-4">Session resumption allows servers to link activity on the original connection
+with the resumed connection, which might be a privacy issue for clients.
+Clients can choose not to enable resumption to avoid creating this correlation.
+Clients <bcp14>SHOULD NOT</bcp14> reuse tickets as that allows entities other than the server
+to correlate connections; see <xref section="C.4" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#appendix-C.4" derivedContent="TLS13"/>.</t>
+      </section>
+      <section anchor="rtt" numbered="true" toc="include" removeInRFC="false" pn="section-4.6">
+        <name slugifiedName="name-0-rtt">0-RTT</name>
+        <t indent="0" pn="section-4.6-1">The 0-RTT feature in QUIC allows a client to send application data before the
+handshake is complete.  This is made possible by reusing negotiated parameters
+from a previous connection.  To enable this, 0-RTT depends on the client
+remembering critical parameters and providing the server with a TLS session
+ticket that allows the server to recover the same information.</t>
+        <t indent="0" pn="section-4.6-2">This information includes parameters that determine TLS state, as governed by
+<xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>, QUIC transport parameters, the chosen application protocol, and any
+information the application protocol might need; see <xref target="app-0rtt" format="default" sectionFormat="of" derivedContent="Section 4.6.3"/>.  This
+information determines how 0-RTT packets and their contents are formed.</t>
+        <t indent="0" pn="section-4.6-3">To ensure that the same information is available to both endpoints, all
+information used to establish 0-RTT comes from the same connection.  Endpoints
+cannot selectively disregard information that might alter the sending or
+processing of 0-RTT.</t>
+        <t indent="0" pn="section-4.6-4"><xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> sets a limit of seven days on the time between the original
+connection and any attempt to use 0-RTT.  There are other constraints on 0-RTT
+usage, notably those caused by the potential exposure to replay attack; see
+<xref target="replay" format="default" sectionFormat="of" derivedContent="Section 9.2"/>.</t>
+        <section anchor="enable-0rtt" numbered="true" toc="include" removeInRFC="false" pn="section-4.6.1">
+          <name slugifiedName="name-enabling-0-rtt">Enabling 0-RTT</name>
+          <t indent="0" pn="section-4.6.1-1">The TLS early_data extension in the NewSessionTicket message is defined to
+convey (in the max_early_data_size parameter) the amount of TLS 0-RTT data the
+server is willing to accept.  QUIC does not use TLS early data.  QUIC uses 0-RTT
+packets to carry early data.  Accordingly, the max_early_data_size parameter is
+repurposed to hold a sentinel value 0xffffffff to indicate that the server is
+willing to accept QUIC 0-RTT data.  To indicate that the server does not accept
+0-RTT data, the early_data extension is omitted from the NewSessionTicket.  The
+amount of data that the client can send in QUIC 0-RTT is controlled by the
+initial_max_data transport parameter supplied by the server.</t>
+          <t indent="0" pn="section-4.6.1-2">Servers <bcp14>MUST NOT</bcp14> send the early_data extension with a max_early_data_size field
+set to any value other than 0xffffffff.  A client <bcp14>MUST</bcp14> treat receipt of a
+NewSessionTicket that contains an early_data extension with any other value as
+a connection error of type PROTOCOL_VIOLATION.</t>
+          <t indent="0" pn="section-4.6.1-3">A client that wishes to send 0-RTT packets uses the early_data extension in the
+ClientHello message of a subsequent handshake; see <xref section="4.2.10" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.2.10" derivedContent="TLS13"/>.
+It then sends application data in 0-RTT packets.</t>
+          <t indent="0" pn="section-4.6.1-4">A client that attempts 0-RTT might also provide an address validation token if
+the server has sent a NEW_TOKEN frame; see <xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>.</t>
+        </section>
+        <section anchor="accepting-and-rejecting-0-rtt" numbered="true" toc="include" removeInRFC="false" pn="section-4.6.2">
+          <name slugifiedName="name-accepting-and-rejecting-0-r">Accepting and Rejecting 0-RTT</name>
+          <t indent="0" pn="section-4.6.2-1">A server accepts 0-RTT by sending an early_data extension in the
+EncryptedExtensions; see <xref section="4.2.10" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.2.10" derivedContent="TLS13"/>.  The server then
+processes and acknowledges the 0-RTT packets that it receives.</t>
+          <t indent="0" pn="section-4.6.2-2">A server rejects 0-RTT by sending the EncryptedExtensions without an early_data
+extension.  A server will always reject 0-RTT if it sends a TLS
+HelloRetryRequest.  When rejecting 0-RTT, a server <bcp14>MUST NOT</bcp14> process any 0-RTT
+packets, even if it could.  When 0-RTT was rejected, a client <bcp14>SHOULD</bcp14> treat
+receipt of an acknowledgment for a 0-RTT packet as a connection error of type
+PROTOCOL_VIOLATION, if it is able to detect the condition.</t>
+          <t indent="0" pn="section-4.6.2-3">When 0-RTT is rejected, all connection characteristics that the client assumed
+might be incorrect.  This includes the choice of application protocol, transport
+parameters, and any application configuration.  The client therefore <bcp14>MUST</bcp14> reset
+the state of all streams, including application state bound to those streams.</t>
+          <t indent="0" pn="section-4.6.2-4">A client <bcp14>MAY</bcp14> reattempt 0-RTT if it receives a Retry or Version Negotiation
+packet.  These packets do not signify rejection of 0-RTT.</t>
+        </section>
+        <section anchor="app-0rtt" numbered="true" toc="include" removeInRFC="false" pn="section-4.6.3">
+          <name slugifiedName="name-validating-0-rtt-configurat">Validating 0-RTT Configuration</name>
+          <t indent="0" pn="section-4.6.3-1">When a server receives a ClientHello with the early_data extension, it has to
+decide whether to accept or reject 0-RTT data from the client. Some of this
+decision is made by the TLS stack (e.g., checking that the cipher suite being
+resumed was included in the ClientHello; see <xref section="4.2.10" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.2.10" derivedContent="TLS13"/>). Even
+when the TLS stack has no reason to reject 0-RTT data, the QUIC stack or the
+application protocol using QUIC might reject 0-RTT data because the
+configuration of the transport or application associated with the resumed
+session is not compatible with the server's current configuration.</t>
+          <t indent="0" pn="section-4.6.3-2">QUIC requires additional transport state to be associated with a 0-RTT session
+ticket. One common way to implement this is using stateless session tickets and
+storing this state in the session ticket. Application protocols that use QUIC
+might have similar requirements regarding associating or storing state. This
+associated state is used for deciding whether 0-RTT data must be rejected. For
+example, HTTP/3 settings <xref target="QUIC-HTTP" format="default" sectionFormat="of" derivedContent="QUIC-HTTP"/> determine how 0-RTT data from the
+client is interpreted. Other applications using QUIC could have different
+requirements for determining whether to accept or reject 0-RTT data.</t>
+        </section>
+      </section>
+      <section anchor="helloretryrequest" numbered="true" toc="include" removeInRFC="false" pn="section-4.7">
+        <name slugifiedName="name-helloretryrequest">HelloRetryRequest</name>
+        <t indent="0" pn="section-4.7-1">The HelloRetryRequest message (see <xref section="4.1.4" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.1.4" derivedContent="TLS13"/>) can be used to
+request that a client provide new information, such as a key share, or to
+validate some characteristic of the client.  From the perspective of QUIC,
+HelloRetryRequest is not differentiated from other cryptographic handshake
+messages that are carried in Initial packets. Although it is in principle
+possible to use this feature for address verification, QUIC implementations
+<bcp14>SHOULD</bcp14> instead use the Retry feature; see <xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>.</t>
+      </section>
+      <section anchor="tls-errors" numbered="true" toc="include" removeInRFC="false" pn="section-4.8">
+        <name slugifiedName="name-tls-errors">TLS Errors</name>
+        <t indent="0" pn="section-4.8-1">If TLS experiences an error, it generates an appropriate alert as defined in
+<xref section="6" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-6" derivedContent="TLS13"/>.</t>
+        <t indent="0" pn="section-4.8-2">A TLS alert is converted into a QUIC connection error. The AlertDescription
+value is
+added to 0x0100 to produce a QUIC error code from the range reserved for
+CRYPTO_ERROR; see <xref section="20.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-20.1" derivedContent="QUIC-TRANSPORT"/>. The resulting value is
+sent in a QUIC CONNECTION_CLOSE frame of type 0x1c.</t>
+        <t indent="0" pn="section-4.8-3">QUIC is only able to convey an alert level of "fatal". In TLS 1.3, the only
+existing uses for the "warning" level are to signal connection close; see
+<xref section="6.1" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-6.1" derivedContent="TLS13"/>. As QUIC provides alternative mechanisms for
+connection termination and the TLS connection is only closed if an error is
+encountered, a QUIC endpoint <bcp14>MUST</bcp14> treat any alert from TLS as if it were at the
+"fatal" level.</t>
+        <t indent="0" pn="section-4.8-4">QUIC permits the use of a generic code in place of a specific error code; see
+<xref section="11" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-11" derivedContent="QUIC-TRANSPORT"/>. For TLS alerts, this includes replacing any
+alert with a generic alert, such as handshake_failure (0x0128 in QUIC).
+Endpoints <bcp14>MAY</bcp14> use a generic error code to avoid possibly exposing confidential
+information.</t>
+      </section>
+      <section anchor="discarding-unused-keys" numbered="true" toc="include" removeInRFC="false" pn="section-4.9">
+        <name slugifiedName="name-discarding-unused-keys">Discarding Unused Keys</name>
+        <t indent="0" pn="section-4.9-1">After QUIC has completed a move to a new encryption level, packet protection
+keys for previous encryption levels can be discarded.  This occurs several times
+during the handshake, as well as when keys are updated; see <xref target="key-update" format="default" sectionFormat="of" derivedContent="Section 6"/>.</t>
+        <t indent="0" pn="section-4.9-2">Packet protection keys are not discarded immediately when new keys are
+available.  If packets from a lower encryption level contain CRYPTO frames,
+frames that retransmit that data <bcp14>MUST</bcp14> be sent at the same encryption level.
+Similarly, an endpoint generates acknowledgments for packets at the same
+encryption level as the packet being acknowledged.  Thus, it is possible that
+keys for a lower encryption level are needed for a short time after keys for a
+newer encryption level are available.</t>
+        <t indent="0" pn="section-4.9-3">An endpoint cannot discard keys for a given encryption level unless it has
+received all the cryptographic handshake messages from its peer at that
+encryption level and its peer has done the same.  Different methods for
+determining this are provided for Initial keys (<xref target="discard-initial" format="default" sectionFormat="of" derivedContent="Section 4.9.1"/>) and
+Handshake keys (<xref target="discard-handshake" format="default" sectionFormat="of" derivedContent="Section 4.9.2"/>).  These methods do not prevent packets
+from being received or sent at that encryption level because a peer might not
+have received all the acknowledgments necessary.</t>
+        <t indent="0" pn="section-4.9-4">Though an endpoint might retain older keys, new data <bcp14>MUST</bcp14> be sent at the highest
+currently available encryption level.  Only ACK frames and retransmissions of
+data in CRYPTO frames are sent at a previous encryption level.  These packets
+<bcp14>MAY</bcp14> also include PADDING frames.</t>
+        <section anchor="discard-initial" numbered="true" toc="include" removeInRFC="false" pn="section-4.9.1">
+          <name slugifiedName="name-discarding-initial-keys">Discarding Initial Keys</name>
+          <t indent="0" pn="section-4.9.1-1">Packets protected with Initial secrets (<xref target="initial-secrets" format="default" sectionFormat="of" derivedContent="Section 5.2"/>) are not
+authenticated, meaning that an attacker could spoof packets with the intent to
+disrupt a connection.  To limit these attacks, Initial packet protection keys
+are discarded more aggressively than other keys.</t>
+          <t indent="0" pn="section-4.9.1-2">The successful use of Handshake packets indicates that no more Initial packets
+need to be exchanged, as these keys can only be produced after receiving all
+CRYPTO frames from Initial packets.  Thus, a client <bcp14>MUST</bcp14> discard Initial keys
+when it first sends a Handshake packet and a server <bcp14>MUST</bcp14> discard Initial keys
+when it first successfully processes a Handshake packet.  Endpoints <bcp14>MUST NOT</bcp14>
+send Initial packets after this point.</t>
+          <t indent="0" pn="section-4.9.1-3">This results in abandoning loss recovery state for the Initial encryption level
+and ignoring any outstanding Initial packets.</t>
+        </section>
+        <section anchor="discard-handshake" numbered="true" toc="include" removeInRFC="false" pn="section-4.9.2">
+          <name slugifiedName="name-discarding-handshake-keys">Discarding Handshake Keys</name>
+          <t indent="0" pn="section-4.9.2-1">An endpoint <bcp14>MUST</bcp14> discard its Handshake keys when the TLS handshake is confirmed
+(<xref target="handshake-confirmed" format="default" sectionFormat="of" derivedContent="Section 4.1.2"/>).</t>
+        </section>
+        <section anchor="discarding-0-rtt-keys" numbered="true" toc="include" removeInRFC="false" pn="section-4.9.3">
+          <name slugifiedName="name-discarding-0-rtt-keys">Discarding 0-RTT Keys</name>
+          <t indent="0" pn="section-4.9.3-1">0-RTT and 1-RTT packets share the same packet number space, and clients do not
+send 0-RTT packets after sending a 1-RTT packet (<xref target="using-early-data" format="default" sectionFormat="of" derivedContent="Section 5.6"/>).</t>
+          <t indent="0" pn="section-4.9.3-2">Therefore, a client <bcp14>SHOULD</bcp14> discard 0-RTT keys as soon as it installs 1-RTT
+keys as they have no use after that moment.</t>
+          <t indent="0" pn="section-4.9.3-3">Additionally, a server <bcp14>MAY</bcp14> discard 0-RTT keys as soon as it receives a 1-RTT
+packet.  However, due to packet reordering, a 0-RTT packet could arrive after
+a 1-RTT packet.  Servers <bcp14>MAY</bcp14> temporarily retain 0-RTT keys to allow decrypting
+reordered packets without requiring their contents to be retransmitted with
+1-RTT keys.  After receiving a 1-RTT packet, servers <bcp14>MUST</bcp14> discard 0-RTT keys
+within a short time; the <bcp14>RECOMMENDED</bcp14> time period is three times the Probe
+Timeout (PTO, see <xref target="QUIC-RECOVERY" format="default" sectionFormat="of" derivedContent="QUIC-RECOVERY"/>).  A server <bcp14>MAY</bcp14> discard 0-RTT keys earlier
+if it determines that it has received all 0-RTT packets, which can be done by
+keeping track of missing packet numbers.</t>
+        </section>
+      </section>
+    </section>
+    <section anchor="packet-protection" numbered="true" toc="include" removeInRFC="false" pn="section-5">
+      <name slugifiedName="name-packet-protection">Packet Protection</name>
+      <t indent="0" pn="section-5-1">As with TLS over TCP, QUIC protects packets with keys derived from the TLS
+handshake, using the AEAD algorithm <xref target="AEAD" format="default" sectionFormat="of" derivedContent="AEAD"/> negotiated by TLS.</t>
+      <t indent="0" pn="section-5-2">QUIC packets have varying protections depending on their type:</t>
+      <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-5-3">
+        <li pn="section-5-3.1">Version Negotiation packets have no cryptographic protection.</li>
+        <li pn="section-5-3.2">Retry packets use AEAD_AES_128_GCM to provide protection against accidental
+modification and to limit the entities that can produce a valid Retry;
+see <xref target="retry-integrity" format="default" sectionFormat="of" derivedContent="Section 5.8"/>.</li>
+        <li pn="section-5-3.3">Initial packets use AEAD_AES_128_GCM with keys derived from the Destination
+Connection ID field of the first Initial packet sent by the client; see
+<xref target="initial-secrets" format="default" sectionFormat="of" derivedContent="Section 5.2"/>.</li>
+        <li pn="section-5-3.4">All other packets have strong cryptographic protections for confidentiality
+and integrity, using keys and algorithms negotiated by TLS.</li>
+      </ul>
+      <t indent="0" pn="section-5-4">This section describes how packet protection is applied to Handshake packets,
+0-RTT packets, and 1-RTT packets. The same packet protection process is applied
+to Initial packets. However, as it is trivial to determine the keys used for
+Initial packets, these packets are not considered to have confidentiality or
+integrity protection. Retry packets use a fixed key and so similarly lack
+confidentiality and integrity protection.</t>
+      <section anchor="protection-keys" numbered="true" toc="include" removeInRFC="false" pn="section-5.1">
+        <name slugifiedName="name-packet-protection-keys">Packet Protection Keys</name>
+        <t indent="0" pn="section-5.1-1">QUIC derives packet protection keys in the same way that TLS derives record
+protection keys.</t>
+        <t indent="0" pn="section-5.1-2">Each encryption level has separate secret values for protection of packets sent
+in each direction. These traffic secrets are derived by TLS (see <xref section="7.1" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-7.1" derivedContent="TLS13"/>) and are used by QUIC for all encryption levels except the Initial
+encryption level. The secrets for the Initial encryption level are computed
+based on the client's initial Destination Connection ID, as described in
+<xref target="initial-secrets" format="default" sectionFormat="of" derivedContent="Section 5.2"/>.</t>
+        <t indent="0" pn="section-5.1-3">The keys used for packet protection are computed from the TLS secrets using the
+KDF provided by TLS.  In TLS 1.3, the HKDF-Expand-Label function described in
+<xref section="7.1" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-7.1" derivedContent="TLS13"/> is used with the hash function from the negotiated
+cipher suite.  All uses of HKDF-Expand-Label in QUIC use a zero-length Context.</t>
+        <t indent="0" pn="section-5.1-4">Note that labels, which are described using strings, are encoded
+as bytes using ASCII <xref target="ASCII" format="default" sectionFormat="of" derivedContent="ASCII"/> without quotes or any trailing NUL
+byte.</t>
+        <t indent="0" pn="section-5.1-5">Other versions of TLS <bcp14>MUST</bcp14> provide a similar function in order to be
+used with QUIC.</t>
+        <t indent="0" pn="section-5.1-6">The current encryption level secret and the label "quic key" are input to the
+KDF to produce the AEAD key; the label "quic iv" is used to derive the
+Initialization Vector (IV); see <xref target="aead" format="default" sectionFormat="of" derivedContent="Section 5.3"/>.  The header protection key uses the
+"quic hp" label; see <xref target="header-protect" format="default" sectionFormat="of" derivedContent="Section 5.4"/>.  Using these labels provides key
+separation between QUIC and TLS; see <xref target="key-diversity" format="default" sectionFormat="of" derivedContent="Section 9.6"/>.</t>
+        <t indent="0" pn="section-5.1-7">Both "quic key" and "quic hp" are used to produce keys, so the Length provided
+to HKDF-Expand-Label along with these labels is determined by the size of keys
+in the AEAD or header protection algorithm. The Length provided with "quic iv"
+is the minimum length of the AEAD nonce or 8 bytes if that is larger; see
+<xref target="AEAD" format="default" sectionFormat="of" derivedContent="AEAD"/>.</t>
+        <t indent="0" pn="section-5.1-8">The KDF used for initial secrets is always the HKDF-Expand-Label function from
+TLS 1.3; see <xref target="initial-secrets" format="default" sectionFormat="of" derivedContent="Section 5.2"/>.</t>
+      </section>
+      <section anchor="initial-secrets" numbered="true" toc="include" removeInRFC="false" pn="section-5.2">
+        <name slugifiedName="name-initial-secrets">Initial Secrets</name>
+        <t indent="0" pn="section-5.2-1">Initial packets apply the packet protection process, but use a secret derived
+from the Destination Connection ID field from the client's first Initial
+packet.</t>
+        <t indent="0" pn="section-5.2-2">This secret is determined by using HKDF-Extract (see <xref section="2.2" sectionFormat="of" target="HKDF" format="default" derivedLink="https://rfc-editor.org/rfc/rfc5869#section-2.2" derivedContent="HKDF"/>)
+with a salt of 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a and the input keying
+material (IKM) of the Destination Connection ID field. This produces an
+intermediate pseudorandom key (PRK) that is used to derive two separate secrets
+for sending and receiving.</t>
+        <t indent="0" pn="section-5.2-3">The secret used by clients to construct Initial packets uses the PRK and the
+label "client in" as input to the HKDF-Expand-Label function from TLS
+<xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> to produce a 32-byte secret.  Packets constructed by the server use
+the same process with the label "server in".  The hash function for HKDF when
+deriving initial secrets and keys is SHA-256
+<xref target="SHA" format="default" sectionFormat="of" derivedContent="SHA"/>.</t>
+        <t indent="0" pn="section-5.2-4">This process in pseudocode is:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-5.2-5">
+initial_salt = 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a
+initial_secret = HKDF-Extract(initial_salt,
+                              client_dst_connection_id)
+
+client_initial_secret = HKDF-Expand-Label(initial_secret,
+                                          "client in", "",
+                                          Hash.length)
+server_initial_secret = HKDF-Expand-Label(initial_secret,
+                                          "server in", "",
+                                          Hash.length)
+</artwork>
+        <t indent="0" pn="section-5.2-6">The connection ID used with HKDF-Expand-Label is the Destination Connection ID
+in the Initial packet sent by the client.  This will be a randomly selected
+value unless the client creates the Initial packet after receiving a Retry
+packet, where the Destination Connection ID is selected by the server.</t>
+        <t indent="0" pn="section-5.2-7">Future versions of QUIC <bcp14>SHOULD</bcp14> generate a new salt value, thus ensuring that
+the keys are different for each version of QUIC.  This prevents a middlebox that
+recognizes only one version of QUIC from seeing or modifying the contents of
+packets from future versions.</t>
+        <t indent="0" pn="section-5.2-8">The HKDF-Expand-Label function defined in TLS 1.3 <bcp14>MUST</bcp14> be used for Initial
+packets even where the TLS versions offered do not include TLS 1.3.</t>
+        <t indent="0" pn="section-5.2-9">The secrets used for constructing subsequent Initial packets change when a
+server sends a Retry packet to use the connection ID value selected by the
+server.  The secrets do not change when a client changes the Destination
+Connection ID it uses in response to an Initial packet from the server.</t>
+        <aside pn="section-5.2-10">
+          <t indent="0" pn="section-5.2-10.1">Note: The Destination Connection ID field could be any length up to 20 bytes,
+  including zero length if the server sends a Retry packet with a zero-length
+  Source Connection ID field. After a Retry, the Initial keys provide the client
+  no assurance that the server received its packet, so the client has to rely on
+  the exchange that included the Retry packet to validate the server address;
+  see <xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>.</t>
+        </aside>
+        <t indent="0" pn="section-5.2-11"><xref target="test-vectors" format="default" sectionFormat="of" derivedContent="Appendix A"/> contains sample Initial packets.</t>
+      </section>
+      <section anchor="aead" numbered="true" toc="include" removeInRFC="false" pn="section-5.3">
+        <name slugifiedName="name-aead-usage">AEAD Usage</name>
+        <t indent="0" pn="section-5.3-1">The Authenticated Encryption with Associated Data (AEAD) function (see
+<xref target="AEAD" format="default" sectionFormat="of" derivedContent="AEAD"/>) used for QUIC packet protection is the AEAD that is negotiated for
+use with the TLS connection.  For example, if TLS is using the
+TLS_AES_128_GCM_SHA256 cipher suite, the AEAD_AES_128_GCM function is used.</t>
+        <t indent="0" pn="section-5.3-2">QUIC can use any of the cipher suites defined in <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> with the exception
+of TLS_AES_128_CCM_8_SHA256.  A cipher suite <bcp14>MUST NOT</bcp14> be negotiated unless a
+header protection scheme is defined for the cipher suite.  This document defines
+a header protection scheme for all cipher suites defined in <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> aside
+from TLS_AES_128_CCM_8_SHA256.  These cipher suites have a 16-byte
+authentication tag and produce an output 16 bytes larger than their input.</t>
+        <t indent="0" pn="section-5.3-3">An endpoint <bcp14>MUST NOT</bcp14> reject a ClientHello that offers a cipher suite that it
+does not support, or it would be impossible to deploy a new cipher suite.  This
+also applies to TLS_AES_128_CCM_8_SHA256.</t>
+        <t indent="0" pn="section-5.3-4">When constructing packets, the AEAD function is applied prior to applying
+header protection; see <xref target="header-protect" format="default" sectionFormat="of" derivedContent="Section 5.4"/>. The unprotected packet header is part
+of the associated data (A). When processing packets, an endpoint first
+removes the header protection.</t>
+        <t indent="0" pn="section-5.3-5">The key and IV for the packet are computed as described in <xref target="protection-keys" format="default" sectionFormat="of" derivedContent="Section 5.1"/>.
+The nonce, N, is formed by combining the packet protection IV with the packet
+number.  The 62 bits of the reconstructed QUIC packet number in network byte
+order are left-padded with zeros to the size of the IV.  The exclusive OR of the
+padded packet number and the IV forms the AEAD nonce.</t>
+        <t indent="0" pn="section-5.3-6">The associated data, A, for the AEAD is the contents of the QUIC header,
+starting from the first byte of either the short or long header, up to and
+including the unprotected packet number.</t>
+        <t indent="0" pn="section-5.3-7">The input plaintext, P, for the AEAD is the payload of the QUIC packet, as
+described in <xref target="QUIC-TRANSPORT" format="default" sectionFormat="of" derivedContent="QUIC-TRANSPORT"/>.</t>
+        <t indent="0" pn="section-5.3-8">The output ciphertext, C, of the AEAD is transmitted in place of P.</t>
+        <t indent="0" pn="section-5.3-9">Some AEAD functions have limits for how many packets can be encrypted under the
+same key and IV; see <xref target="aead-limits" format="default" sectionFormat="of" derivedContent="Section 6.6"/>.  This might be lower than the packet
+number limit.  An endpoint <bcp14>MUST</bcp14> initiate a key update (<xref target="key-update" format="default" sectionFormat="of" derivedContent="Section 6"/>) prior to
+exceeding any limit set for the AEAD that is in use.</t>
+      </section>
+      <section anchor="header-protect" numbered="true" toc="include" removeInRFC="false" pn="section-5.4">
+        <name slugifiedName="name-header-protection">Header Protection</name>
+        <t indent="0" pn="section-5.4-1">Parts of QUIC packet headers, in particular the Packet Number field, are
+protected using a key that is derived separately from the packet protection key
+and IV.  The key derived using the "quic hp" label is used to provide
+confidentiality protection for those fields that are not exposed to on-path
+elements.</t>
+        <t indent="0" pn="section-5.4-2">This protection applies to the least significant bits of the first byte, plus
+the Packet Number field.  The four least significant bits of the first byte are
+protected for packets with long headers; the five least significant bits of the
+first byte are protected for packets with short headers.  For both header forms,
+this covers the reserved bits and the Packet Number Length field; the Key Phase
+bit is also protected for packets with a short header.</t>
+        <t indent="0" pn="section-5.4-3">The same header protection key is used for the duration of the connection, with
+the value not changing after a key update (see <xref target="key-update" format="default" sectionFormat="of" derivedContent="Section 6"/>).  This allows
+header protection to be used to protect the key phase.</t>
+        <t indent="0" pn="section-5.4-4">This process does not apply to Retry or Version Negotiation packets, which do
+not contain a protected payload or any of the fields that are protected by this
+process.</t>
+        <section anchor="header-protection-application" numbered="true" toc="include" removeInRFC="false" pn="section-5.4.1">
+          <name slugifiedName="name-header-protection-applicati">Header Protection Application</name>
+          <t indent="0" pn="section-5.4.1-1">Header protection is applied after packet protection is applied (see <xref target="aead" format="default" sectionFormat="of" derivedContent="Section 5.3"/>).
+The ciphertext of the packet is sampled and used as input to an encryption
+algorithm.  The algorithm used depends on the negotiated AEAD.</t>
+          <t indent="0" pn="section-5.4.1-2">The output of this algorithm is a 5-byte mask that is applied to the protected
+header fields using exclusive OR.  The least significant bits of the first byte
+of the packet are masked by the least significant bits of the first mask byte,
+and the packet number is masked with the remaining bytes.  Any unused bytes of
+mask that might result from a shorter packet number encoding are unused.</t>
+          <t indent="0" pn="section-5.4.1-3"><xref target="pseudo-hp" format="default" sectionFormat="of" derivedContent="Figure 6"/> shows a sample algorithm for applying header protection. Removing
+header protection only differs in the order in which the packet number length
+(pn_length) is determined (here "^" is used to represent exclusive OR).</t>
+          <figure anchor="pseudo-hp" align="left" suppress-title="false" pn="figure-6">
+            <name slugifiedName="name-header-protection-pseudocod">Header Protection Pseudocode</name>
+            <sourcecode type="pseudocode" markers="false" pn="section-5.4.1-4.1">
+mask = header_protection(hp_key, sample)
+
+pn_length = (packet[0] &amp; 0x03) + 1
+if (packet[0] &amp; 0x80) == 0x80:
+   # Long header: 4 bits masked
+   packet[0] ^= mask[0] &amp; 0x0f
+else:
+   # Short header: 5 bits masked
+   packet[0] ^= mask[0] &amp; 0x1f
+
+# pn_offset is the start of the Packet Number field.
+packet[pn_offset:pn_offset+pn_length] ^= mask[1:1+pn_length]
+</sourcecode>
+          </figure>
+          <t indent="0" pn="section-5.4.1-5">Specific header protection functions are defined based on the selected cipher
+suite; see <xref target="hp-aes" format="default" sectionFormat="of" derivedContent="Section 5.4.3"/> and <xref target="hp-chacha" format="default" sectionFormat="of" derivedContent="Section 5.4.4"/>.</t>
+          <t indent="0" pn="section-5.4.1-6"><xref target="fig-sample" format="default" sectionFormat="of" derivedContent="Figure 7"/> shows an example long header packet (Initial) and a short header
+packet (1-RTT). <xref target="fig-sample" format="default" sectionFormat="of" derivedContent="Figure 7"/> shows the fields in each header that are covered
+by header protection and the portion of the protected packet payload that is
+sampled.</t>
+          <figure anchor="fig-sample" align="left" suppress-title="false" pn="figure-7">
+            <name slugifiedName="name-header-protection-and-ciphe">Header Protection and Ciphertext Sample</name>
+            <artwork name="" type="" align="left" alt="" pn="section-5.4.1-7.1">
+Initial Packet {
+  Header Form (1) = 1,
+  Fixed Bit (1) = 1,
+  Long Packet Type (2) = 0,
+  Reserved Bits (2),         # Protected
+  Packet Number Length (2),  # Protected
+  Version (32),
+  DCID Len (8),
+  Destination Connection ID (0..160),
+  SCID Len (8),
+  Source Connection ID (0..160),
+  Token Length (i),
+  Token (..),
+  Length (i),
+  Packet Number (8..32),     # Protected
+  Protected Payload (0..24), # Skipped Part
+  Protected Payload (128),   # Sampled Part
+  Protected Payload (..)     # Remainder
+}
+
+1-RTT Packet {
+  Header Form (1) = 0,
+  Fixed Bit (1) = 1,
+  Spin Bit (1),
+  Reserved Bits (2),         # Protected
+  Key Phase (1),             # Protected
+  Packet Number Length (2),  # Protected
+  Destination Connection ID (0..160),
+  Packet Number (8..32),     # Protected
+  Protected Payload (0..24), # Skipped Part
+  Protected Payload (128),   # Sampled Part
+  Protected Payload (..),    # Remainder
+}
+</artwork>
+          </figure>
+          <t indent="0" pn="section-5.4.1-8">Before a TLS cipher suite can be used with QUIC, a header protection algorithm
+<bcp14>MUST</bcp14> be specified for the AEAD used with that cipher suite.  This document
+defines algorithms for AEAD_AES_128_GCM, AEAD_AES_128_CCM, AEAD_AES_256_GCM (all
+these AES AEADs are defined in <xref target="AEAD" format="default" sectionFormat="of" derivedContent="AEAD"/>), and AEAD_CHACHA20_POLY1305
+(defined in <xref target="CHACHA" format="default" sectionFormat="of" derivedContent="CHACHA"/>).  Prior to TLS selecting a cipher suite, AES
+header protection is used (<xref target="hp-aes" format="default" sectionFormat="of" derivedContent="Section 5.4.3"/>), matching the AEAD_AES_128_GCM packet
+protection.</t>
+        </section>
+        <section anchor="hp-sample" numbered="true" toc="include" removeInRFC="false" pn="section-5.4.2">
+          <name slugifiedName="name-header-protection-sample">Header Protection Sample</name>
+          <t indent="0" pn="section-5.4.2-1">The header protection algorithm uses both the header protection key and a sample
+of the ciphertext from the packet Payload field.</t>
+          <t indent="0" pn="section-5.4.2-2">The same number of bytes are always sampled, but an allowance needs to be made
+for the removal of protection by a receiving endpoint, which will not know the
+length of the Packet Number field.  The sample of ciphertext is taken starting
+from an offset of 4 bytes after the start of the Packet Number field.  That is,
+in sampling packet ciphertext for header protection, the Packet Number field is
+assumed to be 4 bytes long (its maximum possible encoded length).</t>
+          <t indent="0" pn="section-5.4.2-3">An endpoint <bcp14>MUST</bcp14> discard packets that are not long enough to contain a complete
+sample.</t>
+          <t indent="0" pn="section-5.4.2-4">To ensure that sufficient data is available for sampling, packets are padded so
+that the combined lengths of the encoded packet number and protected payload is
+at least 4 bytes longer than the sample required for header protection.  The
+cipher suites defined in <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> -- other than TLS_AES_128_CCM_8_SHA256, for
+which a header protection scheme is not defined in this document -- have 16-byte
+expansions and 16-byte header protection samples.  This results in needing at
+least 3 bytes of frames in the unprotected payload if the packet number is
+encoded on a single byte, or 2 bytes of frames for a 2-byte packet number
+encoding.</t>
+          <t indent="0" pn="section-5.4.2-5">The sampled ciphertext can be determined by the following pseudocode:</t>
+          <sourcecode type="pseudocode" markers="false" pn="section-5.4.2-6">
+# pn_offset is the start of the Packet Number field.
+sample_offset = pn_offset + 4
+
+sample = packet[sample_offset..sample_offset+sample_length]
+</sourcecode>
+          <t indent="0" pn="section-5.4.2-7">Where the packet number offset of a short header packet can be calculated as:</t>
+          <sourcecode type="pseudocode" markers="false" pn="section-5.4.2-8">
+pn_offset = 1 + len(connection_id)
+</sourcecode>
+          <t indent="0" pn="section-5.4.2-9">And the packet number offset of a long header packet can be calculated as:</t>
+          <sourcecode type="pseudocode" markers="false" pn="section-5.4.2-10">
+pn_offset = 7 + len(destination_connection_id) +
+                len(source_connection_id) +
+                len(payload_length)
+if packet_type == Initial:
+    pn_offset += len(token_length) +
+                 len(token)
+</sourcecode>
+          <t indent="0" pn="section-5.4.2-11">For example, for a packet with a short header, an 8-byte connection ID, and
+protected with AEAD_AES_128_GCM, the sample takes bytes 13 to 28 inclusive
+(using zero-based indexing).</t>
+          <t indent="0" pn="section-5.4.2-12">Multiple QUIC packets might be included in the same UDP datagram. Each packet
+is handled separately.</t>
+        </section>
+        <section anchor="hp-aes" numbered="true" toc="include" removeInRFC="false" pn="section-5.4.3">
+          <name slugifiedName="name-aes-based-header-protection">AES-Based Header Protection</name>
+          <t indent="0" pn="section-5.4.3-1">This section defines the packet protection algorithm for AEAD_AES_128_GCM,
+AEAD_AES_128_CCM, and AEAD_AES_256_GCM. AEAD_AES_128_GCM and AEAD_AES_128_CCM
+use 128-bit AES in Electronic Codebook (ECB) mode. AEAD_AES_256_GCM uses
+256-bit AES in ECB mode.  AES is defined in <xref target="AES" format="default" sectionFormat="of" derivedContent="AES"/>.</t>
+          <t indent="0" pn="section-5.4.3-2">This algorithm samples 16 bytes from the packet ciphertext. This value is used
+as the input to AES-ECB.  In pseudocode, the header protection function is
+defined as:</t>
+          <sourcecode type="pseudocode" markers="false" pn="section-5.4.3-3">
+header_protection(hp_key, sample):
+  mask = AES-ECB(hp_key, sample)
+</sourcecode>
+        </section>
+        <section anchor="hp-chacha" numbered="true" toc="include" removeInRFC="false" pn="section-5.4.4">
+          <name slugifiedName="name-chacha20-based-header-prote">ChaCha20-Based Header Protection</name>
+          <t indent="0" pn="section-5.4.4-1">When AEAD_CHACHA20_POLY1305 is in use, header protection uses the raw ChaCha20
+function as defined in <xref section="2.4" sectionFormat="of" target="CHACHA" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8439#section-2.4" derivedContent="CHACHA"/>.  This uses a 256-bit key and
+16 bytes sampled from the packet protection output.</t>
+          <t indent="0" pn="section-5.4.4-2">The first 4 bytes of the sampled ciphertext are the block counter.  A ChaCha20
+implementation could take a 32-bit integer in place of a byte sequence, in
+which case, the byte sequence is interpreted as a little-endian value.</t>
+          <t indent="0" pn="section-5.4.4-3">The remaining 12 bytes are used as the nonce. A ChaCha20 implementation might
+take an array of three 32-bit integers in place of a byte sequence, in which
+case, the nonce bytes are interpreted as a sequence of 32-bit little-endian
+integers.</t>
+          <t indent="0" pn="section-5.4.4-4">The encryption mask is produced by invoking ChaCha20 to protect 5 zero bytes. In
+pseudocode, the header protection function is defined as:</t>
+          <sourcecode type="pseudocode" markers="false" pn="section-5.4.4-5">
+header_protection(hp_key, sample):
+  counter = sample[0..3]
+  nonce = sample[4..15]
+  mask = ChaCha20(hp_key, counter, nonce, {0,0,0,0,0})
+</sourcecode>
+        </section>
+      </section>
+      <section anchor="receiving-protected-packets" numbered="true" toc="include" removeInRFC="false" pn="section-5.5">
+        <name slugifiedName="name-receiving-protected-packets">Receiving Protected Packets</name>
+        <t indent="0" pn="section-5.5-1">Once an endpoint successfully receives a packet with a given packet number, it
+<bcp14>MUST</bcp14> discard all packets in the same packet number space with higher packet
+numbers if they cannot be successfully unprotected with either the same key, or
+-- if there is a key update -- a subsequent packet protection key; see
+<xref target="key-update" format="default" sectionFormat="of" derivedContent="Section 6"/>.  Similarly, a packet that appears to trigger a key update but
+cannot be unprotected successfully <bcp14>MUST</bcp14> be discarded.</t>
+        <t indent="0" pn="section-5.5-2">Failure to unprotect a packet does not necessarily indicate the existence of a
+protocol error in a peer or an attack.  The truncated packet number encoding
+used in QUIC can cause packet numbers to be decoded incorrectly if they are
+delayed significantly.</t>
+      </section>
+      <section anchor="using-early-data" numbered="true" toc="include" removeInRFC="false" pn="section-5.6">
+        <name slugifiedName="name-use-of-0-rtt-keys">Use of 0-RTT Keys</name>
+        <t indent="0" pn="section-5.6-1">If 0-RTT keys are available (see <xref target="enable-0rtt" format="default" sectionFormat="of" derivedContent="Section 4.6.1"/>), the lack of replay protection
+means that restrictions on their use are necessary to avoid replay attacks on
+the protocol.</t>
+        <t indent="0" pn="section-5.6-2">Of the frames defined in <xref target="QUIC-TRANSPORT" format="default" sectionFormat="of" derivedContent="QUIC-TRANSPORT"/>, the STREAM, RESET_STREAM,
+STOP_SENDING, and CONNECTION_CLOSE frames are potentially unsafe for use with
+0-RTT as they carry application data. Application data that is received in
+0-RTT could cause an application at the server to process the data multiple
+times rather than just once. Additional actions taken by a server as a result
+of processing replayed application data could have unwanted consequences. A
+client therefore <bcp14>MUST NOT</bcp14> use 0-RTT for application data unless specifically
+requested by the application that is in use.</t>
+        <t indent="0" pn="section-5.6-3">An application protocol that uses QUIC <bcp14>MUST</bcp14> include a profile that defines
+acceptable use of 0-RTT; otherwise, 0-RTT can only be used to carry QUIC frames
+that do not carry application data. For example, a profile for HTTP is
+described in <xref target="HTTP-REPLAY" format="default" sectionFormat="of" derivedContent="HTTP-REPLAY"/> and used for HTTP/3; see
+<xref section="10.9" sectionFormat="of" target="QUIC-HTTP" format="default" derivedLink="https://tools.ietf.org/html/draft-ietf-quic-http-34#section-10.9" derivedContent="QUIC-HTTP"/>.</t>
+        <t indent="0" pn="section-5.6-4">Though replaying packets might result in additional connection attempts, the
+effect of processing replayed frames that do not carry application data is
+limited to changing the state of the affected connection. A TLS handshake
+cannot be successfully completed using replayed packets.</t>
+        <t indent="0" pn="section-5.6-5">A client <bcp14>MAY</bcp14> wish to apply additional restrictions on what data it sends prior
+to the completion of the TLS handshake.</t>
+        <t indent="0" pn="section-5.6-6">A client otherwise treats 0-RTT keys as equivalent to 1-RTT keys, except that
+it cannot send certain frames with 0-RTT keys; see
+<xref section="12.5" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-12.5" derivedContent="QUIC-TRANSPORT"/>.</t>
+        <t indent="0" pn="section-5.6-7">A client that receives an indication that its 0-RTT data has been accepted by a
+server can send 0-RTT data until it receives all of the server's handshake
+messages.  A client <bcp14>SHOULD</bcp14> stop sending 0-RTT data if it receives an indication
+that 0-RTT data has been rejected.</t>
+        <t indent="0" pn="section-5.6-8">A server <bcp14>MUST NOT</bcp14> use 0-RTT keys to protect packets; it uses 1-RTT keys to
+protect acknowledgments of 0-RTT packets.  A client <bcp14>MUST NOT</bcp14> attempt to
+decrypt 0-RTT packets it receives and instead <bcp14>MUST</bcp14> discard them.</t>
+        <t indent="0" pn="section-5.6-9">Once a client has installed 1-RTT keys, it <bcp14>MUST NOT</bcp14> send any more 0-RTT
+packets.</t>
+        <aside pn="section-5.6-10">
+          <t indent="0" pn="section-5.6-10.1">Note: 0-RTT data can be acknowledged by the server as it receives it, but any
+  packets containing acknowledgments of 0-RTT data cannot have packet protection
+  removed by the client until the TLS handshake is complete.  The 1-RTT keys
+  necessary to remove packet protection cannot be derived until the client
+  receives all server handshake messages.</t>
+        </aside>
+      </section>
+      <section anchor="pre-hs-protected" numbered="true" toc="include" removeInRFC="false" pn="section-5.7">
+        <name slugifiedName="name-receiving-out-of-order-prot">Receiving Out-of-Order Protected Packets</name>
+        <t indent="0" pn="section-5.7-1">Due to reordering and loss, protected packets might be received by an endpoint
+before the final TLS handshake messages are received.  A client will be unable
+to decrypt 1-RTT packets from the server, whereas a server will be able to
+decrypt 1-RTT packets from the client.  Endpoints in either role <bcp14>MUST NOT</bcp14>
+decrypt 1-RTT packets from their peer prior to completing the handshake.</t>
+        <t indent="0" pn="section-5.7-2">Even though 1-RTT keys are available to a server after receiving the first
+handshake messages from a client, it is missing assurances on the client state:</t>
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-5.7-3">
+          <li pn="section-5.7-3.1">The client is not authenticated, unless the server has chosen to use a
+pre-shared key and validated the client's pre-shared key binder; see <xref section="4.2.11" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-4.2.11" derivedContent="TLS13"/>.</li>
+          <li pn="section-5.7-3.2">The client has not demonstrated liveness, unless the server has validated the
+client's address with a Retry packet or other means; see
+<xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>.</li>
+          <li pn="section-5.7-3.3">Any received 0-RTT data that the server responds to might be due to a replay
+attack.</li>
+        </ul>
+        <t indent="0" pn="section-5.7-4">Therefore, the server's use of 1-RTT keys before the handshake is complete is
+limited to sending data.  A server <bcp14>MUST NOT</bcp14> process incoming 1-RTT protected
+packets before the TLS handshake is complete.  Because sending acknowledgments
+indicates that all frames in a packet have been processed, a server cannot send
+acknowledgments for 1-RTT packets until the TLS handshake is complete.  Received
+packets protected with 1-RTT keys <bcp14>MAY</bcp14> be stored and later decrypted and used
+once the handshake is complete.</t>
+        <aside pn="section-5.7-5">
+          <t indent="0" pn="section-5.7-5.1">Note: TLS implementations might provide all 1-RTT secrets prior to handshake
+  completion.  Even where QUIC implementations have 1-RTT read keys, those keys
+  are not to be used prior to completing the handshake.</t>
+        </aside>
+        <t indent="0" pn="section-5.7-6">The requirement for the server to wait for the client Finished message creates
+a dependency on that message being delivered.  A client can avoid the
+potential for head-of-line blocking that this implies by sending its 1-RTT
+packets coalesced with a Handshake packet containing a copy of the CRYPTO frame
+that carries the Finished message, until one of the Handshake packets is
+acknowledged.  This enables immediate server processing for those packets.</t>
+        <t indent="0" pn="section-5.7-7">A server could receive packets protected with 0-RTT keys prior to receiving a
+TLS ClientHello.  The server <bcp14>MAY</bcp14> retain these packets for later decryption in
+anticipation of receiving a ClientHello.</t>
+        <t indent="0" pn="section-5.7-8">A client generally receives 1-RTT keys at the same time as the handshake
+completes.  Even if it has 1-RTT secrets, a client <bcp14>MUST NOT</bcp14> process
+incoming 1-RTT protected packets before the TLS handshake is complete.</t>
+      </section>
+      <section anchor="retry-integrity" numbered="true" toc="include" removeInRFC="false" pn="section-5.8">
+        <name slugifiedName="name-retry-packet-integrity">Retry Packet Integrity</name>
+        <t indent="0" pn="section-5.8-1">Retry packets (see <xref section="17.2.5" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-17.2.5" derivedContent="QUIC-TRANSPORT"/>) carry a Retry Integrity
+Tag that provides two properties: it allows the discarding of packets that have
+accidentally been corrupted by the network, and only an entity that observes an
+Initial packet can send a valid Retry packet.</t>
+        <t indent="0" pn="section-5.8-2">The Retry Integrity Tag is a 128-bit field that is computed as the output of
+AEAD_AES_128_GCM <xref target="AEAD" format="default" sectionFormat="of" derivedContent="AEAD"/> used with the following inputs:</t>
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-5.8-3">
+          <li pn="section-5.8-3.1">The secret key, K, is 128 bits equal to 0xbe0c690b9f66575a1d766b54e368c84e.</li>
+          <li pn="section-5.8-3.2">The nonce, N, is 96 bits equal to 0x461599d35d632bf2239825bb.</li>
+          <li pn="section-5.8-3.3">The plaintext, P, is empty.</li>
+          <li pn="section-5.8-3.4">The associated data, A, is the contents of the Retry Pseudo-Packet, as
+illustrated in <xref target="retry-pseudo" format="default" sectionFormat="of" derivedContent="Figure 8"/>:</li>
+        </ul>
+        <t indent="0" pn="section-5.8-4">The secret key and the nonce are values derived by calling HKDF-Expand-Label
+using 0xd9c9943e6101fd200021506bcc02814c73030f25c79d71ce876eca876e6fca8e as the
+secret, with labels being "quic key" and "quic iv" (<xref target="protection-keys" format="default" sectionFormat="of" derivedContent="Section 5.1"/>).</t>
+        <figure anchor="retry-pseudo" align="left" suppress-title="false" pn="figure-8">
+          <name slugifiedName="name-retry-pseudo-packet">Retry Pseudo-Packet</name>
+          <artwork name="" type="" align="left" alt="" pn="section-5.8-5.1">
+Retry Pseudo-Packet {
+  ODCID Length (8),
+  Original Destination Connection ID (0..160),
+  Header Form (1) = 1,
+  Fixed Bit (1) = 1,
+  Long Packet Type (2) = 3,
+  Unused (4),
+  Version (32),
+  DCID Len (8),
+  Destination Connection ID (0..160),
+  SCID Len (8),
+  Source Connection ID (0..160),
+  Retry Token (..),
+}
+</artwork>
+        </figure>
+        <t indent="0" pn="section-5.8-6">The Retry Pseudo-Packet is not sent over the wire. It is computed by taking
+the transmitted Retry packet, removing the Retry Integrity Tag, and prepending
+the two following fields:</t>
+        <dl indent="3" newline="false" spacing="normal" pn="section-5.8-7">
+          <dt pn="section-5.8-7.1">ODCID Length:</dt>
+          <dd pn="section-5.8-7.2">
+            <t indent="0" pn="section-5.8-7.2.1">The ODCID Length field contains the length in bytes of the Original
+Destination Connection ID field that follows it, encoded as an 8-bit unsigned
+integer.</t>
+          </dd>
+          <dt pn="section-5.8-7.3">Original Destination Connection ID:</dt>
+          <dd pn="section-5.8-7.4">
+            <t indent="0" pn="section-5.8-7.4.1">The Original Destination Connection ID contains the value of the Destination
+Connection ID from the Initial packet that this Retry is in response to. The
+length of this field is given in ODCID Length. The presence of this field
+ensures that a valid Retry packet can only be sent by an entity that
+observes the Initial packet.</t>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section anchor="key-update" numbered="true" toc="include" removeInRFC="false" pn="section-6">
+      <name slugifiedName="name-key-update">Key Update</name>
+      <t indent="0" pn="section-6-1">Once the handshake is confirmed (see <xref target="handshake-confirmed" format="default" sectionFormat="of" derivedContent="Section 4.1.2"/>), an endpoint <bcp14>MAY</bcp14>
+initiate a key update.</t>
+      <t indent="0" pn="section-6-2">The Key Phase bit indicates which packet protection keys are used to protect the
+packet.  The Key Phase bit is initially set to 0 for the first set of 1-RTT
+packets and toggled to signal each subsequent key update.</t>
+      <t indent="0" pn="section-6-3">The Key Phase bit allows a recipient to detect a change in keying material
+without needing to receive the first packet that triggered the change.  An
+endpoint that notices a changed Key Phase bit updates keys and decrypts the
+packet that contains the changed value.</t>
+      <t indent="0" pn="section-6-4">Initiating a key update results in both endpoints updating keys.  This differs
+from TLS where endpoints can update keys independently.</t>
+      <t indent="0" pn="section-6-5">This mechanism replaces the key update mechanism of TLS, which relies on
+KeyUpdate messages sent using 1-RTT encryption keys.  Endpoints <bcp14>MUST NOT</bcp14> send a
+TLS KeyUpdate message.  Endpoints <bcp14>MUST</bcp14> treat the receipt of a TLS KeyUpdate
+message as a connection error of type 0x010a, equivalent to a
+fatal TLS alert of unexpected_message; see <xref target="tls-errors" format="default" sectionFormat="of" derivedContent="Section 4.8"/>.</t>
+      <t indent="0" pn="section-6-6"><xref target="ex-key-update" format="default" sectionFormat="of" derivedContent="Figure 9"/> shows a key update process, where the initial set of keys used
+(identified with @M) are replaced by updated keys (identified with @N).  The
+value of the Key Phase bit is indicated in brackets [].</t>
+      <figure anchor="ex-key-update" align="left" suppress-title="false" pn="figure-9">
+        <name slugifiedName="name-key-update-2">Key Update</name>
+        <artwork name="" type="" align="left" alt="" pn="section-6-7.1">
+   Initiating Peer                    Responding Peer
+
+@M [0] QUIC Packets
+
+... Update to @N
+@N [1] QUIC Packets
+                      --------&gt;
+                                         Update to @N ...
+                                      QUIC Packets [1] @N
+                      &lt;--------
+                                      QUIC Packets [1] @N
+                                    containing ACK
+                      &lt;--------
+... Key Update Permitted
+
+@N [1] QUIC Packets
+         containing ACK for @N packets
+                      --------&gt;
+                                 Key Update Permitted ...
+</artwork>
+      </figure>
+      <section anchor="key-update-initiate" numbered="true" toc="include" removeInRFC="false" pn="section-6.1">
+        <name slugifiedName="name-initiating-a-key-update">Initiating a Key Update</name>
+        <t indent="0" pn="section-6.1-1">Endpoints maintain separate read and write secrets for packet protection.  An
+endpoint initiates a key update by updating its packet protection write secret
+and using that to protect new packets.  The endpoint creates a new write secret
+from the existing write secret as performed in <xref section="7.2" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-7.2" derivedContent="TLS13"/>.  This
+uses the KDF function provided by TLS with a label of "quic ku".  The
+corresponding key and IV are created from that secret as defined in
+<xref target="protection-keys" format="default" sectionFormat="of" derivedContent="Section 5.1"/>.  The header protection key is not updated.</t>
+        <t indent="0" pn="section-6.1-2">For example, to update write keys with TLS 1.3, HKDF-Expand-Label is used as:</t>
+        <sourcecode type="pseudocode" markers="false" pn="section-6.1-3">
+secret_&lt;n+1&gt; = HKDF-Expand-Label(secret_&lt;n&gt;, "quic ku",
+                                 "", Hash.length)
+</sourcecode>
+        <t indent="0" pn="section-6.1-4">The endpoint toggles the value of the Key Phase bit and uses the updated key and
+IV to protect all subsequent packets.</t>
+        <t indent="0" pn="section-6.1-5">An endpoint <bcp14>MUST NOT</bcp14> initiate a key update prior to having confirmed the
+handshake (<xref target="handshake-confirmed" format="default" sectionFormat="of" derivedContent="Section 4.1.2"/>).  An endpoint <bcp14>MUST NOT</bcp14> initiate a subsequent
+key update unless it has received an acknowledgment for a packet that was sent
+protected with keys from the current key phase.  This ensures that keys are
+available to both peers before another key update can be initiated.  This can be
+implemented by tracking the lowest packet number sent with each key phase and
+the highest acknowledged packet number in the 1-RTT space: once the latter is
+higher than or equal to the former, another key update can be initiated.</t>
+        <aside pn="section-6.1-6">
+          <t indent="0" pn="section-6.1-6.1">Note: Keys of packets other than the 1-RTT packets are never updated; their keys
+  are derived solely from the TLS handshake state.</t>
+        </aside>
+        <t indent="0" pn="section-6.1-7">The endpoint that initiates a key update also updates the keys that it uses for
+receiving packets.  These keys will be needed to process packets the peer sends
+after updating.</t>
+        <t indent="0" pn="section-6.1-8">An endpoint <bcp14>MUST</bcp14> retain old keys until it has successfully unprotected a packet
+sent using the new keys.  An endpoint <bcp14>SHOULD</bcp14> retain old keys for some time
+after unprotecting a packet sent using the new keys.  Discarding old keys too
+early can cause delayed packets to be discarded.  Discarding packets will be
+interpreted as packet loss by the peer and could adversely affect performance.</t>
+      </section>
+      <section anchor="responding-to-a-key-update" numbered="true" toc="include" removeInRFC="false" pn="section-6.2">
+        <name slugifiedName="name-responding-to-a-key-update">Responding to a Key Update</name>
+        <t indent="0" pn="section-6.2-1">A peer is permitted to initiate a key update after receiving an acknowledgment
+of a packet in the current key phase.  An endpoint detects a key update when
+processing a packet with a key phase that differs from the value used to protect
+the last packet it sent.  To process this packet, the endpoint uses the next
+packet protection key and IV.  See <xref target="receive-key-generation" format="default" sectionFormat="of" derivedContent="Section 6.3"/> for considerations
+about generating these keys.</t>
+        <t indent="0" pn="section-6.2-2">If a packet is successfully processed using the next key and IV, then the peer
+has initiated a key update.  The endpoint <bcp14>MUST</bcp14> update its send keys to the
+corresponding key phase in response, as described in <xref target="key-update-initiate" format="default" sectionFormat="of" derivedContent="Section 6.1"/>.
+Sending keys <bcp14>MUST</bcp14> be updated before sending an acknowledgment for the packet
+that was received with updated keys.  By acknowledging the packet that triggered
+the key update in a packet protected with the updated keys, the endpoint signals
+that the key update is complete.</t>
+        <t indent="0" pn="section-6.2-3">An endpoint can defer sending the packet or acknowledgment according to its
+normal packet sending behavior; it is not necessary to immediately generate a
+packet in response to a key update.  The next packet sent by the endpoint will
+use the updated keys.  The next packet that contains an acknowledgment will
+cause the key update to be completed.  If an endpoint detects a second update
+before it has sent any packets with updated keys containing an
+acknowledgment for the packet that initiated the key update, it indicates that
+its peer has updated keys twice without awaiting confirmation.  An endpoint <bcp14>MAY</bcp14>
+treat such consecutive key updates as a connection error of type
+KEY_UPDATE_ERROR.</t>
+        <t indent="0" pn="section-6.2-4">An endpoint that receives an acknowledgment that is carried in a packet
+protected with old keys where any acknowledged packet was protected with newer
+keys <bcp14>MAY</bcp14> treat that as a connection error of type KEY_UPDATE_ERROR.  This
+indicates that a peer has received and acknowledged a packet that initiates a
+key update, but has not updated keys in response.</t>
+      </section>
+      <section anchor="receive-key-generation" numbered="true" toc="include" removeInRFC="false" pn="section-6.3">
+        <name slugifiedName="name-timing-of-receive-key-gener">Timing of Receive Key Generation</name>
+        <t indent="0" pn="section-6.3-1">Endpoints responding to an apparent key update <bcp14>MUST NOT</bcp14> generate a timing
+side-channel signal that might indicate that the Key Phase bit was invalid (see
+<xref target="hp-side-channel" format="default" sectionFormat="of" derivedContent="Section 9.5"/>).  Endpoints can use randomized packet protection keys in
+place of discarded keys when key updates are not yet permitted.  Using
+randomized keys ensures that attempting to remove packet protection does not
+result in timing variations, and results in packets with an invalid Key Phase
+bit being rejected.</t>
+        <t indent="0" pn="section-6.3-2">The process of creating new packet protection keys for receiving packets could
+reveal that a key update has occurred. An endpoint <bcp14>MAY</bcp14> generate new keys as
+part of packet processing, but this creates a timing signal that could be used
+by an attacker to learn when key updates happen and thus leak the value of the
+Key Phase bit.</t>
+        <t indent="0" pn="section-6.3-3">Endpoints are generally expected to have current and next receive packet
+protection keys available. For a short period after a key update completes, up
+to the PTO, endpoints <bcp14>MAY</bcp14> defer generation of the next set of
+receive packet protection keys. This allows endpoints
+to retain only two sets of receive keys; see <xref target="old-keys-recv" format="default" sectionFormat="of" derivedContent="Section 6.5"/>.</t>
+        <t indent="0" pn="section-6.3-4">Once generated, the next set of packet protection keys <bcp14>SHOULD</bcp14> be retained, even
+if the packet that was received was subsequently discarded.  Packets containing
+apparent key updates are easy to forge, and while the process of key update does
+not require significant effort, triggering this process could be used by an
+attacker for DoS.</t>
+        <t indent="0" pn="section-6.3-5">For this reason, endpoints <bcp14>MUST</bcp14> be able to retain two sets of packet protection
+keys for receiving packets: the current and the next.  Retaining the previous
+keys in addition to these might improve performance, but this is not essential.</t>
+      </section>
+      <section anchor="old-keys-send" numbered="true" toc="include" removeInRFC="false" pn="section-6.4">
+        <name slugifiedName="name-sending-with-updated-keys">Sending with Updated Keys</name>
+        <t indent="0" pn="section-6.4-1">An endpoint never sends packets that are protected with old keys.  Only the
+current keys are used.  Keys used for protecting packets can be discarded
+immediately after switching to newer keys.</t>
+        <t indent="0" pn="section-6.4-2">Packets with higher packet numbers <bcp14>MUST</bcp14> be protected with either the same or
+newer packet protection keys than packets with lower packet numbers.  An
+endpoint that successfully removes protection with old keys when newer keys were
+used for packets with lower packet numbers <bcp14>MUST</bcp14> treat this as a connection error
+of type KEY_UPDATE_ERROR.</t>
+      </section>
+      <section anchor="old-keys-recv" numbered="true" toc="include" removeInRFC="false" pn="section-6.5">
+        <name slugifiedName="name-receiving-with-different-ke">Receiving with Different Keys</name>
+        <t indent="0" pn="section-6.5-1">For receiving packets during a key update, packets protected with older keys
+might arrive if they were delayed by the network.  Retaining old packet
+protection keys allows these packets to be successfully processed.</t>
+        <t indent="0" pn="section-6.5-2">As packets protected with keys from the next key phase use the same Key Phase
+value as those protected with keys from the previous key phase, it is necessary
+to distinguish between the two if packets protected with old keys are to be
+processed.  This can be done using packet numbers.  A recovered packet number
+that is lower than any packet number from the current key phase uses the
+previous packet protection keys; a recovered packet number that is higher than
+any packet number from the current key phase requires the use of the next packet
+protection keys.</t>
+        <t indent="0" pn="section-6.5-3">Some care is necessary to ensure that any process for selecting between
+previous, current, and next packet protection keys does not expose a timing side
+channel that might reveal which keys were used to remove packet protection.  See
+<xref target="hp-side-channel" format="default" sectionFormat="of" derivedContent="Section 9.5"/> for more information.</t>
+        <t indent="0" pn="section-6.5-4">Alternatively, endpoints can retain only two sets of packet protection keys,
+swapping previous for next after enough time has passed to allow for reordering
+in the network.  In this case, the Key Phase bit alone can be used to select
+keys.</t>
+        <t indent="0" pn="section-6.5-5">An endpoint <bcp14>MAY</bcp14> allow a period of approximately the Probe Timeout (PTO; see
+<xref target="QUIC-RECOVERY" format="default" sectionFormat="of" derivedContent="QUIC-RECOVERY"/>) after promoting the next set of receive keys to be current
+before it creates the subsequent set of packet protection keys. These updated
+keys <bcp14>MAY</bcp14> replace the previous keys at that time. With the caveat that PTO is a
+subjective measure -- that is, a peer could have a different view of the RTT --
+this time is expected to be long enough that any reordered packets would be
+declared lost by a peer even if they were acknowledged and short enough to allow
+a peer to initiate further key updates.</t>
+        <t indent="0" pn="section-6.5-6">Endpoints need to allow for the possibility that a peer might not be able to
+decrypt packets that initiate a key update during the period when the peer
+retains old keys.  Endpoints <bcp14>SHOULD</bcp14> wait three times the PTO before initiating a
+key update after receiving an acknowledgment that confirms that the previous key
+update was received.  Failing to allow sufficient time could lead to packets
+being discarded.</t>
+        <t indent="0" pn="section-6.5-7">An endpoint <bcp14>SHOULD</bcp14> retain old read keys for no more than three times the PTO
+after having received a packet protected using the new keys. After this period,
+old read keys and their corresponding secrets <bcp14>SHOULD</bcp14> be discarded.</t>
+      </section>
+      <section anchor="aead-limits" numbered="true" toc="include" removeInRFC="false" pn="section-6.6">
+        <name slugifiedName="name-limits-on-aead-usage">Limits on AEAD Usage</name>
+        <t indent="0" pn="section-6.6-1">This document sets usage limits for AEAD algorithms to ensure that overuse does
+not give an adversary a disproportionate advantage in attacking the
+confidentiality and integrity of communications when using QUIC.</t>
+        <t indent="0" pn="section-6.6-2">The usage limits defined in TLS 1.3 exist for protection against attacks
+on confidentiality and apply to successful applications of AEAD protection. The
+integrity protections in authenticated encryption also depend on limiting the
+number of attempts to forge packets. TLS achieves this by closing connections
+after any record fails an authentication check. In comparison, QUIC ignores any
+packet that cannot be authenticated, allowing multiple forgery attempts.</t>
+        <t indent="0" pn="section-6.6-3">QUIC accounts for AEAD confidentiality and integrity limits separately. The
+confidentiality limit applies to the number of packets encrypted with a given
+key. The integrity limit applies to the number of packets decrypted within a
+given connection. Details on enforcing these limits for each AEAD algorithm
+follow below.</t>
+        <t indent="0" pn="section-6.6-4">Endpoints <bcp14>MUST</bcp14> count the number of encrypted packets for each set of keys. If
+the total number of encrypted packets with the same key exceeds the
+confidentiality limit for the selected AEAD, the endpoint <bcp14>MUST</bcp14> stop using those
+keys. Endpoints <bcp14>MUST</bcp14> initiate a key update before sending more protected packets
+than the confidentiality limit for the selected AEAD permits. If a key update
+is not possible or integrity limits are reached, the endpoint <bcp14>MUST</bcp14> stop using
+the connection and only send stateless resets in response to receiving packets.
+It is <bcp14>RECOMMENDED</bcp14> that endpoints immediately close the connection with a
+connection error of type AEAD_LIMIT_REACHED before reaching a state where key
+updates are not possible.</t>
+        <t indent="0" pn="section-6.6-5">For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the confidentiality limit is
+2<sup>23</sup> encrypted packets; see <xref target="gcm-bounds" format="default" sectionFormat="of" derivedContent="Appendix B.1"/>. For
+AEAD_CHACHA20_POLY1305, the confidentiality limit is greater than the number of
+possible packets (2<sup>62</sup>) and so can be disregarded. For
+AEAD_AES_128_CCM, the confidentiality limit is 2<sup>21.5</sup> encrypted
+packets; see <xref target="ccm-bounds" format="default" sectionFormat="of" derivedContent="Appendix B.2"/>. Applying a limit reduces the probability that an
+attacker can distinguish the AEAD in use from a random permutation; see
+<xref target="AEBounds" format="default" sectionFormat="of" derivedContent="AEBounds"/>, <xref target="ROBUST" format="default" sectionFormat="of" derivedContent="ROBUST"/>, and <xref target="GCM-MU" format="default" sectionFormat="of" derivedContent="GCM-MU"/>.</t>
+        <t indent="0" pn="section-6.6-6">In addition to counting packets sent, endpoints <bcp14>MUST</bcp14> count the number of
+received packets that fail authentication during the lifetime of a connection.
+If the total number of received packets that fail authentication within the
+connection, across all keys, exceeds the integrity limit for the selected AEAD,
+the endpoint <bcp14>MUST</bcp14> immediately close the connection with a connection error of
+type AEAD_LIMIT_REACHED and not process any more packets.</t>
+        <t indent="0" pn="section-6.6-7">For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the integrity limit is 2<sup>52</sup>
+invalid packets; see <xref target="gcm-bounds" format="default" sectionFormat="of" derivedContent="Appendix B.1"/>. For AEAD_CHACHA20_POLY1305, the integrity
+limit is 2<sup>36</sup> invalid packets; see <xref target="AEBounds" format="default" sectionFormat="of" derivedContent="AEBounds"/>. For AEAD_AES_128_CCM,
+the integrity limit is 2<sup>21.5</sup> invalid packets; see
+<xref target="ccm-bounds" format="default" sectionFormat="of" derivedContent="Appendix B.2"/>. Applying this limit reduces the probability that an attacker can
+successfully forge a packet; see <xref target="AEBounds" format="default" sectionFormat="of" derivedContent="AEBounds"/>, <xref target="ROBUST" format="default" sectionFormat="of" derivedContent="ROBUST"/>, and <xref target="GCM-MU" format="default" sectionFormat="of" derivedContent="GCM-MU"/>.</t>
+        <t indent="0" pn="section-6.6-8">Endpoints that limit the size of packets <bcp14>MAY</bcp14> use higher confidentiality and
+integrity limits; see <xref target="aead-analysis" format="default" sectionFormat="of" derivedContent="Appendix B"/> for details.</t>
+        <t indent="0" pn="section-6.6-9">Future analyses and specifications <bcp14>MAY</bcp14> relax confidentiality or integrity limits
+for an AEAD.</t>
+        <t indent="0" pn="section-6.6-10">Any TLS cipher suite that is specified for use with QUIC <bcp14>MUST</bcp14> define limits on
+the use of the associated AEAD function that preserves margins for
+confidentiality and integrity. That is, limits <bcp14>MUST</bcp14> be specified for the number
+of packets that can be authenticated and for the number of packets that can fail
+authentication.  Providing a reference to any analysis upon which values are
+based -- and any assumptions used in that analysis -- allows limits to be
+adapted to varying usage conditions.</t>
+      </section>
+      <section anchor="key-update-error" numbered="true" toc="include" removeInRFC="false" pn="section-6.7">
+        <name slugifiedName="name-key-update-error-code">Key Update Error Code</name>
+        <t indent="0" pn="section-6.7-1">The KEY_UPDATE_ERROR error code (0x0e) is used to signal errors related to key
+updates.</t>
+      </section>
+    </section>
+    <section anchor="security-of-initial-messages" numbered="true" toc="include" removeInRFC="false" pn="section-7">
+      <name slugifiedName="name-security-of-initial-message">Security of Initial Messages</name>
+      <t indent="0" pn="section-7-1">Initial packets are not protected with a secret key, so they are subject to
+potential tampering by an attacker.  QUIC provides protection against attackers
+that cannot read packets but does not attempt to provide additional protection
+against attacks where the attacker can observe and inject packets.  Some forms
+of tampering -- such as modifying the TLS messages themselves -- are detectable,
+but some -- such as modifying ACKs -- are not.</t>
+      <t indent="0" pn="section-7-2">For example, an attacker could inject a packet containing an ACK frame to
+make it appear that a packet had not been received or to create a false
+impression of the state of the connection (e.g., by modifying the ACK Delay).
+Note that such a packet could cause a legitimate packet to be dropped as a
+duplicate.  Implementations <bcp14>SHOULD</bcp14> use caution in relying on any data that is
+contained in Initial packets that is not otherwise authenticated.</t>
+      <t indent="0" pn="section-7-3">It is also possible for the attacker to tamper with data that is carried in
+Handshake packets, but because that sort of tampering requires modifying TLS
+handshake messages, any such tampering will cause the TLS handshake to fail.</t>
+    </section>
+    <section anchor="quic-specific-adjustments-to-the-tls-handshake" numbered="true" toc="include" removeInRFC="false" pn="section-8">
+      <name slugifiedName="name-quic-specific-adjustments-t">QUIC-Specific Adjustments to the TLS Handshake</name>
+      <t indent="0" pn="section-8-1">Certain aspects of the TLS handshake are different when used with QUIC.</t>
+      <t indent="0" pn="section-8-2">QUIC also requires additional features from TLS.  In addition to negotiation of
+cryptographic parameters, the TLS handshake carries and authenticates values for
+QUIC transport parameters.</t>
+      <section anchor="protocol-negotiation" numbered="true" toc="include" removeInRFC="false" pn="section-8.1">
+        <name slugifiedName="name-protocol-negotiation">Protocol Negotiation</name>
+        <t indent="0" pn="section-8.1-1">QUIC requires that the cryptographic handshake provide authenticated protocol
+negotiation.  TLS uses Application-Layer Protocol Negotiation
+<xref target="ALPN" format="default" sectionFormat="of" derivedContent="ALPN"/> to select an application protocol.  Unless another mechanism
+is used for agreeing on an application protocol, endpoints <bcp14>MUST</bcp14> use ALPN for
+this purpose.</t>
+        <t indent="0" pn="section-8.1-2">When using ALPN, endpoints <bcp14>MUST</bcp14> immediately close a connection (see <xref section="10.2" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-10.2" derivedContent="QUIC-TRANSPORT"/>) with a no_application_protocol TLS alert (QUIC error
+code 0x0178; see <xref target="tls-errors" format="default" sectionFormat="of" derivedContent="Section 4.8"/>) if an application protocol is not negotiated.
+While <xref target="ALPN" format="default" sectionFormat="of" derivedContent="ALPN"/> only specifies that servers use this alert, QUIC clients <bcp14>MUST</bcp14>
+use error 0x0178 to terminate a connection when ALPN negotiation fails.</t>
+        <t indent="0" pn="section-8.1-3">An application protocol <bcp14>MAY</bcp14> restrict the QUIC versions that it can operate over.
+Servers <bcp14>MUST</bcp14> select an application protocol compatible with the QUIC version
+that the client has selected.  The server <bcp14>MUST</bcp14> treat the inability to select a
+compatible application protocol as a connection error of type 0x0178
+(no_application_protocol).  Similarly, a client <bcp14>MUST</bcp14> treat the selection of an
+incompatible application protocol by a server as a connection error of type
+0x0178.</t>
+      </section>
+      <section anchor="quic_parameters" numbered="true" toc="include" removeInRFC="false" pn="section-8.2">
+        <name slugifiedName="name-quic-transport-parameters-e">QUIC Transport Parameters Extension</name>
+        <t indent="0" pn="section-8.2-1">QUIC transport parameters are carried in a TLS extension. Different versions of
+QUIC might define a different method for negotiating transport configuration.</t>
+        <t indent="0" pn="section-8.2-2">Including transport parameters in the TLS handshake provides integrity
+protection for these values.</t>
+        <sourcecode type="tls-presentation" markers="false" pn="section-8.2-3">
+   enum {
+      quic_transport_parameters(0x39), (65535)
+   } ExtensionType;
+</sourcecode>
+        <t indent="0" pn="section-8.2-4">The extension_data field of the quic_transport_parameters extension contains a
+value that is defined by the version of QUIC that is in use.</t>
+        <t indent="0" pn="section-8.2-5">The quic_transport_parameters extension is carried in the ClientHello and the
+EncryptedExtensions messages during the handshake. Endpoints <bcp14>MUST</bcp14> send the
+quic_transport_parameters extension; endpoints that receive ClientHello or
+EncryptedExtensions messages without the quic_transport_parameters extension
+<bcp14>MUST</bcp14> close the connection with an error of type 0x016d (equivalent to a fatal
+TLS missing_extension alert, see <xref target="tls-errors" format="default" sectionFormat="of" derivedContent="Section 4.8"/>).</t>
+        <t indent="0" pn="section-8.2-6">Transport parameters become available prior to the completion of the handshake.
+A server might use these values earlier than handshake completion. However, the
+value of transport parameters is not authenticated until the handshake
+completes, so any use of these parameters cannot depend on their authenticity.
+Any tampering with transport parameters will cause the handshake to fail.</t>
+        <t indent="0" pn="section-8.2-7">Endpoints <bcp14>MUST NOT</bcp14> send this extension in a TLS connection that does not use
+QUIC (such as the use of TLS with TCP defined in <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>).  A fatal
+unsupported_extension alert <bcp14>MUST</bcp14> be sent by an implementation that supports this
+extension if the extension is received when the transport is not QUIC.</t>
+        <t indent="0" pn="section-8.2-8">Negotiating the quic_transport_parameters extension causes the EndOfEarlyData to
+be removed; see <xref target="remove-eoed" format="default" sectionFormat="of" derivedContent="Section 8.3"/>.</t>
+      </section>
+      <section anchor="remove-eoed" numbered="true" toc="include" removeInRFC="false" pn="section-8.3">
+        <name slugifiedName="name-removing-the-endofearlydata">Removing the EndOfEarlyData Message</name>
+        <t indent="0" pn="section-8.3-1">The TLS EndOfEarlyData message is not used with QUIC.  QUIC does not rely on
+this message to mark the end of 0-RTT data or to signal the change to Handshake
+keys.</t>
+        <t indent="0" pn="section-8.3-2">Clients <bcp14>MUST NOT</bcp14> send the EndOfEarlyData message.  A server <bcp14>MUST</bcp14> treat receipt
+of a CRYPTO frame in a 0-RTT packet as a connection error of type
+PROTOCOL_VIOLATION.</t>
+        <t indent="0" pn="section-8.3-3">As a result, EndOfEarlyData does not appear in the TLS handshake transcript.</t>
+      </section>
+      <section anchor="compat-mode" numbered="true" toc="include" removeInRFC="false" pn="section-8.4">
+        <name slugifiedName="name-prohibit-tls-middlebox-comp">Prohibit TLS Middlebox Compatibility Mode</name>
+        <t indent="0" pn="section-8.4-1">Appendix D.4 of <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> describes an alteration to the TLS 1.3 handshake as
+a workaround for bugs in some middleboxes. The TLS 1.3 middlebox compatibility
+mode involves setting the legacy_session_id field to a 32-byte value in the
+ClientHello and ServerHello, then sending a change_cipher_spec record. Both
+field and record carry no semantic content and are ignored.</t>
+        <t indent="0" pn="section-8.4-2">This mode has no use in QUIC as it only applies to middleboxes that interfere
+with TLS over TCP. QUIC also provides no means to carry a change_cipher_spec
+record. A client <bcp14>MUST NOT</bcp14> request the use of the TLS 1.3 compatibility mode. A
+server <bcp14>SHOULD</bcp14> treat the receipt of a TLS ClientHello with a non-empty
+legacy_session_id field as a connection error of type PROTOCOL_VIOLATION.</t>
+      </section>
+    </section>
+    <section anchor="security-considerations" numbered="true" toc="include" removeInRFC="false" pn="section-9">
+      <name slugifiedName="name-security-considerations">Security Considerations</name>
+      <t indent="0" pn="section-9-1">All of the security considerations that apply to TLS also apply to the use of
+TLS in QUIC. Reading all of <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> and its appendices is the best way to
+gain an understanding of the security properties of QUIC.</t>
+      <t indent="0" pn="section-9-2">This section summarizes some of the more important security aspects specific to
+the TLS integration, though there are many security-relevant details in the
+remainder of the document.</t>
+      <section anchor="session-linkability" numbered="true" toc="include" removeInRFC="false" pn="section-9.1">
+        <name slugifiedName="name-session-linkability">Session Linkability</name>
+        <t indent="0" pn="section-9.1-1">Use of TLS session tickets allows servers and possibly other entities to
+correlate connections made by the same client; see <xref target="resumption" format="default" sectionFormat="of" derivedContent="Section 4.5"/> for details.</t>
+      </section>
+      <section anchor="replay" numbered="true" toc="include" removeInRFC="false" pn="section-9.2">
+        <name slugifiedName="name-replay-attacks-with-0-rtt">Replay Attacks with 0-RTT</name>
+        <t indent="0" pn="section-9.2-1">As described in <xref section="8" sectionFormat="of" target="TLS13" format="default" derivedLink="https://rfc-editor.org/rfc/rfc8446#section-8" derivedContent="TLS13"/>, use of TLS early data comes with an
+exposure to replay attack.  The use of 0-RTT in QUIC is similarly vulnerable to
+replay attack.</t>
+        <t indent="0" pn="section-9.2-2">Endpoints <bcp14>MUST</bcp14> implement and use the replay protections described in <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>,
+however it is recognized that these protections are imperfect.  Therefore,
+additional consideration of the risk of replay is needed.</t>
+        <t indent="0" pn="section-9.2-3">QUIC is not vulnerable to replay attack, except via the application protocol
+information it might carry.  The management of QUIC protocol state based on the
+frame types defined in <xref target="QUIC-TRANSPORT" format="default" sectionFormat="of" derivedContent="QUIC-TRANSPORT"/> is not vulnerable to replay.
+Processing of QUIC frames is idempotent and cannot result in invalid connection
+states if frames are replayed, reordered, or lost.  QUIC connections do not
+produce effects that last beyond the lifetime of the connection, except for
+those produced by the application protocol that QUIC serves.</t>
+        <t indent="0" pn="section-9.2-4">TLS session tickets and address validation tokens are used to carry QUIC
+configuration information between connections, specifically, to enable a server
+to efficiently recover state that is used in connection establishment and
+address validation.  These <bcp14>MUST NOT</bcp14> be used to communicate application semantics
+between endpoints; clients <bcp14>MUST</bcp14> treat them as opaque values.  The potential for
+reuse of these tokens means that they require stronger protections against
+replay.</t>
+        <t indent="0" pn="section-9.2-5">A server that accepts 0-RTT on a connection incurs a higher cost than accepting
+a connection without 0-RTT.  This includes higher processing and computation
+costs.  Servers need to consider the probability of replay and all associated
+costs when accepting 0-RTT.</t>
+        <t indent="0" pn="section-9.2-6">Ultimately, the responsibility for managing the risks of replay attacks with
+0-RTT lies with an application protocol.  An application protocol that uses QUIC
+<bcp14>MUST</bcp14> describe how the protocol uses 0-RTT and the measures that are employed to
+protect against replay attack.  An analysis of replay risk needs to consider
+all QUIC protocol features that carry application semantics.</t>
+        <t indent="0" pn="section-9.2-7">Disabling 0-RTT entirely is the most effective defense against replay attack.</t>
+        <t indent="0" pn="section-9.2-8">QUIC extensions <bcp14>MUST</bcp14> either describe how replay attacks affect their operation
+or prohibit the use of the extension in 0-RTT.  Application protocols <bcp14>MUST</bcp14>
+either prohibit the use of extensions that carry application semantics in 0-RTT
+or provide replay mitigation strategies.</t>
+      </section>
+      <section anchor="reflection" numbered="true" toc="include" removeInRFC="false" pn="section-9.3">
+        <name slugifiedName="name-packet-reflection-attack-mi">Packet Reflection Attack Mitigation</name>
+        <t indent="0" pn="section-9.3-1">A small ClientHello that results in a large block of handshake messages from a
+server can be used in packet reflection attacks to amplify the traffic generated
+by an attacker.</t>
+        <t indent="0" pn="section-9.3-2">QUIC includes three defenses against this attack. First, the packet containing
+a ClientHello <bcp14>MUST</bcp14> be padded to a minimum size. Second, if responding to an
+unverified source address, the server is forbidden to send more than three
+times as many bytes as the number of bytes it has received (see <xref section="8.1" sectionFormat="of" target="QUIC-TRANSPORT" format="default" derivedLink="https://rfc-editor.org/rfc/rfc9000#section-8.1" derivedContent="QUIC-TRANSPORT"/>). Finally, because acknowledgments of Handshake packets are
+authenticated, a blind attacker cannot forge them. Put together, these defenses
+limit the level of amplification.</t>
+      </section>
+      <section anchor="header-protect-analysis" numbered="true" toc="include" removeInRFC="false" pn="section-9.4">
+        <name slugifiedName="name-header-protection-analysis">Header Protection Analysis</name>
+        <t indent="0" pn="section-9.4-1"><xref target="NAN" format="default" sectionFormat="of" derivedContent="NAN"/> analyzes authenticated encryption
+algorithms that provide nonce privacy, referred to as "Hide Nonce" (HN)
+transforms. The general header protection construction in this document is
+one of those algorithms (HN1). Header protection is applied after the packet
+protection AEAD, sampling a set of bytes (<tt>sample</tt>) from the AEAD output and
+encrypting the header field using a pseudorandom function (PRF) as follows:</t>
+        <sourcecode type="pseudocode" markers="false" pn="section-9.4-2">
+protected_field = field XOR PRF(hp_key, sample)
+</sourcecode>
+        <t indent="0" pn="section-9.4-3">The header protection variants in this document use a pseudorandom permutation
+(PRP) in place of a generic PRF. However, since all PRPs are also PRFs <xref target="IMC" format="default" sectionFormat="of" derivedContent="IMC"/>,
+these variants do not deviate from the HN1 construction.</t>
+        <t indent="0" pn="section-9.4-4">As <tt>hp_key</tt> is distinct from the packet protection key, it follows that header
+protection achieves AE2 security as defined in <xref target="NAN" format="default" sectionFormat="of" derivedContent="NAN"/> and therefore guarantees
+privacy of <tt>field</tt>, the protected packet header. Future header protection
+variants based on this construction <bcp14>MUST</bcp14> use a PRF to ensure equivalent
+security guarantees.</t>
+        <t indent="0" pn="section-9.4-5">Use of the same key and ciphertext sample more than once risks compromising
+header protection. Protecting two different headers with the same key and
+ciphertext sample reveals the exclusive OR of the protected fields.  Assuming
+that the AEAD acts as a PRF, if L bits are sampled, the odds of two ciphertext
+samples being identical approach 2<sup>-L/2</sup>, that is, the birthday bound.
+For the algorithms described in this document, that probability is one in
+2<sup>64</sup>.</t>
+        <t indent="0" pn="section-9.4-6">To prevent an attacker from modifying packet headers, the header is transitively
+authenticated using packet protection; the entire packet header is part of the
+authenticated additional data.  Protected fields that are falsified or modified
+can only be detected once the packet protection is removed.</t>
+      </section>
+      <section anchor="hp-side-channel" numbered="true" toc="include" removeInRFC="false" pn="section-9.5">
+        <name slugifiedName="name-header-protection-timing-si">Header Protection Timing Side Channels</name>
+        <t indent="0" pn="section-9.5-1">An attacker could guess values for packet numbers or Key Phase and have an
+endpoint confirm guesses through timing side channels.  Similarly, guesses for
+the packet number length can be tried and exposed.  If the recipient of a packet
+discards packets with duplicate packet numbers without attempting to remove
+packet protection, they could reveal through timing side channels that the
+packet number matches a received packet.  For authentication to be free from
+side channels, the entire process of header protection removal, packet number
+recovery, and packet protection removal <bcp14>MUST</bcp14> be applied together without timing
+and other side channels.</t>
+        <t indent="0" pn="section-9.5-2">For the sending of packets, construction and protection of packet payloads and
+packet numbers <bcp14>MUST</bcp14> be free from side channels that would reveal the packet
+number or its encoded size.</t>
+        <t indent="0" pn="section-9.5-3">During a key update, the time taken to generate new keys could reveal through
+timing side channels that a key update has occurred.  Alternatively, where an
+attacker injects packets, this side channel could reveal the value of the Key
+Phase on injected packets.  After receiving a key update, an endpoint <bcp14>SHOULD</bcp14>
+generate and save the next set of receive packet protection keys, as described
+in <xref target="receive-key-generation" format="default" sectionFormat="of" derivedContent="Section 6.3"/>.  By generating new keys before a key update is
+received, receipt of packets will not create timing signals that leak the value
+of the Key Phase.</t>
+        <t indent="0" pn="section-9.5-4">This depends on not doing this key generation during packet processing, and it
+can require that endpoints maintain three sets of packet protection keys for
+receiving: for the previous key phase, for the current key phase, and for the
+next key phase.  Endpoints can instead choose to defer generation of the next
+receive packet protection keys until they discard old keys so that only two sets
+of receive keys need to be retained at any point in time.</t>
+      </section>
+      <section anchor="key-diversity" numbered="true" toc="include" removeInRFC="false" pn="section-9.6">
+        <name slugifiedName="name-key-diversity">Key Diversity</name>
+        <t indent="0" pn="section-9.6-1">In using TLS, the central key schedule of TLS is used.  As a result of the TLS
+handshake messages being integrated into the calculation of secrets, the
+inclusion of the QUIC transport parameters extension ensures that the handshake
+and 1-RTT keys are not the same as those that might be produced by a server
+running TLS over TCP.  To avoid the possibility of cross-protocol key
+synchronization, additional measures are provided to improve key separation.</t>
+        <t indent="0" pn="section-9.6-2">The QUIC packet protection keys and IVs are derived using a different label than
+the equivalent keys in TLS.</t>
+        <t indent="0" pn="section-9.6-3">To preserve this separation, a new version of QUIC <bcp14>SHOULD</bcp14> define new labels for
+key derivation for packet protection key and IV, plus the header protection
+keys.  This version of QUIC uses the string "quic".  Other versions can use a
+version-specific label in place of that string.</t>
+        <t indent="0" pn="section-9.6-4">The initial secrets use a key that is specific to the negotiated QUIC version.
+New QUIC versions <bcp14>SHOULD</bcp14> define a new salt value used in calculating initial
+secrets.</t>
+      </section>
+      <section anchor="randomness" numbered="true" toc="include" removeInRFC="false" pn="section-9.7">
+        <name slugifiedName="name-randomness">Randomness</name>
+        <t indent="0" pn="section-9.7-1">QUIC depends on endpoints being able to generate secure random numbers, both
+directly for protocol values such as the connection ID, and transitively via
+TLS. See <xref target="RFC4086" format="default" sectionFormat="of" derivedContent="RFC4086"/> for guidance on secure random number generation.</t>
+      </section>
+    </section>
+    <section anchor="iana-considerations" numbered="true" toc="include" removeInRFC="false" pn="section-10">
+      <name slugifiedName="name-iana-considerations">IANA Considerations</name>
+      <t indent="0" pn="section-10-1">IANA has registered a codepoint of 57 (or 0x39) for the
+quic_transport_parameters extension (defined in <xref target="quic_parameters" format="default" sectionFormat="of" derivedContent="Section 8.2"/>) in the "TLS
+ExtensionType Values" registry <xref target="TLS-REGISTRIES" format="default" sectionFormat="of" derivedContent="TLS-REGISTRIES"/>.</t>
+      <t indent="0" pn="section-10-2">The Recommended column for this extension is marked Yes. The TLS 1.3 Column
+includes CH (ClientHello) and EE (EncryptedExtensions).</t>
+      <table anchor="iana-tls-ext" align="center" pn="table-2">
+        <name slugifiedName="name-tls-extensiontype-values-re">TLS ExtensionType Values Registry Entry</name>
+        <thead>
+          <tr>
+            <th align="right" colspan="1" rowspan="1">Value</th>
+            <th align="left" colspan="1" rowspan="1">Extension Name</th>
+            <th align="left" colspan="1" rowspan="1">TLS 1.3</th>
+            <th align="left" colspan="1" rowspan="1">Recommended</th>
+            <th align="left" colspan="1" rowspan="1">Reference</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td align="right" colspan="1" rowspan="1">57</td>
+            <td align="left" colspan="1" rowspan="1">quic_transport_parameters</td>
+            <td align="left" colspan="1" rowspan="1">CH, EE</td>
+            <td align="left" colspan="1" rowspan="1">Y</td>
+            <td align="left" colspan="1" rowspan="1">This document</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </middle>
+  <back>
+    <references pn="section-11">
+      <name slugifiedName="name-references">References</name>
+      <references pn="section-11.1">
+        <name slugifiedName="name-normative-references">Normative References</name>
+        <reference anchor="AEAD" target="https://www.rfc-editor.org/info/rfc5116" quoteTitle="true" derivedAnchor="AEAD">
+          <front>
+            <title>An Interface and Algorithms for Authenticated Encryption</title>
+            <author fullname="D. McGrew" initials="D." surname="McGrew">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="January" year="2008"/>
+            <abstract>
+              <t indent="0">This document defines algorithms for Authenticated Encryption with Associated Data (AEAD), and defines a uniform interface and a registry for such algorithms.  The interface and registry can be used as an application-independent set of cryptoalgorithm suites.  This approach provides advantages in efficiency and security, and promotes the reuse of crypto implementations.  [STANDARDS-TRACK]</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="5116"/>
+          <seriesInfo name="DOI" value="10.17487/RFC5116"/>
+        </reference>
+        <reference anchor="AES" quoteTitle="true" target="https://doi.org/10.6028/nist.fips.197" derivedAnchor="AES">
+          <front>
+            <title>Advanced encryption standard (AES)</title>
+            <author>
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="November" year="2001"/>
+          </front>
+          <seriesInfo name="National Institute of Standards and Technology" value="report"/>
+          <seriesInfo name="DOI" value="10.6028/nist.fips.197"/>
+        </reference>
+        <reference anchor="ALPN" target="https://www.rfc-editor.org/info/rfc7301" quoteTitle="true" derivedAnchor="ALPN">
+          <front>
+            <title>Transport Layer Security (TLS) Application-Layer Protocol Negotiation Extension</title>
+            <author fullname="S. Friedl" initials="S." surname="Friedl">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="A. Popov" initials="A." surname="Popov">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="A. Langley" initials="A." surname="Langley">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="E. Stephan" initials="E." surname="Stephan">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="July" year="2014"/>
+            <abstract>
+              <t indent="0">This document describes a Transport Layer Security (TLS) extension for application-layer protocol negotiation within the TLS handshake. For instances in which multiple application protocols are supported on the same TCP or UDP port, this extension allows the application layer to negotiate which protocol will be used within the TLS connection.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="7301"/>
+          <seriesInfo name="DOI" value="10.17487/RFC7301"/>
+        </reference>
+        <reference anchor="CHACHA" target="https://www.rfc-editor.org/info/rfc8439" quoteTitle="true" derivedAnchor="CHACHA">
+          <front>
+            <title>ChaCha20 and Poly1305 for IETF Protocols</title>
+            <author fullname="Y. Nir" initials="Y." surname="Nir">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="A. Langley" initials="A." surname="Langley">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="June" year="2018"/>
+            <abstract>
+              <t indent="0">This document defines the ChaCha20 stream cipher as well as the use of the Poly1305 authenticator, both as stand-alone algorithms and as a "combined mode", or Authenticated Encryption with Associated Data (AEAD) algorithm.</t>
+              <t indent="0">RFC 7539, the predecessor of this document, was meant to serve as a stable reference and an implementation guide.  It was a product of the Crypto Forum Research Group (CFRG).  This document merges the errata filed against RFC 7539 and adds a little text to the Security Considerations section.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8439"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8439"/>
+        </reference>
+        <reference anchor="HKDF" target="https://www.rfc-editor.org/info/rfc5869" quoteTitle="true" derivedAnchor="HKDF">
+          <front>
+            <title>HMAC-based Extract-and-Expand Key Derivation Function (HKDF)</title>
+            <author fullname="H. Krawczyk" initials="H." surname="Krawczyk">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="P. Eronen" initials="P." surname="Eronen">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="May" year="2010"/>
+            <abstract>
+              <t indent="0">This document specifies a simple Hashed Message Authentication Code (HMAC)-based key derivation function (HKDF), which can be used as a building block in various protocols and applications.  The key derivation function (KDF) is intended to support a wide range of applications and requirements, and is conservative in its use of cryptographic hash functions.  This document is not an Internet  Standards Track specification; it is published for informational  purposes.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="5869"/>
+          <seriesInfo name="DOI" value="10.17487/RFC5869"/>
+        </reference>
+        <reference anchor="QUIC-RECOVERY" target="https://www.rfc-editor.org/info/rfc9002" quoteTitle="true" derivedAnchor="QUIC-RECOVERY">
+          <front>
+            <title>QUIC Loss Detection and Congestion Control</title>
+            <author initials="J." surname="Iyengar" fullname="Jana Iyengar" role="editor">
+              <organization showOnFrontPage="true">Fastly</organization>
+            </author>
+            <author initials="I." surname="Swett" fullname="Ian Swett" role="editor">
+              <organization showOnFrontPage="true">Google</organization>
+            </author>
+            <date year="2021" month="May"/>
+          </front>
+          <seriesInfo name="RFC" value="9002"/>
+          <seriesInfo name="DOI" value="10.17487/RFC9002"/>
+        </reference>
+        <reference anchor="QUIC-TRANSPORT" target="https://www.rfc-editor.org/info/rfc9000" quoteTitle="true" derivedAnchor="QUIC-TRANSPORT">
+          <front>
+            <title>QUIC: A UDP-Based Multiplexed and Secure Transport</title>
+            <author initials="J." surname="Iyengar" fullname="Jana Iyengar" role="editor">
+              <organization showOnFrontPage="true">Fastly</organization>
+            </author>
+            <author initials="M." surname="Thomson" fullname="Martin Thomson" role="editor">
+              <organization showOnFrontPage="true">Mozilla</organization>
+            </author>
+            <date year="2021" month="May"/>
+          </front>
+          <seriesInfo name="RFC" value="9000"/>
+          <seriesInfo name="DOI" value="10.17487/RFC9000"/>
+        </reference>
+        <reference anchor="RFC2119" target="https://www.rfc-editor.org/info/rfc2119" quoteTitle="true" derivedAnchor="RFC2119">
+          <front>
+            <title>Key words for use in RFCs to Indicate Requirement Levels</title>
+            <author fullname="S. Bradner" initials="S." surname="Bradner">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="March" year="1997"/>
+            <abstract>
+              <t indent="0">In many standards track documents several words are used to signify the requirements in the specification.  These words are often capitalized. This document defines these words as they should be interpreted in IETF documents.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="14"/>
+          <seriesInfo name="RFC" value="2119"/>
+          <seriesInfo name="DOI" value="10.17487/RFC2119"/>
+        </reference>
+        <reference anchor="RFC4086" target="https://www.rfc-editor.org/info/rfc4086" quoteTitle="true" derivedAnchor="RFC4086">
+          <front>
+            <title>Randomness Requirements for Security</title>
+            <author fullname="D. Eastlake 3rd" initials="D." surname="Eastlake 3rd">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="J. Schiller" initials="J." surname="Schiller">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="S. Crocker" initials="S." surname="Crocker">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="June" year="2005"/>
+            <abstract>
+              <t indent="0">Security systems are built on strong cryptographic algorithms that foil pattern analysis attempts.  However, the security of these systems is dependent on generating secret quantities for passwords, cryptographic keys, and similar quantities.  The use of pseudo-random processes to generate secret quantities can result in pseudo-security. A sophisticated attacker may find it easier to reproduce the environment that produced the secret quantities and to search the resulting small set of possibilities than to locate the quantities in the whole of the potential number space.</t>
+              <t indent="0">Choosing random quantities to foil a resourceful and motivated adversary is surprisingly difficult.  This document points out many pitfalls in using poor entropy sources or traditional pseudo-random number generation techniques for generating such quantities.  It recommends the use of truly random hardware techniques and shows that the existing hardware on many systems can be used for this purpose. It provides suggestions to ameliorate the problem when a hardware solution is not available, and it gives examples of how large such quantities need to be for some applications.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="106"/>
+          <seriesInfo name="RFC" value="4086"/>
+          <seriesInfo name="DOI" value="10.17487/RFC4086"/>
+        </reference>
+        <reference anchor="RFC8174" target="https://www.rfc-editor.org/info/rfc8174" quoteTitle="true" derivedAnchor="RFC8174">
+          <front>
+            <title>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</title>
+            <author fullname="B. Leiba" initials="B." surname="Leiba">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="May" year="2017"/>
+            <abstract>
+              <t indent="0">RFC 2119 specifies common key words that may be used in protocol  specifications.  This document aims to reduce the ambiguity by clarifying that only UPPERCASE usage of the key words have the  defined special meanings.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="BCP" value="14"/>
+          <seriesInfo name="RFC" value="8174"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8174"/>
+        </reference>
+        <reference anchor="SHA" quoteTitle="true" target="https://doi.org/10.6028/nist.fips.180-4" derivedAnchor="SHA">
+          <front>
+            <title>Secure Hash Standard</title>
+            <author fullname="Quynh H. Dang" initials="Q." surname="Dang">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="July" year="2015"/>
+          </front>
+          <seriesInfo name="National Institute of Standards and Technology" value="report"/>
+          <seriesInfo name="DOI" value="10.6028/nist.fips.180-4"/>
+        </reference>
+        <reference anchor="TLS-REGISTRIES" target="https://www.rfc-editor.org/info/rfc8447" quoteTitle="true" derivedAnchor="TLS-REGISTRIES">
+          <front>
+            <title>IANA Registry Updates for TLS and DTLS</title>
+            <author fullname="J. Salowey" initials="J." surname="Salowey">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="S. Turner" initials="S." surname="Turner">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="August" year="2018"/>
+            <abstract>
+              <t indent="0">This document describes a number of changes to TLS and DTLS IANA registries that range from adding notes to the registry all the way to changing the registration policy.  These changes were mostly motivated by WG review of the TLS- and DTLS-related registries undertaken as part of the TLS 1.3 development process.</t>
+              <t indent="0">This document updates the following RFCs: 3749, 5077, 4680, 5246, 5705, 5878, 6520, and 7301.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8447"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8447"/>
+        </reference>
+        <reference anchor="TLS13" target="https://www.rfc-editor.org/info/rfc8446" quoteTitle="true" derivedAnchor="TLS13">
+          <front>
+            <title>The Transport Layer Security (TLS) Protocol Version 1.3</title>
+            <author fullname="E. Rescorla" initials="E." surname="Rescorla">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="August" year="2018"/>
+            <abstract>
+              <t indent="0">This document specifies version 1.3 of the Transport Layer Security (TLS) protocol.  TLS allows client/server applications to communicate over the Internet in a way that is designed to prevent eavesdropping, tampering, and message forgery.</t>
+              <t indent="0">This document updates RFCs 5705 and 6066, and obsoletes RFCs 5077, 5246, and 6961.  This document also specifies new requirements for TLS 1.2 implementations.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8446"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8446"/>
+        </reference>
+      </references>
+      <references pn="section-11.2">
+        <name slugifiedName="name-informative-references">Informative References</name>
+        <reference anchor="AEBounds" target="https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf" quoteTitle="true" derivedAnchor="AEBounds">
+          <front>
+            <title>Limits on Authenticated Encryption Use in TLS</title>
+            <author initials="A." surname="Luykx">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="K." surname="Paterson">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2017" month="August" day="28"/>
+          </front>
+        </reference>
+        <reference anchor="ASCII" target="https://www.rfc-editor.org/info/rfc20" quoteTitle="true" derivedAnchor="ASCII">
+          <front>
+            <title>ASCII format for network interchange</title>
+            <author fullname="V.G. Cerf" initials="V.G." surname="Cerf">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="October" year="1969"/>
+          </front>
+          <seriesInfo name="STD" value="80"/>
+          <seriesInfo name="RFC" value="20"/>
+          <seriesInfo name="DOI" value="10.17487/RFC0020"/>
+        </reference>
+        <reference anchor="CCM-ANALYSIS" quoteTitle="true" target="https://doi.org/10.1007/3-540-36492-7_7" derivedAnchor="CCM-ANALYSIS">
+          <front>
+            <title>On the Security of CTR + CBC-MAC</title>
+            <author initials="J." surname="Jonsson" fullname="Jakob Jonsson">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2003"/>
+          </front>
+          <seriesInfo name="DOI" value="10.1007/3-540-36492-7_7"/>
+          <refcontent>Selected Areas in Cryptography</refcontent>
+          <refcontent>SAC 2002</refcontent>
+          <refcontent>Lecture Notes in Computer Science, vol 2595</refcontent>
+          <refcontent>pp. 76-93</refcontent>
+        </reference>
+        <reference anchor="COMPRESS" target="https://www.rfc-editor.org/info/rfc8879" quoteTitle="true" derivedAnchor="COMPRESS">
+          <front>
+            <title>TLS Certificate Compression</title>
+            <author fullname="A. Ghedini" initials="A." surname="Ghedini">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="V. Vasiliev" initials="V." surname="Vasiliev">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="December" year="2020"/>
+            <abstract>
+              <t indent="0">In TLS handshakes, certificate chains often take up the majority of the bytes transmitted.</t>
+              <t indent="0">This document describes how certificate chains can be compressed to reduce the amount of data transmitted and avoid some round trips.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8879"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8879"/>
+        </reference>
+        <reference anchor="GCM-MU" quoteTitle="true" target="https://doi.org/10.1145/3243734.3243816" derivedAnchor="GCM-MU">
+          <front>
+            <title>The Multi-user Security of GCM, Revisited: Tight Bounds for Nonce Randomization</title>
+            <author initials="V." surname="Hoang" fullname="Viet Tung Hoang">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="S." surname="Tessaro" fullname="Stefano Tessaro">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="A." surname="Thiruvengadam" fullname="Aishwarya Thiruvengadam">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2018"/>
+          </front>
+          <seriesInfo name="DOI" value="10.1145/3243734.3243816"/>
+          <refcontent>CCS '18: Proceedings of the 2018 ACM SIGSAC Conference on Computer and Communications Security</refcontent>
+          <refcontent>pp. 1429-1440</refcontent>
+        </reference>
+        <reference anchor="HTTP-REPLAY" target="https://www.rfc-editor.org/info/rfc8470" quoteTitle="true" derivedAnchor="HTTP-REPLAY">
+          <front>
+            <title>Using Early Data in HTTP</title>
+            <author fullname="M. Thomson" initials="M." surname="Thomson">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="M. Nottingham" initials="M." surname="Nottingham">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="W. Tarreau" initials="W." surname="Tarreau">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="September" year="2018"/>
+            <abstract>
+              <t indent="0">Using TLS early data creates an exposure to the possibility of a replay attack.  This document defines mechanisms that allow clients to communicate with servers about HTTP requests that are sent in early data.  Techniques are described that use these mechanisms to mitigate the risk of replay.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8470"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8470"/>
+        </reference>
+        <reference anchor="HTTP2-TLS13" target="https://www.rfc-editor.org/info/rfc8740" quoteTitle="true" derivedAnchor="HTTP2-TLS13">
+          <front>
+            <title>Using TLS 1.3 with HTTP/2</title>
+            <author fullname="D. Benjamin" initials="D." surname="Benjamin">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="February" year="2020"/>
+            <abstract>
+              <t indent="0">This document updates RFC 7540 by forbidding TLS 1.3 post-handshake authentication, as an analog to the existing TLS 1.2 renegotiation restriction.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="8740"/>
+          <seriesInfo name="DOI" value="10.17487/RFC8740"/>
+        </reference>
+        <reference anchor="IMC" quoteTitle="true" derivedAnchor="IMC">
+          <front>
+            <title>Introduction to Modern Cryptography, Second Edition</title>
+            <author initials="J." surname="Katz">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="Y." surname="Lindell">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2014" month="November" day="06"/>
+          </front>
+          <seriesInfo name="ISBN" value="978-1466570269"/>
+        </reference>
+        <reference anchor="NAN" quoteTitle="true" target="https://doi.org/10.1007/978-3-030-26948-7_9" derivedAnchor="NAN">
+          <front>
+            <title>Nonces Are Noticed: AEAD Revisited</title>
+            <author initials="M." surname="Bellare" fullname="Mihir Bellare">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="R." surname="Ng" fullname="Ruth Ng">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="B." surname="Tackmann" fullname="Björn Tackmann">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2019"/>
+          </front>
+          <seriesInfo name="DOI" value="10.1007/978-3-030-26948-7_9"/>
+          <refcontent>Advances in Cryptology - CRYPTO 2019</refcontent>
+          <refcontent>Lecture Notes in Computer Science, vol 11692</refcontent>
+          <refcontent>pp. 235-265</refcontent>
+        </reference>
+        <reference anchor="QUIC-HTTP" quoteTitle="true" target="https://tools.ietf.org/html/draft-ietf-quic-http-34" derivedAnchor="QUIC-HTTP">
+          <front>
+            <title>Hypertext Transfer Protocol Version 3 (HTTP/3)</title>
+            <author initials="M." surname="Bishop" fullname="Mike Bishop" role="editor">
+              <organization showOnFrontPage="true">Akamai Technologies</organization>
+            </author>
+            <date year="2021" month="February" day="2"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-ietf-quic-http-34"/>
+          <refcontent>Work in Progress</refcontent>
+        </reference>
+        <reference anchor="RFC2818" target="https://www.rfc-editor.org/info/rfc2818" quoteTitle="true" derivedAnchor="RFC2818">
+          <front>
+            <title>HTTP Over TLS</title>
+            <author fullname="E. Rescorla" initials="E." surname="Rescorla">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="May" year="2000"/>
+            <abstract>
+              <t indent="0">This memo describes how to use Transport Layer Security (TLS) to secure Hypertext Transfer Protocol (HTTP) connections over the Internet.  This memo provides information for the Internet community.</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="2818"/>
+          <seriesInfo name="DOI" value="10.17487/RFC2818"/>
+        </reference>
+        <reference anchor="RFC5280" target="https://www.rfc-editor.org/info/rfc5280" quoteTitle="true" derivedAnchor="RFC5280">
+          <front>
+            <title>Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</title>
+            <author fullname="D. Cooper" initials="D." surname="Cooper">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="S. Santesson" initials="S." surname="Santesson">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="S. Farrell" initials="S." surname="Farrell">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="S. Boeyen" initials="S." surname="Boeyen">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="R. Housley" initials="R." surname="Housley">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author fullname="W. Polk" initials="W." surname="Polk">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date month="May" year="2008"/>
+            <abstract>
+              <t indent="0">This memo profiles the X.509 v3 certificate and X.509 v2 certificate revocation list (CRL) for use in the Internet.  An overview of this approach and model is provided as an introduction.  The X.509 v3 certificate format is described in detail, with additional information regarding the format and semantics of Internet name forms.  Standard certificate extensions are described and two Internet-specific extensions are defined.  A set of required certificate extensions is specified.  The X.509 v2 CRL format is described in detail along with standard and Internet-specific extensions.  An algorithm for X.509 certification path validation is described.  An ASN.1 module and examples are provided in the appendices.  [STANDARDS-TRACK]</t>
+            </abstract>
+          </front>
+          <seriesInfo name="RFC" value="5280"/>
+          <seriesInfo name="DOI" value="10.17487/RFC5280"/>
+        </reference>
+        <reference anchor="ROBUST" target="https://eprint.iacr.org/2020/718" quoteTitle="true" derivedAnchor="ROBUST">
+          <front>
+            <title>Robust Channels: Handling Unreliable Networks in the Record Layers of QUIC and DTLS 1.3</title>
+            <author initials="M." surname="Fischlin">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="F." surname="Günther">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <author initials="C." surname="Janson">
+              <organization showOnFrontPage="true"/>
+            </author>
+            <date year="2020" month="May" day="16"/>
+          </front>
+        </reference>
+      </references>
+    </references>
+    <section anchor="test-vectors" numbered="true" toc="include" removeInRFC="false" pn="section-appendix.a">
+      <name slugifiedName="name-sample-packet-protection">Sample Packet Protection</name>
+      <t indent="0" pn="section-appendix.a-1">This section shows examples of packet protection so that implementations can be
+verified incrementally. Samples of Initial packets from both client and server
+plus a Retry packet are defined. These packets use an 8-byte client-chosen
+Destination Connection ID of 0x8394c8f03e515708. Some intermediate values are
+included. All values are shown in hexadecimal.</t>
+      <section anchor="keys" numbered="true" toc="include" removeInRFC="false" pn="section-a.1">
+        <name slugifiedName="name-keys">Keys</name>
+        <t indent="0" pn="section-a.1-1">The labels generated during the execution of the HKDF-Expand-Label function
+(that is, HkdfLabel.label) and part of the value given to the HKDF-Expand
+function in order to produce its output are:</t>
+        <dl indent="3" newline="false" spacing="normal" pn="section-a.1-2">
+          <dt pn="section-a.1-2.1">client in:</dt>
+          <dd pn="section-a.1-2.2">
+            <t indent="0" pn="section-a.1-2.2.1">00200f746c73313320636c69656e7420696e00</t>
+          </dd>
+          <dt pn="section-a.1-2.3">server in:</dt>
+          <dd pn="section-a.1-2.4">
+            <t indent="0" pn="section-a.1-2.4.1">00200f746c7331332073657276657220696e00</t>
+          </dd>
+          <dt pn="section-a.1-2.5">quic key:</dt>
+          <dd pn="section-a.1-2.6">
+            <t indent="0" pn="section-a.1-2.6.1">00100e746c7331332071756963206b657900</t>
+          </dd>
+          <dt pn="section-a.1-2.7">quic iv:</dt>
+          <dd pn="section-a.1-2.8">
+            <t indent="0" pn="section-a.1-2.8.1">000c0d746c733133207175696320697600</t>
+          </dd>
+          <dt pn="section-a.1-2.9">quic hp:</dt>
+          <dd pn="section-a.1-2.10">
+            <t indent="0" pn="section-a.1-2.10.1">00100d746c733133207175696320687000</t>
+          </dd>
+        </dl>
+        <t indent="0" pn="section-a.1-3">The initial secret is common:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.1-4">
+initial_secret = HKDF-Extract(initial_salt, cid)
+    = 7db5df06e7a69e432496adedb0085192
+      3595221596ae2ae9fb8115c1e9ed0a44
+</artwork>
+        <t indent="0" pn="section-a.1-5">The secrets for protecting client packets are:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.1-6">
+client_initial_secret
+    = HKDF-Expand-Label(initial_secret, "client in", "", 32)
+    = c00cf151ca5be075ed0ebfb5c80323c4
+      2d6b7db67881289af4008f1f6c357aea
+
+key = HKDF-Expand-Label(client_initial_secret, "quic key", "", 16)
+    = 1f369613dd76d5467730efcbe3b1a22d
+
+iv  = HKDF-Expand-Label(client_initial_secret, "quic iv", "", 12)
+    = fa044b2f42a3fd3b46fb255c
+
+hp  = HKDF-Expand-Label(client_initial_secret, "quic hp", "", 16)
+    = 9f50449e04a0e810283a1e9933adedd2
+</artwork>
+        <t indent="0" pn="section-a.1-7">The secrets for protecting server packets are:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.1-8">
+server_initial_secret
+    = HKDF-Expand-Label(initial_secret, "server in", "", 32)
+    = 3c199828fd139efd216c155ad844cc81
+      fb82fa8d7446fa7d78be803acdda951b
+
+key = HKDF-Expand-Label(server_initial_secret, "quic key", "", 16)
+    = cf3a5331653c364c88f0f379b6067e37
+
+iv  = HKDF-Expand-Label(server_initial_secret, "quic iv", "", 12)
+    = 0ac1493ca1905853b0bba03e
+
+hp  = HKDF-Expand-Label(server_initial_secret, "quic hp", "", 16)
+    = c206b8d9b9f0f37644430b490eeaa314
+</artwork>
+      </section>
+      <section anchor="sample-client-initial" numbered="true" toc="include" removeInRFC="false" pn="section-a.2">
+        <name slugifiedName="name-client-initial">Client Initial</name>
+        <t indent="0" pn="section-a.2-1">The client sends an Initial packet.  The unprotected payload of this packet
+contains the following CRYPTO frame, plus enough PADDING frames to make a
+1162-byte payload:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.2-2">
+060040f1010000ed0303ebf8fa56f129 39b9584a3896472ec40bb863cfd3e868
+04fe3a47f06a2b69484c000004130113 02010000c000000010000e00000b6578
+616d706c652e636f6dff01000100000a 00080006001d00170018001000070005
+04616c706e0005000501000000000033 00260024001d00209370b2c9caa47fba
+baf4559fedba753de171fa71f50f1ce1 5d43e994ec74d748002b000302030400
+0d0010000e0403050306030203080408 050806002d00020101001c0002400100
+3900320408ffffffffffffffff050480 00ffff07048000ffff08011001048000
+75300901100f088394c8f03e51570806 048000ffff
+</artwork>
+        <t indent="0" pn="section-a.2-3">The unprotected header indicates a length of 1182 bytes: the 4-byte packet
+number, 1162 bytes of frames, and the 16-byte authentication tag.  The header
+includes the connection ID and a packet number of 2:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.2-4">
+c300000001088394c8f03e5157080000449e00000002
+</artwork>
+        <t indent="0" pn="section-a.2-5">Protecting the payload produces output that is sampled for header protection.
+Because the header uses a 4-byte packet number encoding, the first 16 bytes of
+the protected payload is sampled and then applied to the header as follows:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.2-6">
+sample = d1b1c98dd7689fb8ec11d242b123dc9b
+
+mask = AES-ECB(hp, sample)[0..4]
+     = 437b9aec36
+
+header[0] ^= mask[0] &amp; 0x0f
+     = c0
+header[18..21] ^= mask[1..4]
+     = 7b9aec34
+header = c000000001088394c8f03e5157080000449e7b9aec34
+</artwork>
+        <t indent="0" pn="section-a.2-7">The resulting protected packet is:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.2-8">
+c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11
+d242b123dc9bd8bab936b47d92ec356c 0bab7df5976d27cd449f63300099f399
+1c260ec4c60d17b31f8429157bb35a12 82a643a8d2262cad67500cadb8e7378c
+8eb7539ec4d4905fed1bee1fc8aafba1 7c750e2c7ace01e6005f80fcb7df6212
+30c83711b39343fa028cea7f7fb5ff89 eac2308249a02252155e2347b63d58c5
+457afd84d05dfffdb20392844ae81215 4682e9cf012f9021a6f0be17ddd0c208
+4dce25ff9b06cde535d0f920a2db1bf3 62c23e596d11a4f5a6cf3948838a3aec
+4e15daf8500a6ef69ec4e3feb6b1d98e 610ac8b7ec3faf6ad760b7bad1db4ba3
+485e8a94dc250ae3fdb41ed15fb6a8e5 eba0fc3dd60bc8e30c5c4287e53805db
+059ae0648db2f64264ed5e39be2e20d8 2df566da8dd5998ccabdae053060ae6c
+7b4378e846d29f37ed7b4ea9ec5d82e7 961b7f25a9323851f681d582363aa5f8
+9937f5a67258bf63ad6f1a0b1d96dbd4 faddfcefc5266ba6611722395c906556
+be52afe3f565636ad1b17d508b73d874 3eeb524be22b3dcbc2c7468d54119c74
+68449a13d8e3b95811a198f3491de3e7 fe942b330407abf82a4ed7c1b311663a
+c69890f4157015853d91e923037c227a 33cdd5ec281ca3f79c44546b9d90ca00
+f064c99e3dd97911d39fe9c5d0b23a22 9a234cb36186c4819e8b9c5927726632
+291d6a418211cc2962e20fe47feb3edf 330f2c603a9d48c0fcb5699dbfe58964
+25c5bac4aee82e57a85aaf4e2513e4f0 5796b07ba2ee47d80506f8d2c25e50fd
+14de71e6c418559302f939b0e1abd576 f279c4b2e0feb85c1f28ff18f58891ff
+ef132eef2fa09346aee33c28eb130ff2 8f5b766953334113211996d20011a198
+e3fc433f9f2541010ae17c1bf202580f 6047472fb36857fe843b19f5984009dd
+c324044e847a4f4a0ab34f719595de37 252d6235365e9b84392b061085349d73
+203a4a13e96f5432ec0fd4a1ee65accd d5e3904df54c1da510b0ff20dcc0c77f
+cb2c0e0eb605cb0504db87632cf3d8b4 dae6e705769d1de354270123cb11450e
+fc60ac47683d7b8d0f811365565fd98c 4c8eb936bcab8d069fc33bd801b03ade
+a2e1fbc5aa463d08ca19896d2bf59a07 1b851e6c239052172f296bfb5e724047
+90a2181014f3b94a4e97d117b4381303 68cc39dbb2d198065ae3986547926cd2
+162f40a29f0c3c8745c0f50fba3852e5 66d44575c29d39a03f0cda721984b6f4
+40591f355e12d439ff150aab7613499d bd49adabc8676eef023b15b65bfc5ca0
+6948109f23f350db82123535eb8a7433 bdabcb909271a6ecbcb58b936a88cd4e
+8f2e6ff5800175f113253d8fa9ca8885 c2f552e657dc603f252e1a8e308f76f0
+be79e2fb8f5d5fbbe2e30ecadd220723 c8c0aea8078cdfcb3868263ff8f09400
+54da48781893a7e49ad5aff4af300cd8 04a6b6279ab3ff3afb64491c85194aab
+760d58a606654f9f4400e8b38591356f bf6425aca26dc85244259ff2b19c41b9
+f96f3ca9ec1dde434da7d2d392b905dd f3d1f9af93d1af5950bd493f5aa731b4
+056df31bd267b6b90a079831aaf579be 0a39013137aac6d404f518cfd4684064
+7e78bfe706ca4cf5e9c5453e9f7cfd2b 8b4c8d169a44e55c88d4a9a7f9474241
+e221af44860018ab0856972e194cd934
+</artwork>
+      </section>
+      <section anchor="server-initial" numbered="true" toc="include" removeInRFC="false" pn="section-a.3">
+        <name slugifiedName="name-server-initial">Server Initial</name>
+        <t indent="0" pn="section-a.3-1">The server sends the following payload in response, including an ACK frame, a
+CRYPTO frame, and no PADDING frames:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.3-2">
+02000000000600405a020000560303ee fce7f7b37ba1d1632e96677825ddf739
+88cfc79825df566dc5430b9a045a1200 130100002e00330024001d00209d3c94
+0d89690b84d08a60993c144eca684d10 81287c834d5311bcf32bb9da1a002b00
+020304
+</artwork>
+        <t indent="0" pn="section-a.3-3">The header from the server includes a new connection ID and a 2-byte packet
+number encoding for a packet number of 1:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.3-4">
+c1000000010008f067a5502a4262b50040750001
+</artwork>
+        <t indent="0" pn="section-a.3-5">As a result, after protection, the header protection sample is taken starting
+from the third protected byte:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.3-6">
+sample = 2cd0991cd25b0aac406a5816b6394100
+mask   = 2ec0d8356a
+header = cf000000010008f067a5502a4262b5004075c0d9
+</artwork>
+        <t indent="0" pn="section-a.3-7">The final protected packet is then:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.3-8">
+cf000000010008f067a5502a4262b500 4075c0d95a482cd0991cd25b0aac406a
+5816b6394100f37a1c69797554780bb3 8cc5a99f5ede4cf73c3ec2493a1839b3
+dbcba3f6ea46c5b7684df3548e7ddeb9 c3bf9c73cc3f3bded74b562bfb19fb84
+022f8ef4cdd93795d77d06edbb7aaf2f 58891850abbdca3d20398c276456cbc4
+2158407dd074ee
+</artwork>
+      </section>
+      <section anchor="retry" numbered="true" toc="include" removeInRFC="false" pn="section-a.4">
+        <name slugifiedName="name-retry">Retry</name>
+        <t indent="0" pn="section-a.4-1">This shows a Retry packet that might be sent in response to the Initial packet
+in <xref target="sample-client-initial" format="default" sectionFormat="of" derivedContent="Appendix A.2"/>. The integrity check includes the client-chosen
+connection ID value of 0x8394c8f03e515708, but that value is not
+included in the final Retry packet:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.4-2">
+ff000000010008f067a5502a4262b574 6f6b656e04a265ba2eff4d829058fb3f
+0f2496ba
+</artwork>
+      </section>
+      <section anchor="chacha20-poly1305-short-header-packet" numbered="true" toc="include" removeInRFC="false" pn="section-a.5">
+        <name slugifiedName="name-chacha20-poly1305-short-hea">ChaCha20-Poly1305 Short Header Packet</name>
+        <t indent="0" pn="section-a.5-1">This example shows some of the steps required to protect a packet with
+a short header.  This example uses AEAD_CHACHA20_POLY1305.</t>
+        <t indent="0" pn="section-a.5-2">In this example, TLS produces an application write secret from which a server
+uses HKDF-Expand-Label to produce four values: a key, an IV, a header
+protection key, and the secret that will be used after keys are updated (this
+last value is not used further in this example).</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.5-3">
+secret
+    = 9ac312a7f877468ebe69422748ad00a1
+      5443f18203a07d6060f688f30f21632b
+
+key = HKDF-Expand-Label(secret, "quic key", "", 32)
+    = c6d98ff3441c3fe1b2182094f69caa2e
+      d4b716b65488960a7a984979fb23e1c8
+
+iv  = HKDF-Expand-Label(secret, "quic iv", "", 12)
+    = e0459b3474bdd0e44a41c144
+
+hp  = HKDF-Expand-Label(secret, "quic hp", "", 32)
+    = 25a282b9e82f06f21f488917a4fc8f1b
+      73573685608597d0efcb076b0ab7a7a4
+
+ku  = HKDF-Expand-Label(secret, "quic ku", "", 32)
+    = 1223504755036d556342ee9361d25342
+      1a826c9ecdf3c7148684b36b714881f9
+</artwork>
+        <t indent="0" pn="section-a.5-4">The following shows the steps involved in protecting a minimal packet with an
+empty Destination Connection ID. This packet contains a single PING frame (that
+is, a payload of just 0x01) and has a packet number of 654360564. In this
+example, using a packet number of length 3 (that is, 49140 is encoded) avoids
+having to pad the payload of the packet; PADDING frames would be needed if the
+packet number is encoded on fewer bytes.</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.5-5">
+pn                 = 654360564 (decimal)
+nonce              = e0459b3474bdd0e46d417eb0
+unprotected header = 4200bff4
+payload plaintext  = 01
+payload ciphertext = 655e5cd55c41f69080575d7999c25a5bfb
+</artwork>
+        <t indent="0" pn="section-a.5-6">The resulting ciphertext is the minimum size possible. One byte is skipped to
+produce the sample for header protection.</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.5-7">
+sample = 5e5cd55c41f69080575d7999c25a5bfb
+mask   = aefefe7d03
+header = 4cfe4189
+</artwork>
+        <t indent="0" pn="section-a.5-8">The protected packet is the smallest possible packet size of 21 bytes.</t>
+        <artwork name="" type="" align="left" alt="" pn="section-a.5-9">
+packet = 4cfe4189655e5cd55c41f69080575d7999c25a5bfb
+</artwork>
+      </section>
+    </section>
+    <section anchor="aead-analysis" numbered="true" toc="include" removeInRFC="false" pn="section-appendix.b">
+      <name slugifiedName="name-aead-algorithm-analysis">AEAD Algorithm Analysis</name>
+      <t indent="0" pn="section-appendix.b-1">This section documents analyses used in deriving AEAD algorithm limits for
+AEAD_AES_128_GCM, AEAD_AES_128_CCM, and AEAD_AES_256_GCM. The analyses that
+follow use symbols for multiplication (*), division (/), and exponentiation (^),
+plus parentheses for establishing precedence. The following symbols are also
+used:</t>
+      <dl indent="3" newline="false" spacing="normal" pn="section-appendix.b-2">
+        <dt pn="section-appendix.b-2.1">t:</dt>
+        <dd pn="section-appendix.b-2.2">
+          <t indent="0" pn="section-appendix.b-2.2.1">The size of the authentication tag in bits. For these ciphers, t is 128.</t>
+        </dd>
+        <dt pn="section-appendix.b-2.3">n:</dt>
+        <dd pn="section-appendix.b-2.4">
+          <t indent="0" pn="section-appendix.b-2.4.1">The size of the block function in bits. For these ciphers, n is 128.</t>
+        </dd>
+        <dt pn="section-appendix.b-2.5">k:</dt>
+        <dd pn="section-appendix.b-2.6">
+          <t indent="0" pn="section-appendix.b-2.6.1">The size of the key in bits. This is 128 for AEAD_AES_128_GCM and
+AEAD_AES_128_CCM; 256 for AEAD_AES_256_GCM.</t>
+        </dd>
+        <dt pn="section-appendix.b-2.7">l:</dt>
+        <dd pn="section-appendix.b-2.8">
+          <t indent="0" pn="section-appendix.b-2.8.1">The number of blocks in each packet (see below).</t>
+        </dd>
+        <dt pn="section-appendix.b-2.9">q:</dt>
+        <dd pn="section-appendix.b-2.10">
+          <t indent="0" pn="section-appendix.b-2.10.1">The number of genuine packets created and protected by endpoints. This value
+is the bound on the number of packets that can be protected before updating
+keys.</t>
+        </dd>
+        <dt pn="section-appendix.b-2.11">v:</dt>
+        <dd pn="section-appendix.b-2.12">
+          <t indent="0" pn="section-appendix.b-2.12.1">The number of forged packets that endpoints will accept. This value is the
+bound on the number of forged packets that an endpoint can reject before
+updating keys.</t>
+        </dd>
+        <dt pn="section-appendix.b-2.13">o:</dt>
+        <dd pn="section-appendix.b-2.14">
+          <t indent="0" pn="section-appendix.b-2.14.1">The amount of offline ideal cipher queries made by an adversary.</t>
+        </dd>
+      </dl>
+      <t indent="0" pn="section-appendix.b-3">The analyses that follow rely on a count of the number of block operations
+involved in producing each message. This analysis is performed for packets of
+size up to 2<sup>11</sup> (l = 2<sup>7</sup>) and 2<sup>16</sup> (l =
+2<sup>12</sup>). A size of 2<sup>11</sup> is expected to be a limit that matches
+common deployment patterns, whereas the 2<sup>16</sup> is the maximum possible
+size of a QUIC packet. Only endpoints that strictly limit packet size can use
+the larger confidentiality and integrity limits that are derived using the
+smaller packet size.</t>
+      <t indent="0" pn="section-appendix.b-4">For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the message length (l) is the length
+of the associated data in blocks plus the length of the plaintext in blocks.</t>
+      <t indent="0" pn="section-appendix.b-5">For AEAD_AES_128_CCM, the total number of block cipher operations is the sum of
+the following: the length of the associated data in blocks, the length of the
+ciphertext in blocks, the length of the plaintext in blocks, plus 1. In this
+analysis, this is simplified to a value of twice the length of the packet in
+blocks (that is, <tt>2l = 2<sup>8</sup></tt> for packets that are limited to
+2<sup>11</sup> bytes, or <tt>2l = 2<sup>13</sup></tt> otherwise). This
+simplification is based on the packet containing all of the associated data and
+ciphertext. This results in a one to three block overestimation of the number of
+operations per packet.</t>
+      <section anchor="gcm-bounds" numbered="true" toc="include" removeInRFC="false" pn="section-b.1">
+        <name slugifiedName="name-analysis-of-aead_aes_128_gc">Analysis of AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits</name>
+        <t indent="0" pn="section-b.1-1"><xref target="GCM-MU" format="default" sectionFormat="of" derivedContent="GCM-MU"/> specifies concrete bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM
+as used in TLS 1.3 and QUIC. This section documents this analysis using several
+simplifying assumptions:</t>
+        <ul spacing="normal" bare="false" empty="false" indent="3" pn="section-b.1-2">
+          <li pn="section-b.1-2.1">The number of ciphertext blocks an attacker uses in forgery attempts is
+bounded by v * l, which is the number of forgery attempts multiplied by the
+size of each packet (in blocks).</li>
+          <li pn="section-b.1-2.2">The amount of offline work done by an attacker does not dominate other factors
+in the analysis.</li>
+        </ul>
+        <t indent="0" pn="section-b.1-3">The bounds in <xref target="GCM-MU" format="default" sectionFormat="of" derivedContent="GCM-MU"/> are tighter and more complete than those used in
+<xref target="AEBounds" format="default" sectionFormat="of" derivedContent="AEBounds"/>, which allows for larger limits than those described in
+<xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>.</t>
+        <section anchor="confidentiality-limit" numbered="true" toc="include" removeInRFC="false" pn="section-b.1.1">
+          <name slugifiedName="name-confidentiality-limit">Confidentiality Limit</name>
+          <t indent="0" pn="section-b.1.1-1">For confidentiality, Theorem (4.3) in <xref target="GCM-MU" format="default" sectionFormat="of" derivedContent="GCM-MU"/> establishes that, for a single
+user that does not repeat nonces, the dominant term in determining the
+distinguishing advantage between a real and random AEAD algorithm gained by an
+attacker is:</t>
+          <artwork name="" type="" align="left" alt="" pn="section-b.1.1-2">
+2 * (q * l)^2 / 2^n
+</artwork>
+          <t indent="0" pn="section-b.1.1-3">For a target advantage of 2<sup>-57</sup>, this results in the relation:</t>
+          <artwork name="" type="" align="left" alt="" pn="section-b.1.1-4">
+q &lt;= 2^35 / l
+</artwork>
+          <t indent="0" pn="section-b.1.1-5">Thus, endpoints that do not send packets larger than 2<sup>11</sup> bytes cannot
+protect more than 2<sup>28</sup> packets in a single connection without causing
+an attacker to gain a more significant advantage than the target of
+2<sup>-57</sup>. The limit for endpoints that allow for the packet size to be as
+large as 2<sup>16</sup> is instead 2<sup>23</sup>.</t>
+        </section>
+        <section anchor="integrity-limit" numbered="true" toc="include" removeInRFC="false" pn="section-b.1.2">
+          <name slugifiedName="name-integrity-limit">Integrity Limit</name>
+          <t indent="0" pn="section-b.1.2-1">For integrity, Theorem (4.3) in <xref target="GCM-MU" format="default" sectionFormat="of" derivedContent="GCM-MU"/> establishes that an attacker gains
+an advantage in successfully forging a packet of no more than the following:</t>
+          <artwork name="" type="" align="left" alt="" pn="section-b.1.2-2">
+(1 / 2^(8 * n)) + ((2 * v) / 2^(2 * n))
+        + ((2 * o * v) / 2^(k + n)) + (n * (v + (v * l)) / 2^k)
+</artwork>
+          <t indent="0" pn="section-b.1.2-3">The goal is to limit this advantage to 2<sup>-57</sup>.  For AEAD_AES_128_GCM,
+the fourth term in this inequality dominates the rest, so the others can be
+removed without significant effect on the result. This produces the following
+approximation:</t>
+          <artwork name="" type="" align="left" alt="" pn="section-b.1.2-4">
+v &lt;= 2^64 / l
+</artwork>
+          <t indent="0" pn="section-b.1.2-5">Endpoints that do not attempt to remove protection from packets larger than
+2<sup>11</sup> bytes can attempt to remove protection from at most
+2<sup>57</sup> packets. Endpoints that do not restrict the size of processed
+packets can attempt to remove protection from at most 2<sup>52</sup> packets.</t>
+          <t indent="0" pn="section-b.1.2-6">For AEAD_AES_256_GCM, the same term dominates, but the larger value of k
+produces the following approximation:</t>
+          <artwork name="" type="" align="left" alt="" pn="section-b.1.2-7">
+v &lt;= 2^192 / l
+</artwork>
+          <t indent="0" pn="section-b.1.2-8">This is substantially larger than the limit for AEAD_AES_128_GCM.  However, this
+document recommends that the same limit be applied to both functions as either
+limit is acceptably large.</t>
+        </section>
+      </section>
+      <section anchor="ccm-bounds" numbered="true" toc="include" removeInRFC="false" pn="section-b.2">
+        <name slugifiedName="name-analysis-of-aead_aes_128_cc">Analysis of AEAD_AES_128_CCM Usage Limits</name>
+        <t indent="0" pn="section-b.2-1">TLS <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/> and <xref target="AEBounds" format="default" sectionFormat="of" derivedContent="AEBounds"/> do not specify limits on usage
+for AEAD_AES_128_CCM. However, any AEAD that is used with QUIC requires limits
+on use that ensure that both confidentiality and integrity are preserved. This
+section documents that analysis.</t>
+        <t indent="0" pn="section-b.2-2"><xref target="CCM-ANALYSIS" format="default" sectionFormat="of" derivedContent="CCM-ANALYSIS"/> is used as the basis of this
+analysis. The results of that analysis are used to derive usage limits that are
+based on those chosen in <xref target="TLS13" format="default" sectionFormat="of" derivedContent="TLS13"/>.</t>
+        <t indent="0" pn="section-b.2-3">For confidentiality, Theorem 2 in <xref target="CCM-ANALYSIS" format="default" sectionFormat="of" derivedContent="CCM-ANALYSIS"/> establishes that an attacker
+gains a distinguishing advantage over an ideal pseudorandom permutation (PRP) of
+no more than the following:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-b.2-4">
+(2l * q)^2 / 2^n
+</artwork>
+        <t indent="0" pn="section-b.2-5">The integrity limit in Theorem 1 in <xref target="CCM-ANALYSIS" format="default" sectionFormat="of" derivedContent="CCM-ANALYSIS"/> provides an attacker a
+strictly higher advantage for the same number of messages. As the targets for
+the confidentiality advantage and the integrity advantage are the same, only
+Theorem 1 needs to be considered.</t>
+        <t indent="0" pn="section-b.2-6">Theorem 1 establishes that an attacker gains an advantage over an
+ideal PRP of no more than the following:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-b.2-7">
+v / 2^t + (2l * (v + q))^2 / 2^n
+</artwork>
+        <t indent="0" pn="section-b.2-8">As <tt>t</tt> and <tt>n</tt> are both 128, the first term is negligible relative to the
+second, so that term can be removed without a significant effect on the result.</t>
+        <t indent="0" pn="section-b.2-9">This produces a relation that combines both encryption and decryption attempts
+with the same limit as that produced by the theorem for confidentiality alone.
+For a target advantage of 2<sup>-57</sup>, this results in the following:</t>
+        <artwork name="" type="" align="left" alt="" pn="section-b.2-10">
+v + q &lt;= 2^34.5 / l
+</artwork>
+        <t indent="0" pn="section-b.2-11">By setting <tt>q = v</tt>, values for both confidentiality and integrity limits can be
+produced. Endpoints that limit packets to 2<sup>11</sup> bytes therefore have
+both confidentiality and integrity limits of 2<sup>26.5</sup> packets. Endpoints
+that do not restrict packet size have a limit of 2<sup>21.5</sup>.</t>
+      </section>
+    </section>
+    <section numbered="false" anchor="contributors" toc="include" removeInRFC="false" pn="section-appendix.c">
+      <name slugifiedName="name-contributors">Contributors</name>
+      <t indent="0" pn="section-appendix.c-1">The IETF QUIC Working Group received an enormous amount of support from many
+people. The following people provided substantive contributions to this
+document:</t>
+      <ul spacing="compact" bare="false" empty="false" indent="3" pn="section-appendix.c-2">
+        <li pn="section-appendix.c-2.1">
+          <t indent="0" pn="section-appendix.c-2.1.1"><contact fullname="Adam Langley"/></t>
+        </li>
+        <li pn="section-appendix.c-2.2">
+          <t indent="0" pn="section-appendix.c-2.2.1"><contact fullname="Alessandro Ghedini"/></t>
+        </li>
+        <li pn="section-appendix.c-2.3">
+          <t indent="0" pn="section-appendix.c-2.3.1"><contact fullname="Christian Huitema"/></t>
+        </li>
+        <li pn="section-appendix.c-2.4">
+          <t indent="0" pn="section-appendix.c-2.4.1"><contact fullname="Christopher Wood"/></t>
+        </li>
+        <li pn="section-appendix.c-2.5">
+          <t indent="0" pn="section-appendix.c-2.5.1"><contact fullname="David Schinazi"/></t>
+        </li>
+        <li pn="section-appendix.c-2.6">
+          <t indent="0" pn="section-appendix.c-2.6.1"><contact fullname="Dragana Damjanovic"/></t>
+        </li>
+        <li pn="section-appendix.c-2.7">
+          <t indent="0" pn="section-appendix.c-2.7.1"><contact fullname="Eric Rescorla"/></t>
+        </li>
+        <li pn="section-appendix.c-2.8">
+          <t indent="0" pn="section-appendix.c-2.8.1"><contact fullname="Felix Günther"/></t>
+        </li>
+        <li pn="section-appendix.c-2.9">
+          <t indent="0" pn="section-appendix.c-2.9.1"><contact fullname="Ian Swett"/></t>
+        </li>
+        <li pn="section-appendix.c-2.10">
+          <t indent="0" pn="section-appendix.c-2.10.1"><contact fullname="Jana Iyengar"/></t>
+        </li>
+        <li pn="section-appendix.c-2.11">
+          <t indent="0" pn="section-appendix.c-2.11.1"><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t>
+        </li>
+        <li pn="section-appendix.c-2.12">
+          <t indent="0" pn="section-appendix.c-2.12.1"><contact fullname="Marten Seemann"/></t>
+        </li>
+        <li pn="section-appendix.c-2.13">
+          <t indent="0" pn="section-appendix.c-2.13.1"><contact fullname="Martin Duke"/></t>
+        </li>
+        <li pn="section-appendix.c-2.14">
+          <t indent="0" pn="section-appendix.c-2.14.1"><contact fullname="Mike Bishop"/></t>
+        </li>
+        <li pn="section-appendix.c-2.15">
+          <t indent="0" pn="section-appendix.c-2.15.1"><contact fullname="Mikkel Fahnøe Jørgensen"/></t>
+        </li>
+        <li pn="section-appendix.c-2.16">
+          <t indent="0" pn="section-appendix.c-2.16.1"><contact fullname="Nick Banks"/></t>
+        </li>
+        <li pn="section-appendix.c-2.17">
+          <t indent="0" pn="section-appendix.c-2.17.1"><contact fullname="Nick Harper"/></t>
+        </li>
+        <li pn="section-appendix.c-2.18">
+          <t indent="0" pn="section-appendix.c-2.18.1"><contact fullname="Roberto Peon"/></t>
+        </li>
+        <li pn="section-appendix.c-2.19">
+          <t indent="0" pn="section-appendix.c-2.19.1"><contact fullname="Rui Paulo"/></t>
+        </li>
+        <li pn="section-appendix.c-2.20">
+          <t indent="0" pn="section-appendix.c-2.20.1"><contact fullname="Ryan Hamilton"/></t>
+        </li>
+        <li pn="section-appendix.c-2.21">
+          <t indent="0" pn="section-appendix.c-2.21.1"><contact fullname="Victor Vasiliev"/></t>
+        </li>
+      </ul>
+    </section>
+    <section anchor="authors-addresses" numbered="false" removeInRFC="false" toc="include" pn="section-appendix.d">
+      <name slugifiedName="name-authors-addresses">Authors' Addresses</name>
+      <author initials="M." surname="Thomson" fullname="Martin Thomson" role="editor">
+        <organization showOnFrontPage="true">Mozilla</organization>
+        <address>
+          <email>mt@lowentropy.net</email>
+        </address>
+      </author>
+      <author initials="S." surname="Turner" fullname="Sean Turner" role="editor">
+        <organization showOnFrontPage="true">sn3rd</organization>
+        <address>
+          <email>sean@sn3rd.com</email>
+        </address>
+      </author>
+    </section>
+  </back>
+</rfc>

--- a/cli/tests/valid/rfc9001.html
+++ b/cli/tests/valid/rfc9001.html
@@ -1,0 +1,3215 @@
+<!DOCTYPE html>
+<html lang="en" class="RFC">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>RFC 9001: Using TLS to Secure QUIC</title>
+<meta content="Martin Thomson" name="author">
+<meta content="Sean Turner" name="author">
+<meta content="
+       This document describes how Transport Layer Security (TLS) is used to secure
+QUIC. 
+    " name="description">
+<meta content="xml2rfc 3.9.1" name="generator">
+<meta content="crypto" name="keyword">
+<meta content="opportunistic encryption" name="keyword">
+<meta content="plaintext quic" name="keyword">
+<meta content="9001" name="rfc.number">
+<link href="tests/input/rfc9001.prepped.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<link href="xml2rfc.css" rel="stylesheet">
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<link href="https://dx.doi.org/10.17487/rfc9001" rel="alternate">
+  <link href="urn:issn:2070-1721" rel="alternate">
+  <link href="https://datatracker.ietf.org/doc/draft-ietf-quic-tls-34" rel="prev">
+  </head>
+<body>
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left">RFC 9001</td>
+<td class="center">Using TLS to Secure QUIC</td>
+<td class="right">May 2021</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Thomson &amp; Turner</td>
+<td class="center">Standards Track</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-stream">Stream:</dt>
+<dd class="stream">Internet Engineering Task Force (IETF)</dd>
+<dt class="label-rfc">RFC:</dt>
+<dd class="rfc"><a href="https://www.rfc-editor.org/rfc/rfc9001" class="eref">9001</a></dd>
+<dt class="label-category">Category:</dt>
+<dd class="category">Standards Track</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2021-05" class="published">May 2021</time>
+    </dd>
+<dt class="label-issn">ISSN:</dt>
+<dd class="issn">2070-1721</dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">M. Thomson, <span class="editor">Ed.</span>
+</div>
+<div class="org">Mozilla</div>
+</div>
+<div class="author">
+      <div class="author-name">S. Turner, <span class="editor">Ed.</span>
+</div>
+<div class="org">sn3rd</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="rfcnum">RFC 9001</h1>
+<h1 id="title">Using TLS to Secure QUIC</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">This document describes how Transport Layer Security (TLS) is used to secure
+QUIC.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+            This is an Internet Standards Track document.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+            This document is a product of the Internet Engineering Task Force
+            (IETF).  It represents the consensus of the IETF community.  It has
+            received public review and has been approved for publication by
+            the Internet Engineering Steering Group (IESG).  Further
+            information on Internet Standards is available in Section 2 of 
+            RFC 7841.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+            Information about the current status of this document, any
+            errata, and how to provide feedback on it may be obtained at
+            <span><a href="https://www.rfc-editor.org/info/rfc9001">https://www.rfc-editor.org/info/rfc9001</a></span>.<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2021 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Simplified BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Simplified BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="ulEmpty compact toc ulBare">
+<li class="ulEmpty compact toc ulBare" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a></p>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-notational-conventions" class="xref">Notational Conventions</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-tls-overview" class="xref">TLS Overview</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-protocol-overview" class="xref">Protocol Overview</a></p>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-carrying-tls-messages" class="xref">Carrying TLS Messages</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-interface-to-tls" class="xref">Interface to TLS</a></p>
+<ul class="ulEmpty ulBare toc compact">
+<li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.1.2.1">
+                    <p id="section-toc.1-1.4.2.1.2.1.1"><a href="#section-4.1.1" class="xref">4.1.1</a>.  <a href="#name-handshake-complete" class="xref">Handshake Complete</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.1.2.2">
+                    <p id="section-toc.1-1.4.2.1.2.2.1"><a href="#section-4.1.2" class="xref">4.1.2</a>.  <a href="#name-handshake-confirmed" class="xref">Handshake Confirmed</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.1.2.3">
+                    <p id="section-toc.1-1.4.2.1.2.3.1"><a href="#section-4.1.3" class="xref">4.1.3</a>.  <a href="#name-sending-and-receiving-hands" class="xref">Sending and Receiving Handshake Messages</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.1.2.4">
+                    <p id="section-toc.1-1.4.2.1.2.4.1"><a href="#section-4.1.4" class="xref">4.1.4</a>.  <a href="#name-encryption-level-changes" class="xref">Encryption Level Changes</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.1.2.5">
+                    <p id="section-toc.1-1.4.2.1.2.5.1"><a href="#section-4.1.5" class="xref">4.1.5</a>.  <a href="#name-tls-interface-summary" class="xref">TLS Interface Summary</a></p>
+</li>
+                </ul>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.2">
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-tls-version" class="xref">TLS Version</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.3">
+                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-clienthello-size" class="xref">ClientHello Size</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.4">
+                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-peer-authentication" class="xref">Peer Authentication</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.5">
+                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-session-resumption" class="xref">Session Resumption</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.6">
+                <p id="section-toc.1-1.4.2.6.1"><a href="#section-4.6" class="xref">4.6</a>.  <a href="#name-0-rtt" class="xref">0-RTT</a></p>
+<ul class="ulEmpty ulBare toc compact">
+<li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.6.2.1">
+                    <p id="section-toc.1-1.4.2.6.2.1.1"><a href="#section-4.6.1" class="xref">4.6.1</a>.  <a href="#name-enabling-0-rtt" class="xref">Enabling 0-RTT</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.6.2.2">
+                    <p id="section-toc.1-1.4.2.6.2.2.1"><a href="#section-4.6.2" class="xref">4.6.2</a>.  <a href="#name-accepting-and-rejecting-0-r" class="xref">Accepting and Rejecting 0-RTT</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.6.2.3">
+                    <p id="section-toc.1-1.4.2.6.2.3.1"><a href="#section-4.6.3" class="xref">4.6.3</a>.  <a href="#name-validating-0-rtt-configurat" class="xref">Validating 0-RTT Configuration</a></p>
+</li>
+                </ul>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.7">
+                <p id="section-toc.1-1.4.2.7.1"><a href="#section-4.7" class="xref">4.7</a>.  <a href="#name-helloretryrequest" class="xref">HelloRetryRequest</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.8">
+                <p id="section-toc.1-1.4.2.8.1"><a href="#section-4.8" class="xref">4.8</a>.  <a href="#name-tls-errors" class="xref">TLS Errors</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.4.2.9">
+                <p id="section-toc.1-1.4.2.9.1"><a href="#section-4.9" class="xref">4.9</a>.  <a href="#name-discarding-unused-keys" class="xref">Discarding Unused Keys</a></p>
+<ul class="ulEmpty ulBare toc compact">
+<li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.9.2.1">
+                    <p id="section-toc.1-1.4.2.9.2.1.1"><a href="#section-4.9.1" class="xref">4.9.1</a>.  <a href="#name-discarding-initial-keys" class="xref">Discarding Initial Keys</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.9.2.2">
+                    <p id="section-toc.1-1.4.2.9.2.2.1"><a href="#section-4.9.2" class="xref">4.9.2</a>.  <a href="#name-discarding-handshake-keys" class="xref">Discarding Handshake Keys</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.4.2.9.2.3">
+                    <p id="section-toc.1-1.4.2.9.2.3.1"><a href="#section-4.9.3" class="xref">4.9.3</a>.  <a href="#name-discarding-0-rtt-keys" class="xref">Discarding 0-RTT Keys</a></p>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-packet-protection" class="xref">Packet Protection</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-packet-protection-keys" class="xref">Packet Protection Keys</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-initial-secrets" class="xref">Initial Secrets</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-aead-usage" class="xref">AEAD Usage</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-header-protection" class="xref">Header Protection</a></p>
+<ul class="ulEmpty ulBare toc compact">
+<li class="ulEmpty ulBare toc compact" id="section-toc.1-1.5.2.4.2.1">
+                    <p id="section-toc.1-1.5.2.4.2.1.1"><a href="#section-5.4.1" class="xref">5.4.1</a>.  <a href="#name-header-protection-applicati" class="xref">Header Protection Application</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.5.2.4.2.2">
+                    <p id="section-toc.1-1.5.2.4.2.2.1"><a href="#section-5.4.2" class="xref">5.4.2</a>.  <a href="#name-header-protection-sample" class="xref">Header Protection Sample</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.5.2.4.2.3">
+                    <p id="section-toc.1-1.5.2.4.2.3.1"><a href="#section-5.4.3" class="xref">5.4.3</a>.  <a href="#name-aes-based-header-protection" class="xref">AES-Based Header Protection</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.5.2.4.2.4">
+                    <p id="section-toc.1-1.5.2.4.2.4.1"><a href="#section-5.4.4" class="xref">5.4.4</a>.  <a href="#name-chacha20-based-header-prote" class="xref">ChaCha20-Based Header Protection</a></p>
+</li>
+                </ul>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.5">
+                <p id="section-toc.1-1.5.2.5.1"><a href="#section-5.5" class="xref">5.5</a>.  <a href="#name-receiving-protected-packets" class="xref">Receiving Protected Packets</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.6">
+                <p id="section-toc.1-1.5.2.6.1"><a href="#section-5.6" class="xref">5.6</a>.  <a href="#name-use-of-0-rtt-keys" class="xref">Use of 0-RTT Keys</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.7">
+                <p id="section-toc.1-1.5.2.7.1"><a href="#section-5.7" class="xref">5.7</a>.  <a href="#name-receiving-out-of-order-prot" class="xref">Receiving Out-of-Order Protected Packets</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.5.2.8">
+                <p id="section-toc.1-1.5.2.8.1"><a href="#section-5.8" class="xref">5.8</a>.  <a href="#name-retry-packet-integrity" class="xref">Retry Packet Integrity</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-key-update" class="xref">Key Update</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-initiating-a-key-update" class="xref">Initiating a Key Update</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-responding-to-a-key-update" class="xref">Responding to a Key Update</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-timing-of-receive-key-gener" class="xref">Timing of Receive Key Generation</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.4">
+                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-sending-with-updated-keys" class="xref">Sending with Updated Keys</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.5">
+                <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="xref">6.5</a>.  <a href="#name-receiving-with-different-ke" class="xref">Receiving with Different Keys</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.6">
+                <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="xref">6.6</a>.  <a href="#name-limits-on-aead-usage" class="xref">Limits on AEAD Usage</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.6.2.7">
+                <p id="section-toc.1-1.6.2.7.1"><a href="#section-6.7" class="xref">6.7</a>.  <a href="#name-key-update-error-code" class="xref">Key Update Error Code</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-security-of-initial-message" class="xref">Security of Initial Messages</a></p>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-quic-specific-adjustments-t" class="xref">QUIC-Specific Adjustments to the TLS Handshake</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.8.2.1">
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-protocol-negotiation" class="xref">Protocol Negotiation</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.8.2.2">
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-quic-transport-parameters-e" class="xref">QUIC Transport Parameters Extension</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.8.2.3">
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-removing-the-endofearlydata" class="xref">Removing the EndOfEarlyData Message</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.8.2.4">
+                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-prohibit-tls-middlebox-comp" class="xref">Prohibit TLS Middlebox Compatibility Mode</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.1">
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="xref">9.1</a>.  <a href="#name-session-linkability" class="xref">Session Linkability</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="xref">9.2</a>.  <a href="#name-replay-attacks-with-0-rtt" class="xref">Replay Attacks with 0-RTT</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.3">
+                <p id="section-toc.1-1.9.2.3.1"><a href="#section-9.3" class="xref">9.3</a>.  <a href="#name-packet-reflection-attack-mi" class="xref">Packet Reflection Attack Mitigation</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.4">
+                <p id="section-toc.1-1.9.2.4.1"><a href="#section-9.4" class="xref">9.4</a>.  <a href="#name-header-protection-analysis" class="xref">Header Protection Analysis</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.5">
+                <p id="section-toc.1-1.9.2.5.1"><a href="#section-9.5" class="xref">9.5</a>.  <a href="#name-header-protection-timing-si" class="xref">Header Protection Timing Side Channels</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.6">
+                <p id="section-toc.1-1.9.2.6.1"><a href="#section-9.6" class="xref">9.6</a>.  <a href="#name-key-diversity" class="xref">Key Diversity</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.9.2.7">
+                <p id="section-toc.1-1.9.2.7.1"><a href="#section-9.7" class="xref">9.7</a>.  <a href="#name-randomness" class="xref">Randomness</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-references" class="xref">References</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.11.2.1">
+                <p id="section-toc.1-1.11.2.1.1"><a href="#section-11.1" class="xref">11.1</a>.  <a href="#name-normative-references" class="xref">Normative References</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.11.2.2">
+                <p id="section-toc.1-1.11.2.2.1"><a href="#section-11.2" class="xref">11.2</a>.  <a href="#name-informative-references" class="xref">Informative References</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-sample-packet-protection" class="xref">Sample Packet Protection</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.12.2.1">
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-keys" class="xref">Keys</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.12.2.2">
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-client-initial" class="xref">Client Initial</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.12.2.3">
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-server-initial" class="xref">Server Initial</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.12.2.4">
+                <p id="section-toc.1-1.12.2.4.1"><a href="#appendix-A.4" class="xref">A.4</a>.  <a href="#name-retry" class="xref">Retry</a></p>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.12.2.5">
+                <p id="section-toc.1-1.12.2.5.1"><a href="#appendix-A.5" class="xref">A.5</a>.  <a href="#name-chacha20-poly1305-short-hea" class="xref">ChaCha20-Poly1305 Short Header Packet</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-aead-algorithm-analysis" class="xref">AEAD Algorithm Analysis</a></p>
+<ul class="ulEmpty toc ulBare compact">
+<li class="ulEmpty toc ulBare compact" id="section-toc.1-1.13.2.1">
+                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-analysis-of-aead_aes_128_gc" class="xref">Analysis of AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits</a></p>
+<ul class="ulEmpty ulBare toc compact">
+<li class="ulEmpty ulBare toc compact" id="section-toc.1-1.13.2.1.2.1">
+                    <p id="section-toc.1-1.13.2.1.2.1.1"><a href="#appendix-B.1.1" class="xref">B.1.1</a>.  <a href="#name-confidentiality-limit" class="xref">Confidentiality Limit</a></p>
+</li>
+                  <li class="ulEmpty ulBare toc compact" id="section-toc.1-1.13.2.1.2.2">
+                    <p id="section-toc.1-1.13.2.1.2.2.1"><a href="#appendix-B.1.2" class="xref">B.1.2</a>.  <a href="#name-integrity-limit" class="xref">Integrity Limit</a></p>
+</li>
+                </ul>
+</li>
+              <li class="ulEmpty toc ulBare compact" id="section-toc.1-1.13.2.2">
+                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-analysis-of-aead_aes_128_cc" class="xref">Analysis of AEAD_AES_128_CCM Usage Limits</a></p>
+</li>
+            </ul>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="xref"></a><a href="#name-contributors" class="xref">Contributors</a></p>
+</li>
+          <li class="ulEmpty compact toc ulBare" id="section-toc.1-1.15">
+            <p id="section-toc.1-1.15.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="introduction">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">This document describes how QUIC <span>[<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span> is secured using TLS
+<span>[<a href="#TLS13" class="xref">TLS13</a>]</span>.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">TLS 1.3 provides critical latency improvements for connection establishment over
+previous versions.  Absent packet loss, most new connections can be established
+and secured within a single round trip; on subsequent connections between the
+same client and server, the client can often send application data immediately,
+that is, using a zero round-trip setup.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<p id="section-1-3">This document describes how TLS acts as a security component of QUIC.<a href="#section-1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="notational-conventions">
+<section id="section-2">
+      <h2 id="name-notational-conventions">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-notational-conventions" class="section-name selfRef">Notational Conventions</a>
+      </h2>
+<p id="section-2-1">The key words "<span class="bcp14">MUST</span>", "<span class="bcp14">MUST NOT</span>", "<span class="bcp14">REQUIRED</span>", "<span class="bcp14">SHALL</span>", "<span class="bcp14">SHALL NOT</span>", "<span class="bcp14">SHOULD</span>",
+"<span class="bcp14">SHOULD NOT</span>", "<span class="bcp14">RECOMMENDED</span>", "<span class="bcp14">NOT RECOMMENDED</span>", "<span class="bcp14">MAY</span>", and "<span class="bcp14">OPTIONAL</span>" in this
+document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="xref">RFC8174</a>]</span>
+when, and only when, they appear in all capitals, as shown here.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">This document uses the terminology established in <span>[<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<p id="section-2-3">For brevity, the acronym TLS is used to refer to TLS 1.3, though a newer version
+could be used; see <a href="#tls-version" class="xref">Section 4.2</a>.<a href="#section-2-3" class="pilcrow">¶</a></p>
+<div id="tls-overview">
+<section id="section-2.1">
+        <h3 id="name-tls-overview">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-tls-overview" class="section-name selfRef">TLS Overview</a>
+        </h3>
+<p id="section-2.1-1">TLS provides two endpoints with a way to establish a means of communication over
+an untrusted medium (for example, the Internet). TLS enables authentication of
+peers and provides confidentiality and integrity protection for messages that
+endpoints exchange.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-2">Internally, TLS is a layered protocol, with the structure shown in
+<a href="#tls-layers" class="xref">Figure 1</a>.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
+<span id="name-tls-layers"></span><div id="tls-layers">
+<figure id="figure-1">
+          <div class="artwork art-text alignLeft" id="section-2.1-3.1">
+<pre>
+          +-------------+------------+--------------+---------+
+Content   |             |            |  Application |         |
+Layer     |  Handshake  |   Alerts   |     Data     |   ...   |
+          |             |            |              |         |
+          +-------------+------------+--------------+---------+
+Record    |                                                   |
+Layer     |                      Records                      |
+          |                                                   |
+          +---------------------------------------------------+
+</pre>
+</div>
+<figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
+<a href="#name-tls-layers" class="selfRef">TLS Layers</a>
+          </figcaption></figure>
+</div>
+<p id="section-2.1-4">Each content-layer message (e.g., handshake, alerts, and application data) is
+carried as a series of typed TLS records by the record layer.  Records are
+individually cryptographically protected and then transmitted over a reliable
+transport (typically TCP), which provides sequencing and guaranteed delivery.<a href="#section-2.1-4" class="pilcrow">¶</a></p>
+<p id="section-2.1-5">The TLS authenticated key exchange occurs between two endpoints: client and
+server.  The client initiates the exchange and the server responds.  If the key
+exchange completes successfully, both client and server will agree on a secret.
+TLS supports both pre-shared key (PSK) and Diffie-Hellman over either finite
+fields or elliptic curves ((EC)DHE) key exchanges.  PSK is the basis for Early
+Data (0-RTT); the latter provides forward secrecy (FS) when the (EC)DHE
+keys are destroyed.  The two modes can also be combined to provide forward
+secrecy while using the PSK for authentication.<a href="#section-2.1-5" class="pilcrow">¶</a></p>
+<p id="section-2.1-6">After completing the TLS handshake, the client will have learned and
+authenticated an identity for the server, and the server is optionally able to
+learn and authenticate an identity for the client.  TLS supports X.509
+<span>[<a href="#RFC5280" class="xref">RFC5280</a>]</span> certificate-based authentication for both server and client.
+When PSK key exchange is used (as in resumption), knowledge of the PSK
+serves to authenticate the peer.<a href="#section-2.1-6" class="pilcrow">¶</a></p>
+<p id="section-2.1-7">The TLS key exchange is resistant to tampering by attackers, and it produces
+shared secrets that cannot be controlled by either participating peer.<a href="#section-2.1-7" class="pilcrow">¶</a></p>
+<p id="section-2.1-8">TLS provides two basic handshake modes of interest to QUIC:<a href="#section-2.1-8" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-2.1-9.1">A full 1-RTT handshake, in which the client is able to send application data
+after one round trip and the server immediately responds after receiving the
+first handshake message from the client.<a href="#section-2.1-9.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-2.1-9.2">A 0-RTT handshake, in which the client uses information it has previously
+learned about the server to send application data immediately.  This
+application data can be replayed by an attacker, so 0-RTT is not suitable for
+carrying instructions that might initiate any action that could cause
+unwanted effects if replayed.<a href="#section-2.1-9.2" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-2.1-10">A simplified TLS handshake with 0-RTT application data is shown in <a href="#tls-full" class="xref">Figure 2</a>.<a href="#section-2.1-10" class="pilcrow">¶</a></p>
+<span id="name-tls-handshake-with-0-rtt"></span><div id="tls-full">
+<figure id="figure-2">
+          <div class="artwork art-text alignLeft" id="section-2.1-11.1">
+<pre>
+    Client                                             Server
+
+    ClientHello
+   (0-RTT Application Data)  --------&gt;
+                                                  ServerHello
+                                         {EncryptedExtensions}
+                                                    {Finished}
+                             &lt;--------      [Application Data]
+   {Finished}                --------&gt;
+
+   [Application Data]        &lt;-------&gt;      [Application Data]
+
+    () Indicates messages protected by Early Data (0-RTT) Keys
+    {} Indicates messages protected using Handshake Keys
+    [] Indicates messages protected using Application Data
+       (1-RTT) Keys
+</pre>
+</div>
+<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
+<a href="#name-tls-handshake-with-0-rtt" class="selfRef">TLS Handshake with 0-RTT</a>
+          </figcaption></figure>
+</div>
+<p id="section-2.1-12"><a href="#tls-full" class="xref">Figure 2</a> omits the EndOfEarlyData message, which is not used in QUIC; see
+<a href="#remove-eoed" class="xref">Section 8.3</a>. Likewise, neither ChangeCipherSpec nor KeyUpdate messages are
+used by QUIC. ChangeCipherSpec is redundant in TLS 1.3; see <a href="#compat-mode" class="xref">Section 8.4</a>.
+QUIC has its own key update mechanism; see <a href="#key-update" class="xref">Section 6</a>.<a href="#section-2.1-12" class="pilcrow">¶</a></p>
+<p id="section-2.1-13">Data is protected using a number of encryption levels:<a href="#section-2.1-13" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-2.1-14.1">Initial keys<a href="#section-2.1-14.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-2.1-14.2">Early data (0-RTT) keys<a href="#section-2.1-14.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-2.1-14.3">Handshake keys<a href="#section-2.1-14.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-2.1-14.4">Application data (1-RTT) keys<a href="#section-2.1-14.4" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-2.1-15">Application data can only appear in the early data and application data
+levels. Handshake and alert messages may appear in any level.<a href="#section-2.1-15" class="pilcrow">¶</a></p>
+<p id="section-2.1-16">The 0-RTT handshake can be used if the client and server have previously
+communicated.  In the 1-RTT handshake, the client is unable to send protected
+application data until it has received all of the handshake messages sent by the
+server.<a href="#section-2.1-16" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="protocol-overview">
+<section id="section-3">
+      <h2 id="name-protocol-overview">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-protocol-overview" class="section-name selfRef">Protocol Overview</a>
+      </h2>
+<p id="section-3-1">QUIC <span>[<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span> assumes responsibility for the confidentiality and
+integrity protection of packets.  For this it uses keys derived from a TLS
+handshake <span>[<a href="#TLS13" class="xref">TLS13</a>]</span>, but instead of carrying TLS records over QUIC (as with
+TCP), TLS handshake and alert messages are carried directly over the QUIC
+transport, which takes over the responsibilities of the TLS record layer, as
+shown in <a href="#quic-layers" class="xref">Figure 3</a>.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<span id="name-quic-layers"></span><div id="quic-layers">
+<figure id="figure-3">
+        <div class="artwork art-text alignLeft" id="section-3-2.1">
+<pre>
++--------------+--------------+ +-------------+
+|     TLS      |     TLS      | |    QUIC     |
+|  Handshake   |    Alerts    | | Applications|
+|              |              | |  (h3, etc.) |
++--------------+--------------+-+-------------+
+|                                             |
+|                QUIC Transport               |
+|   (streams, reliability, congestion, etc.)  |
+|                                             |
++---------------------------------------------+
+|                                             |
+|            QUIC Packet Protection           |
+|                                             |
++---------------------------------------------+
+</pre>
+</div>
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<a href="#name-quic-layers" class="selfRef">QUIC Layers</a>
+        </figcaption></figure>
+</div>
+<p id="section-3-3">QUIC also relies on TLS for authentication and negotiation of parameters that
+are critical to security and performance.<a href="#section-3-3" class="pilcrow">¶</a></p>
+<p id="section-3-4">Rather than a strict layering, these two protocols cooperate: QUIC uses the TLS
+handshake; TLS uses the reliability, ordered delivery, and record layer provided
+by QUIC.<a href="#section-3-4" class="pilcrow">¶</a></p>
+<p id="section-3-5">At a high level, there are two main interactions between the TLS and QUIC
+components:<a href="#section-3-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-3-6.1">The TLS component sends and receives messages via the QUIC component, with
+QUIC providing a reliable stream abstraction to TLS.<a href="#section-3-6.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-3-6.2">The TLS component provides a series of updates to the QUIC component,
+including (a) new packet protection keys to install and (b) state changes such
+as handshake completion, the server certificate, etc.<a href="#section-3-6.2" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="section-3-7"><a href="#schematic" class="xref">Figure 4</a> shows these interactions in more detail, with the QUIC packet
+protection being called out specially.<a href="#section-3-7" class="pilcrow">¶</a></p>
+<span id="name-quic-and-tls-interactions"></span><div id="schematic">
+<figure id="figure-4">
+        <div class="artwork art-text alignLeft" id="section-3-8.1">
+<pre>
++------------+                               +------------+
+|            |&lt;---- Handshake Messages -----&gt;|            |
+|            |&lt;- Validate 0-RTT Parameters -&gt;|            |
+|            |&lt;--------- 0-RTT Keys ---------|            |
+|    QUIC    |&lt;------- Handshake Keys -------|    TLS     |
+|            |&lt;--------- 1-RTT Keys ---------|            |
+|            |&lt;------- Handshake Done -------|            |
++------------+                               +------------+
+ |         ^
+ | Protect | Protected
+ v         | Packet
++------------+
+|   QUIC     |
+|  Packet    |
+| Protection |
++------------+
+</pre>
+</div>
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<a href="#name-quic-and-tls-interactions" class="selfRef">QUIC and TLS Interactions</a>
+        </figcaption></figure>
+</div>
+<p id="section-3-9">Unlike TLS over TCP, QUIC applications that want to send data do not send it
+using TLS Application Data records. Rather, they send it as QUIC STREAM
+frames or other frame types, which are then carried in QUIC packets.<a href="#section-3-9" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="carrying-tls">
+<section id="section-4">
+      <h2 id="name-carrying-tls-messages">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-carrying-tls-messages" class="section-name selfRef">Carrying TLS Messages</a>
+      </h2>
+<p id="section-4-1">QUIC carries TLS handshake data in CRYPTO frames, each of which consists of a
+contiguous block of handshake data identified by an offset and length. Those
+frames are packaged into QUIC packets and encrypted under the current
+encryption level.  As with TLS over TCP, once TLS handshake data has been
+delivered to QUIC, it is QUIC's responsibility to deliver it reliably. Each
+chunk of data that is produced by TLS is associated with the set of keys that
+TLS is currently using.  If QUIC needs to retransmit that data, it <span class="bcp14">MUST</span> use the
+same keys even if TLS has already updated to newer keys.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">Each encryption level corresponds to a packet number space. The packet number
+space that is used determines the semantics of frames. Some frames are
+prohibited in different packet number spaces; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-12.5" class="relref">Section 12.5</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3">Because packets could be reordered on the wire, QUIC uses the packet type to
+indicate which keys were used to protect a given packet, as shown in
+<a href="#packet-types-keys" class="xref">Table 1</a>. When packets of different types need to be sent,
+endpoints <span class="bcp14">SHOULD</span> use coalesced packets to send them in the same UDP datagram.<a href="#section-4-3" class="pilcrow">¶</a></p>
+<span id="name-encryption-keys-by-packet-t"></span><div id="packet-types-keys">
+<table class="center" id="table-1">
+        <caption>
+<a href="#table-1" class="selfRef">Table 1</a>:
+<a href="#name-encryption-keys-by-packet-t" class="selfRef">Encryption Keys by Packet Type</a>
+        </caption>
+<thead>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">Packet Type</th>
+            <th class="text-left" rowspan="1" colspan="1">Encryption Keys</th>
+            <th class="text-left" rowspan="1" colspan="1">PN Space</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">Initial</th>
+            <td class="text-left" rowspan="1" colspan="1">Initial secrets</td>
+            <td class="text-left" rowspan="1" colspan="1">Initial</td>
+          </tr>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">0-RTT Protected</th>
+            <td class="text-left" rowspan="1" colspan="1">0-RTT</td>
+            <td class="text-left" rowspan="1" colspan="1">Application data</td>
+          </tr>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">Handshake</th>
+            <td class="text-left" rowspan="1" colspan="1">Handshake</td>
+            <td class="text-left" rowspan="1" colspan="1">Handshake</td>
+          </tr>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">Retry</th>
+            <td class="text-left" rowspan="1" colspan="1">Retry</td>
+            <td class="text-left" rowspan="1" colspan="1">N/A</td>
+          </tr>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">Version Negotiation</th>
+            <td class="text-left" rowspan="1" colspan="1">N/A</td>
+            <td class="text-left" rowspan="1" colspan="1">N/A</td>
+          </tr>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">Short Header</th>
+            <td class="text-left" rowspan="1" colspan="1">1-RTT</td>
+            <td class="text-left" rowspan="1" colspan="1">Application data</td>
+          </tr>
+        </tbody>
+      </table>
+</div>
+<p id="section-4-5"><span><a href="https://rfc-editor.org/rfc/rfc9000#section-17" class="relref">Section 17</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span> shows how packets at the various encryption
+levels fit into the handshake process.<a href="#section-4-5" class="pilcrow">¶</a></p>
+<div id="interface-to-tls">
+<section id="section-4.1">
+        <h3 id="name-interface-to-tls">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-interface-to-tls" class="section-name selfRef">Interface to TLS</a>
+        </h3>
+<p id="section-4.1-1">As shown in <a href="#schematic" class="xref">Figure 4</a>, the interface from QUIC to TLS consists of four
+primary functions:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.1-2.1">Sending and receiving handshake messages<a href="#section-4.1-2.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-2.2">Processing stored transport and application state from a resumed session
+and determining if it is valid to generate or accept 0-RTT data<a href="#section-4.1-2.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-2.3">Rekeying (both transmit and receive)<a href="#section-4.1-2.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-2.4">Updating handshake state<a href="#section-4.1-2.4" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-4.1-3">Additional functions might be needed to configure TLS.  In particular, QUIC and
+TLS need to agree on which is responsible for validation of peer credentials,
+such as certificate validation <span>[<a href="#RFC5280" class="xref">RFC5280</a>]</span>.<a href="#section-4.1-3" class="pilcrow">¶</a></p>
+<div id="handshake-complete">
+<section id="section-4.1.1">
+          <h4 id="name-handshake-complete">
+<a href="#section-4.1.1" class="section-number selfRef">4.1.1. </a><a href="#name-handshake-complete" class="section-name selfRef">Handshake Complete</a>
+          </h4>
+<p id="section-4.1.1-1">In this document, the TLS handshake is considered complete when the TLS stack
+has reported that the handshake is complete.  This happens when the TLS stack
+has both sent a Finished message and verified the peer's Finished message.
+Verifying the peer's Finished message provides the endpoints with an assurance
+that previous handshake messages have not been modified.  Note that the
+handshake does not complete at both endpoints simultaneously.  Consequently, any
+requirement that is based on the completion of the handshake depends on the
+perspective of the endpoint in question.<a href="#section-4.1.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="handshake-confirmed">
+<section id="section-4.1.2">
+          <h4 id="name-handshake-confirmed">
+<a href="#section-4.1.2" class="section-number selfRef">4.1.2. </a><a href="#name-handshake-confirmed" class="section-name selfRef">Handshake Confirmed</a>
+          </h4>
+<p id="section-4.1.2-1">In this document, the TLS handshake is considered confirmed at the server when
+the handshake completes.  The server <span class="bcp14">MUST</span> send a HANDSHAKE_DONE frame as soon as
+the handshake is complete.  At the client, the handshake is considered confirmed
+when a HANDSHAKE_DONE frame is received.<a href="#section-4.1.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.1.2-2">Additionally, a client <span class="bcp14">MAY</span> consider the handshake to be confirmed when it
+receives an acknowledgment for a 1-RTT packet.  This can be implemented by
+recording the lowest packet number sent with 1-RTT keys and comparing it to the
+Largest Acknowledged field in any received 1-RTT ACK frame: once the latter is
+greater than or equal to the former, the handshake is confirmed.<a href="#section-4.1.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="sending-and-receiving-handshake-messages">
+<section id="section-4.1.3">
+          <h4 id="name-sending-and-receiving-hands">
+<a href="#section-4.1.3" class="section-number selfRef">4.1.3. </a><a href="#name-sending-and-receiving-hands" class="section-name selfRef">Sending and Receiving Handshake Messages</a>
+          </h4>
+<p id="section-4.1.3-1">In order to drive the handshake, TLS depends on being able to send and receive
+handshake messages. There are two basic functions on this interface: one where
+QUIC requests handshake messages and one where QUIC provides bytes that comprise
+handshake messages.<a href="#section-4.1.3-1" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-2">Before starting the handshake, QUIC provides TLS with the transport parameters
+(see <a href="#quic_parameters" class="xref">Section 8.2</a>) that it wishes to carry.<a href="#section-4.1.3-2" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-3">A QUIC client starts TLS by requesting TLS handshake bytes from TLS.  The client
+acquires handshake bytes before sending its first packet.  A QUIC server starts
+the process by providing TLS with the client's handshake bytes.<a href="#section-4.1.3-3" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-4">At any time, the TLS stack at an endpoint will have a current sending encryption
+level and a receiving encryption level. TLS encryption levels determine the QUIC
+packet type and keys that are used for protecting data.<a href="#section-4.1.3-4" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-5">Each encryption level is associated with a different sequence of bytes, which is
+reliably transmitted to the peer in CRYPTO frames. When TLS provides handshake
+bytes to be sent, they are appended to the handshake bytes for the current
+encryption level. The encryption level then determines the type of packet that
+the resulting CRYPTO frame is carried in; see <a href="#packet-types-keys" class="xref">Table 1</a>.<a href="#section-4.1.3-5" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-6">Four encryption levels are used, producing keys for Initial, 0-RTT, Handshake,
+and 1-RTT packets. CRYPTO frames are carried in just three of these levels,
+omitting the 0-RTT level. These four levels correspond to three packet number
+spaces: Initial and Handshake encrypted packets use their own separate spaces;
+0-RTT and 1-RTT packets use the application data packet number space.<a href="#section-4.1.3-6" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-7">QUIC takes the unprotected content of TLS handshake records as the content of
+CRYPTO frames. TLS record protection is not used by QUIC. QUIC assembles
+CRYPTO frames into QUIC packets, which are protected using QUIC packet
+protection.<a href="#section-4.1.3-7" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-8">QUIC CRYPTO frames only carry TLS handshake messages.  TLS
+alerts are turned into QUIC CONNECTION_CLOSE error codes; see <a href="#tls-errors" class="xref">Section 4.8</a>.
+TLS application data and other content types cannot be carried by QUIC at any
+encryption level; it is an error if they are received from the TLS stack.<a href="#section-4.1.3-8" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-9">When an endpoint receives a QUIC packet containing a CRYPTO frame from the
+network, it proceeds as follows:<a href="#section-4.1.3-9" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.1.3-10.1">If the packet uses the current TLS receiving encryption level, sequence the
+data into the input flow as usual. As with STREAM frames, the offset is used
+to find the proper location in the data sequence.  If the result of this
+process is that new data is available, then it is delivered to TLS in order.<a href="#section-4.1.3-10.1" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-4.1.3-10.2">If the packet is from a previously installed encryption level, it <span class="bcp14">MUST NOT</span>
+contain data that extends past the end of previously received data in that
+flow. Implementations <span class="bcp14">MUST</span> treat any violations of this requirement as a
+connection error of type PROTOCOL_VIOLATION.<a href="#section-4.1.3-10.2" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-4.1.3-10.3">If the packet is from a new encryption level, it is saved for later processing
+by TLS.  Once TLS moves to receiving from this encryption level, saved data
+can be provided to TLS.  When TLS provides keys for a higher encryption level,
+if there is data from a previous encryption level that TLS has not consumed,
+this <span class="bcp14">MUST</span> be treated as a connection error of type PROTOCOL_VIOLATION.<a href="#section-4.1.3-10.3" class="pilcrow">¶</a>
+</li>
+          </ul>
+<p id="section-4.1.3-11">Each time that TLS is provided with new data, new handshake bytes are requested
+from TLS.  TLS might not provide any bytes if the handshake messages it has
+received are incomplete or it has no data to send.<a href="#section-4.1.3-11" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-12">The content of CRYPTO frames might either be processed incrementally by TLS or
+buffered until complete messages or flights are available.  TLS is responsible
+for buffering handshake bytes that have arrived in order.  QUIC is responsible
+for buffering handshake bytes that arrive out of order or for encryption levels
+that are not yet ready.  QUIC does not provide any means of flow control for
+CRYPTO frames; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-7.5" class="relref">Section 7.5</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-4.1.3-12" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-13">Once the TLS handshake is complete, this is indicated to QUIC along with any
+final handshake bytes that TLS needs to send.  At this stage, the transport
+parameters that the peer advertised during the handshake are authenticated;
+see <a href="#quic_parameters" class="xref">Section 8.2</a>.<a href="#section-4.1.3-13" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-14">Once the handshake is complete, TLS becomes passive.  TLS can still receive data
+from its peer and respond in kind, but it will not need to send more data unless
+specifically requested -- either by an application or QUIC.  One reason to send
+data is that the server might wish to provide additional or updated session
+tickets to a client.<a href="#section-4.1.3-14" class="pilcrow">¶</a></p>
+<p id="section-4.1.3-15">When the handshake is complete, QUIC only needs to provide TLS with any data
+that arrives in CRYPTO streams.  In the same manner that is used during the
+handshake, new data is requested from TLS after providing received data.<a href="#section-4.1.3-15" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="encryption-level-changes">
+<section id="section-4.1.4">
+          <h4 id="name-encryption-level-changes">
+<a href="#section-4.1.4" class="section-number selfRef">4.1.4. </a><a href="#name-encryption-level-changes" class="section-name selfRef">Encryption Level Changes</a>
+          </h4>
+<p id="section-4.1.4-1">As keys at a given encryption level become available to TLS, TLS indicates to
+QUIC that reading or writing keys at that encryption level are available.<a href="#section-4.1.4-1" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-2">The availability of new keys is always a result of providing inputs to TLS.  TLS
+only provides new keys after being initialized (by a client) or when provided
+with new handshake data.<a href="#section-4.1.4-2" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-3">However, a TLS implementation could perform some of its processing
+asynchronously. In particular, the process of validating a certificate can take
+some time. While waiting for TLS processing to complete, an endpoint <span class="bcp14">SHOULD</span>
+buffer received packets if they might be processed using keys that are not yet
+available. These packets can be processed once keys are provided by TLS. An
+endpoint <span class="bcp14">SHOULD</span> continue to respond to packets that can be processed during this
+time.<a href="#section-4.1.4-3" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-4">After processing inputs, TLS might produce handshake bytes, keys for new
+encryption levels, or both.<a href="#section-4.1.4-4" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-5">TLS provides QUIC with three items as a new encryption level becomes available:<a href="#section-4.1.4-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.1.4-6.1">A secret<a href="#section-4.1.4-6.1" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-4.1.4-6.2">An Authenticated Encryption with Associated Data (AEAD) function<a href="#section-4.1.4-6.2" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-4.1.4-6.3">A Key Derivation Function (KDF)<a href="#section-4.1.4-6.3" class="pilcrow">¶</a>
+</li>
+          </ul>
+<p id="section-4.1.4-7">These values are based on the values that TLS negotiates and are used by QUIC to
+generate packet and header protection keys; see <a href="#packet-protection" class="xref">Section 5</a> and
+<a href="#header-protect" class="xref">Section 5.4</a>.<a href="#section-4.1.4-7" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-8">If 0-RTT is possible, it is ready after the client sends a TLS ClientHello
+message or the server receives that message.  After providing a QUIC client with
+the first handshake bytes, the TLS stack might signal the change to 0-RTT
+keys. On the server, after receiving handshake bytes that contain a ClientHello
+message, a TLS server might signal that 0-RTT keys are available.<a href="#section-4.1.4-8" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-9">Although TLS only uses one encryption level at a time, QUIC may use more than
+one level. For instance, after sending its Finished message (using a CRYPTO
+frame at the Handshake encryption level) an endpoint can send STREAM data (in
+1-RTT encryption). If the Finished message is lost, the endpoint uses the
+Handshake encryption level to retransmit the lost message.  Reordering or loss
+of packets can mean that QUIC will need to handle packets at multiple encryption
+levels.  During the handshake, this means potentially handling packets at higher
+and lower encryption levels than the current encryption level used by TLS.<a href="#section-4.1.4-9" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-10">In particular, server implementations need to be able to read packets at the
+Handshake encryption level at the same time as the 0-RTT encryption level.  A
+client could interleave ACK frames that are protected with Handshake keys with
+0-RTT data, and the server needs to process those acknowledgments in order to
+detect lost Handshake packets.<a href="#section-4.1.4-10" class="pilcrow">¶</a></p>
+<p id="section-4.1.4-11">QUIC also needs access to keys that might not ordinarily be available to a TLS
+implementation.  For instance, a client might need to acknowledge Handshake
+packets before it is ready to send CRYPTO frames at that encryption level.  TLS
+therefore needs to provide keys to QUIC before it might produce them for its own
+use.<a href="#section-4.1.4-11" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="tls-interface-summary">
+<section id="section-4.1.5">
+          <h4 id="name-tls-interface-summary">
+<a href="#section-4.1.5" class="section-number selfRef">4.1.5. </a><a href="#name-tls-interface-summary" class="section-name selfRef">TLS Interface Summary</a>
+          </h4>
+<p id="section-4.1.5-1"><a href="#exchange-summary" class="xref">Figure 5</a> summarizes the exchange between QUIC and TLS for both
+client and server. Solid arrows indicate packets that carry handshake data;
+dashed arrows show where application data can be sent.  Each arrow is tagged
+with the encryption level used for that transmission.<a href="#section-4.1.5-1" class="pilcrow">¶</a></p>
+<span id="name-interaction-summary-between"></span><div id="exchange-summary">
+<figure id="figure-5">
+            <div class="artwork art-text alignLeft" id="section-4.1.5-2.1">
+<pre>
+Client                                                    Server
+======                                                    ======
+
+Get Handshake
+                     Initial -------------&gt;
+Install tx 0-RTT keys
+                     0-RTT - - - - - - - -&gt;
+
+                                              Handshake Received
+                                                   Get Handshake
+                     &lt;------------- Initial
+                                           Install rx 0-RTT keys
+                                          Install Handshake keys
+                                                   Get Handshake
+                     &lt;----------- Handshake
+                                           Install tx 1-RTT keys
+                     &lt;- - - - - - - - 1-RTT
+
+Handshake Received (Initial)
+Install Handshake keys
+Handshake Received (Handshake)
+Get Handshake
+                     Handshake -----------&gt;
+Handshake Complete
+Install 1-RTT keys
+                     1-RTT - - - - - - - -&gt;
+
+                                              Handshake Received
+                                              Handshake Complete
+                                             Handshake Confirmed
+                                           Install rx 1-RTT keys
+                     &lt;--------------- 1-RTT
+                           (HANDSHAKE_DONE)
+Handshake Confirmed
+</pre>
+</div>
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<a href="#name-interaction-summary-between" class="selfRef">Interaction Summary between QUIC and TLS</a>
+            </figcaption></figure>
+</div>
+<p id="section-4.1.5-3"><a href="#exchange-summary" class="xref">Figure 5</a> shows the multiple packets that form a single "flight" of
+messages being processed individually, to show what incoming messages trigger
+different actions. This shows multiple "Get Handshake" invocations to retrieve
+handshake messages at different encryption levels. New handshake messages are
+requested after incoming packets have been processed.<a href="#section-4.1.5-3" class="pilcrow">¶</a></p>
+<p id="section-4.1.5-4"><a href="#exchange-summary" class="xref">Figure 5</a> shows one possible structure for a simple handshake
+exchange. The exact process varies based on the structure of endpoint
+implementations and the order in which packets arrive. Implementations could
+use a different number of operations or execute them in other orders.<a href="#section-4.1.5-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="tls-version">
+<section id="section-4.2">
+        <h3 id="name-tls-version">
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-tls-version" class="section-name selfRef">TLS Version</a>
+        </h3>
+<p id="section-4.2-1">This document describes how TLS 1.3 <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> is used with QUIC.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.2-2">In practice, the TLS handshake will negotiate a version of TLS to use.  This
+could result in a version of TLS newer than 1.3 being negotiated if both
+endpoints support that version.  This is acceptable provided that the features
+of TLS 1.3 that are used by QUIC are supported by the newer version.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.2-3">Clients <span class="bcp14">MUST NOT</span> offer TLS versions older than 1.3.  A badly configured TLS
+implementation could negotiate TLS 1.2 or another older version of TLS.  An
+endpoint <span class="bcp14">MUST</span> terminate the connection if a version of TLS older than 1.3 is
+negotiated.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="clienthello-size">
+<section id="section-4.3">
+        <h3 id="name-clienthello-size">
+<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-clienthello-size" class="section-name selfRef">ClientHello Size</a>
+        </h3>
+<p id="section-4.3-1">The first Initial packet from a client contains the start or all of its first
+cryptographic handshake message, which for TLS is the ClientHello.  Servers
+might need to parse the entire ClientHello (e.g., to access extensions such as
+Server Name Identification (SNI) or Application-Layer Protocol Negotiation
+(ALPN)) in order to decide whether to accept the new incoming QUIC connection.
+If the ClientHello spans multiple Initial packets, such servers would need to
+buffer the first received fragments, which could consume excessive resources if
+the client's address has not yet been validated.  To avoid this, servers <span class="bcp14">MAY</span>
+use the Retry feature (see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>) to only buffer
+partial ClientHello messages from clients with a validated address.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
+<p id="section-4.3-2">QUIC packet and framing add at least 36 bytes of overhead to the ClientHello
+message.  That overhead increases if the client chooses a Source Connection ID
+field longer than zero bytes.  Overheads also do not include the token or a
+Destination Connection ID longer than 8 bytes, both of which might be required
+if a server sends a Retry packet.<a href="#section-4.3-2" class="pilcrow">¶</a></p>
+<p id="section-4.3-3">A typical TLS ClientHello can easily fit into a 1200-byte packet.  However, in
+addition to the overheads added by QUIC, there are several variables that could
+cause this limit to be exceeded.  Large session tickets, multiple or large key
+shares, and long lists of supported ciphers, signature algorithms, versions,
+QUIC transport parameters, and other negotiable parameters and extensions could
+cause this message to grow.<a href="#section-4.3-3" class="pilcrow">¶</a></p>
+<p id="section-4.3-4">For servers, in addition to connection IDs and tokens, the size of TLS session
+tickets can have an effect on a client's ability to connect efficiently.
+Minimizing the size of these values increases the probability that clients can
+use them and still fit their entire ClientHello message in their first Initial
+packet.<a href="#section-4.3-4" class="pilcrow">¶</a></p>
+<p id="section-4.3-5">The TLS implementation does not need to ensure that the ClientHello is large
+enough to meet QUIC's requirements for datagrams that carry Initial packets; see
+<span><a href="https://rfc-editor.org/rfc/rfc9000#section-14.1" class="relref">Section 14.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>. QUIC implementations use PADDING frames or
+packet coalescing to ensure that datagrams are large enough.<a href="#section-4.3-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="peer-authentication">
+<section id="section-4.4">
+        <h3 id="name-peer-authentication">
+<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-peer-authentication" class="section-name selfRef">Peer Authentication</a>
+        </h3>
+<p id="section-4.4-1">The requirements for authentication depend on the application protocol that is
+in use.  TLS provides server authentication and permits the server to request
+client authentication.<a href="#section-4.4-1" class="pilcrow">¶</a></p>
+<p id="section-4.4-2">A client <span class="bcp14">MUST</span> authenticate the identity of the server.  This typically involves
+verification that the identity of the server is included in a certificate and
+that the certificate is issued by a trusted entity (see for example
+<span>[<a href="#RFC2818" class="xref">RFC2818</a>]</span>).<a href="#section-4.4-2" class="pilcrow">¶</a></p>
+<aside id="section-4.4-3">
+          <p id="section-4.4-3.1">Note: Where servers provide certificates for authentication, the size of the
+  certificate chain can consume a large number of bytes.  Controlling the size
+  of certificate chains is critical to performance in QUIC as servers are
+  limited to sending 3 bytes for every byte received prior to validating the
+  client address; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.  The size of a
+  certificate chain can be managed by limiting the number of names or
+  extensions; using keys with small public key representations, like ECDSA; or
+  by using certificate compression <span>[<a href="#COMPRESS" class="xref">COMPRESS</a>]</span>.<a href="#section-4.4-3.1" class="pilcrow">¶</a></p>
+</aside>
+<p id="section-4.4-4">A server <span class="bcp14">MAY</span> request that the client authenticate during the handshake. A server
+<span class="bcp14">MAY</span> refuse a connection if the client is unable to authenticate when requested.
+The requirements for client authentication vary based on application protocol
+and deployment.<a href="#section-4.4-4" class="pilcrow">¶</a></p>
+<p id="section-4.4-5">A server <span class="bcp14">MUST NOT</span> use post-handshake client authentication (as defined in
+<span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.6.2" class="relref">Section 4.6.2</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>) because the multiplexing offered by QUIC prevents
+clients from correlating the certificate request with the application-level
+event that triggered it (see <span>[<a href="#HTTP2-TLS13" class="xref">HTTP2-TLS13</a>]</span>).  More specifically,
+servers <span class="bcp14">MUST NOT</span> send post-handshake TLS CertificateRequest messages, and
+clients <span class="bcp14">MUST</span> treat receipt of such messages as a connection error of type
+PROTOCOL_VIOLATION.<a href="#section-4.4-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="resumption">
+<section id="section-4.5">
+        <h3 id="name-session-resumption">
+<a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-session-resumption" class="section-name selfRef">Session Resumption</a>
+        </h3>
+<p id="section-4.5-1">QUIC can use the session resumption feature of TLS 1.3. It does this by
+carrying NewSessionTicket messages in CRYPTO frames after the handshake is
+complete. Session resumption can be used to provide 0-RTT and can also be
+used when 0-RTT is disabled.<a href="#section-4.5-1" class="pilcrow">¶</a></p>
+<p id="section-4.5-2">Endpoints that use session resumption might need to remember some information
+about the current connection when creating a resumed connection. TLS requires
+that some information be retained; see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.6.1" class="relref">Section 4.6.1</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>. QUIC itself
+does not depend on any state being retained when resuming a connection unless
+0-RTT is also used; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-7.4.1" class="relref">Section 7.4.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span> and
+<a href="#enable-0rtt" class="xref">Section 4.6.1</a>. Application protocols could depend on state that is retained
+between resumed connections.<a href="#section-4.5-2" class="pilcrow">¶</a></p>
+<p id="section-4.5-3">Clients can store any state required for resumption along with the session
+ticket. Servers can use the session ticket to help carry state.<a href="#section-4.5-3" class="pilcrow">¶</a></p>
+<p id="section-4.5-4">Session resumption allows servers to link activity on the original connection
+with the resumed connection, which might be a privacy issue for clients.
+Clients can choose not to enable resumption to avoid creating this correlation.
+Clients <span class="bcp14">SHOULD NOT</span> reuse tickets as that allows entities other than the server
+to correlate connections; see <span><a href="https://rfc-editor.org/rfc/rfc8446#appendix-C.4" class="relref">Appendix C.4</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>.<a href="#section-4.5-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="rtt">
+<section id="section-4.6">
+        <h3 id="name-0-rtt">
+<a href="#section-4.6" class="section-number selfRef">4.6. </a><a href="#name-0-rtt" class="section-name selfRef">0-RTT</a>
+        </h3>
+<p id="section-4.6-1">The 0-RTT feature in QUIC allows a client to send application data before the
+handshake is complete.  This is made possible by reusing negotiated parameters
+from a previous connection.  To enable this, 0-RTT depends on the client
+remembering critical parameters and providing the server with a TLS session
+ticket that allows the server to recover the same information.<a href="#section-4.6-1" class="pilcrow">¶</a></p>
+<p id="section-4.6-2">This information includes parameters that determine TLS state, as governed by
+<span>[<a href="#TLS13" class="xref">TLS13</a>]</span>, QUIC transport parameters, the chosen application protocol, and any
+information the application protocol might need; see <a href="#app-0rtt" class="xref">Section 4.6.3</a>.  This
+information determines how 0-RTT packets and their contents are formed.<a href="#section-4.6-2" class="pilcrow">¶</a></p>
+<p id="section-4.6-3">To ensure that the same information is available to both endpoints, all
+information used to establish 0-RTT comes from the same connection.  Endpoints
+cannot selectively disregard information that might alter the sending or
+processing of 0-RTT.<a href="#section-4.6-3" class="pilcrow">¶</a></p>
+<p id="section-4.6-4"><span>[<a href="#TLS13" class="xref">TLS13</a>]</span> sets a limit of seven days on the time between the original
+connection and any attempt to use 0-RTT.  There are other constraints on 0-RTT
+usage, notably those caused by the potential exposure to replay attack; see
+<a href="#replay" class="xref">Section 9.2</a>.<a href="#section-4.6-4" class="pilcrow">¶</a></p>
+<div id="enable-0rtt">
+<section id="section-4.6.1">
+          <h4 id="name-enabling-0-rtt">
+<a href="#section-4.6.1" class="section-number selfRef">4.6.1. </a><a href="#name-enabling-0-rtt" class="section-name selfRef">Enabling 0-RTT</a>
+          </h4>
+<p id="section-4.6.1-1">The TLS early_data extension in the NewSessionTicket message is defined to
+convey (in the max_early_data_size parameter) the amount of TLS 0-RTT data the
+server is willing to accept.  QUIC does not use TLS early data.  QUIC uses 0-RTT
+packets to carry early data.  Accordingly, the max_early_data_size parameter is
+repurposed to hold a sentinel value 0xffffffff to indicate that the server is
+willing to accept QUIC 0-RTT data.  To indicate that the server does not accept
+0-RTT data, the early_data extension is omitted from the NewSessionTicket.  The
+amount of data that the client can send in QUIC 0-RTT is controlled by the
+initial_max_data transport parameter supplied by the server.<a href="#section-4.6.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.6.1-2">Servers <span class="bcp14">MUST NOT</span> send the early_data extension with a max_early_data_size field
+set to any value other than 0xffffffff.  A client <span class="bcp14">MUST</span> treat receipt of a
+NewSessionTicket that contains an early_data extension with any other value as
+a connection error of type PROTOCOL_VIOLATION.<a href="#section-4.6.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.6.1-3">A client that wishes to send 0-RTT packets uses the early_data extension in the
+ClientHello message of a subsequent handshake; see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.2.10" class="relref">Section 4.2.10</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>.
+It then sends application data in 0-RTT packets.<a href="#section-4.6.1-3" class="pilcrow">¶</a></p>
+<p id="section-4.6.1-4">A client that attempts 0-RTT might also provide an address validation token if
+the server has sent a NEW_TOKEN frame; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-4.6.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="accepting-and-rejecting-0-rtt">
+<section id="section-4.6.2">
+          <h4 id="name-accepting-and-rejecting-0-r">
+<a href="#section-4.6.2" class="section-number selfRef">4.6.2. </a><a href="#name-accepting-and-rejecting-0-r" class="section-name selfRef">Accepting and Rejecting 0-RTT</a>
+          </h4>
+<p id="section-4.6.2-1">A server accepts 0-RTT by sending an early_data extension in the
+EncryptedExtensions; see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.2.10" class="relref">Section 4.2.10</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>.  The server then
+processes and acknowledges the 0-RTT packets that it receives.<a href="#section-4.6.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.6.2-2">A server rejects 0-RTT by sending the EncryptedExtensions without an early_data
+extension.  A server will always reject 0-RTT if it sends a TLS
+HelloRetryRequest.  When rejecting 0-RTT, a server <span class="bcp14">MUST NOT</span> process any 0-RTT
+packets, even if it could.  When 0-RTT was rejected, a client <span class="bcp14">SHOULD</span> treat
+receipt of an acknowledgment for a 0-RTT packet as a connection error of type
+PROTOCOL_VIOLATION, if it is able to detect the condition.<a href="#section-4.6.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.6.2-3">When 0-RTT is rejected, all connection characteristics that the client assumed
+might be incorrect.  This includes the choice of application protocol, transport
+parameters, and any application configuration.  The client therefore <span class="bcp14">MUST</span> reset
+the state of all streams, including application state bound to those streams.<a href="#section-4.6.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.6.2-4">A client <span class="bcp14">MAY</span> reattempt 0-RTT if it receives a Retry or Version Negotiation
+packet.  These packets do not signify rejection of 0-RTT.<a href="#section-4.6.2-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="app-0rtt">
+<section id="section-4.6.3">
+          <h4 id="name-validating-0-rtt-configurat">
+<a href="#section-4.6.3" class="section-number selfRef">4.6.3. </a><a href="#name-validating-0-rtt-configurat" class="section-name selfRef">Validating 0-RTT Configuration</a>
+          </h4>
+<p id="section-4.6.3-1">When a server receives a ClientHello with the early_data extension, it has to
+decide whether to accept or reject 0-RTT data from the client. Some of this
+decision is made by the TLS stack (e.g., checking that the cipher suite being
+resumed was included in the ClientHello; see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.2.10" class="relref">Section 4.2.10</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>). Even
+when the TLS stack has no reason to reject 0-RTT data, the QUIC stack or the
+application protocol using QUIC might reject 0-RTT data because the
+configuration of the transport or application associated with the resumed
+session is not compatible with the server's current configuration.<a href="#section-4.6.3-1" class="pilcrow">¶</a></p>
+<p id="section-4.6.3-2">QUIC requires additional transport state to be associated with a 0-RTT session
+ticket. One common way to implement this is using stateless session tickets and
+storing this state in the session ticket. Application protocols that use QUIC
+might have similar requirements regarding associating or storing state. This
+associated state is used for deciding whether 0-RTT data must be rejected. For
+example, HTTP/3 settings <span>[<a href="#QUIC-HTTP" class="xref">QUIC-HTTP</a>]</span> determine how 0-RTT data from the
+client is interpreted. Other applications using QUIC could have different
+requirements for determining whether to accept or reject 0-RTT data.<a href="#section-4.6.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="helloretryrequest">
+<section id="section-4.7">
+        <h3 id="name-helloretryrequest">
+<a href="#section-4.7" class="section-number selfRef">4.7. </a><a href="#name-helloretryrequest" class="section-name selfRef">HelloRetryRequest</a>
+        </h3>
+<p id="section-4.7-1">The HelloRetryRequest message (see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.1.4" class="relref">Section 4.1.4</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>) can be used to
+request that a client provide new information, such as a key share, or to
+validate some characteristic of the client.  From the perspective of QUIC,
+HelloRetryRequest is not differentiated from other cryptographic handshake
+messages that are carried in Initial packets. Although it is in principle
+possible to use this feature for address verification, QUIC implementations
+<span class="bcp14">SHOULD</span> instead use the Retry feature; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-4.7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="tls-errors">
+<section id="section-4.8">
+        <h3 id="name-tls-errors">
+<a href="#section-4.8" class="section-number selfRef">4.8. </a><a href="#name-tls-errors" class="section-name selfRef">TLS Errors</a>
+        </h3>
+<p id="section-4.8-1">If TLS experiences an error, it generates an appropriate alert as defined in
+<span><a href="https://rfc-editor.org/rfc/rfc8446#section-6" class="relref">Section 6</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>.<a href="#section-4.8-1" class="pilcrow">¶</a></p>
+<p id="section-4.8-2">A TLS alert is converted into a QUIC connection error. The AlertDescription
+value is
+added to 0x0100 to produce a QUIC error code from the range reserved for
+CRYPTO_ERROR; see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-20.1" class="relref">Section 20.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>. The resulting value is
+sent in a QUIC CONNECTION_CLOSE frame of type 0x1c.<a href="#section-4.8-2" class="pilcrow">¶</a></p>
+<p id="section-4.8-3">QUIC is only able to convey an alert level of "fatal". In TLS 1.3, the only
+existing uses for the "warning" level are to signal connection close; see
+<span><a href="https://rfc-editor.org/rfc/rfc8446#section-6.1" class="relref">Section 6.1</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>. As QUIC provides alternative mechanisms for
+connection termination and the TLS connection is only closed if an error is
+encountered, a QUIC endpoint <span class="bcp14">MUST</span> treat any alert from TLS as if it were at the
+"fatal" level.<a href="#section-4.8-3" class="pilcrow">¶</a></p>
+<p id="section-4.8-4">QUIC permits the use of a generic code in place of a specific error code; see
+<span><a href="https://rfc-editor.org/rfc/rfc9000#section-11" class="relref">Section 11</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>. For TLS alerts, this includes replacing any
+alert with a generic alert, such as handshake_failure (0x0128 in QUIC).
+Endpoints <span class="bcp14">MAY</span> use a generic error code to avoid possibly exposing confidential
+information.<a href="#section-4.8-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="discarding-unused-keys">
+<section id="section-4.9">
+        <h3 id="name-discarding-unused-keys">
+<a href="#section-4.9" class="section-number selfRef">4.9. </a><a href="#name-discarding-unused-keys" class="section-name selfRef">Discarding Unused Keys</a>
+        </h3>
+<p id="section-4.9-1">After QUIC has completed a move to a new encryption level, packet protection
+keys for previous encryption levels can be discarded.  This occurs several times
+during the handshake, as well as when keys are updated; see <a href="#key-update" class="xref">Section 6</a>.<a href="#section-4.9-1" class="pilcrow">¶</a></p>
+<p id="section-4.9-2">Packet protection keys are not discarded immediately when new keys are
+available.  If packets from a lower encryption level contain CRYPTO frames,
+frames that retransmit that data <span class="bcp14">MUST</span> be sent at the same encryption level.
+Similarly, an endpoint generates acknowledgments for packets at the same
+encryption level as the packet being acknowledged.  Thus, it is possible that
+keys for a lower encryption level are needed for a short time after keys for a
+newer encryption level are available.<a href="#section-4.9-2" class="pilcrow">¶</a></p>
+<p id="section-4.9-3">An endpoint cannot discard keys for a given encryption level unless it has
+received all the cryptographic handshake messages from its peer at that
+encryption level and its peer has done the same.  Different methods for
+determining this are provided for Initial keys (<a href="#discard-initial" class="xref">Section 4.9.1</a>) and
+Handshake keys (<a href="#discard-handshake" class="xref">Section 4.9.2</a>).  These methods do not prevent packets
+from being received or sent at that encryption level because a peer might not
+have received all the acknowledgments necessary.<a href="#section-4.9-3" class="pilcrow">¶</a></p>
+<p id="section-4.9-4">Though an endpoint might retain older keys, new data <span class="bcp14">MUST</span> be sent at the highest
+currently available encryption level.  Only ACK frames and retransmissions of
+data in CRYPTO frames are sent at a previous encryption level.  These packets
+<span class="bcp14">MAY</span> also include PADDING frames.<a href="#section-4.9-4" class="pilcrow">¶</a></p>
+<div id="discard-initial">
+<section id="section-4.9.1">
+          <h4 id="name-discarding-initial-keys">
+<a href="#section-4.9.1" class="section-number selfRef">4.9.1. </a><a href="#name-discarding-initial-keys" class="section-name selfRef">Discarding Initial Keys</a>
+          </h4>
+<p id="section-4.9.1-1">Packets protected with Initial secrets (<a href="#initial-secrets" class="xref">Section 5.2</a>) are not
+authenticated, meaning that an attacker could spoof packets with the intent to
+disrupt a connection.  To limit these attacks, Initial packet protection keys
+are discarded more aggressively than other keys.<a href="#section-4.9.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.9.1-2">The successful use of Handshake packets indicates that no more Initial packets
+need to be exchanged, as these keys can only be produced after receiving all
+CRYPTO frames from Initial packets.  Thus, a client <span class="bcp14">MUST</span> discard Initial keys
+when it first sends a Handshake packet and a server <span class="bcp14">MUST</span> discard Initial keys
+when it first successfully processes a Handshake packet.  Endpoints <span class="bcp14">MUST NOT</span>
+send Initial packets after this point.<a href="#section-4.9.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.9.1-3">This results in abandoning loss recovery state for the Initial encryption level
+and ignoring any outstanding Initial packets.<a href="#section-4.9.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="discard-handshake">
+<section id="section-4.9.2">
+          <h4 id="name-discarding-handshake-keys">
+<a href="#section-4.9.2" class="section-number selfRef">4.9.2. </a><a href="#name-discarding-handshake-keys" class="section-name selfRef">Discarding Handshake Keys</a>
+          </h4>
+<p id="section-4.9.2-1">An endpoint <span class="bcp14">MUST</span> discard its Handshake keys when the TLS handshake is confirmed
+(<a href="#handshake-confirmed" class="xref">Section 4.1.2</a>).<a href="#section-4.9.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="discarding-0-rtt-keys">
+<section id="section-4.9.3">
+          <h4 id="name-discarding-0-rtt-keys">
+<a href="#section-4.9.3" class="section-number selfRef">4.9.3. </a><a href="#name-discarding-0-rtt-keys" class="section-name selfRef">Discarding 0-RTT Keys</a>
+          </h4>
+<p id="section-4.9.3-1">0-RTT and 1-RTT packets share the same packet number space, and clients do not
+send 0-RTT packets after sending a 1-RTT packet (<a href="#using-early-data" class="xref">Section 5.6</a>).<a href="#section-4.9.3-1" class="pilcrow">¶</a></p>
+<p id="section-4.9.3-2">Therefore, a client <span class="bcp14">SHOULD</span> discard 0-RTT keys as soon as it installs 1-RTT
+keys as they have no use after that moment.<a href="#section-4.9.3-2" class="pilcrow">¶</a></p>
+<p id="section-4.9.3-3">Additionally, a server <span class="bcp14">MAY</span> discard 0-RTT keys as soon as it receives a 1-RTT
+packet.  However, due to packet reordering, a 0-RTT packet could arrive after
+a 1-RTT packet.  Servers <span class="bcp14">MAY</span> temporarily retain 0-RTT keys to allow decrypting
+reordered packets without requiring their contents to be retransmitted with
+1-RTT keys.  After receiving a 1-RTT packet, servers <span class="bcp14">MUST</span> discard 0-RTT keys
+within a short time; the <span class="bcp14">RECOMMENDED</span> time period is three times the Probe
+Timeout (PTO, see <span>[<a href="#QUIC-RECOVERY" class="xref">QUIC-RECOVERY</a>]</span>).  A server <span class="bcp14">MAY</span> discard 0-RTT keys earlier
+if it determines that it has received all 0-RTT packets, which can be done by
+keeping track of missing packet numbers.<a href="#section-4.9.3-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="packet-protection">
+<section id="section-5">
+      <h2 id="name-packet-protection">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-packet-protection" class="section-name selfRef">Packet Protection</a>
+      </h2>
+<p id="section-5-1">As with TLS over TCP, QUIC protects packets with keys derived from the TLS
+handshake, using the AEAD algorithm <span>[<a href="#AEAD" class="xref">AEAD</a>]</span> negotiated by TLS.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">QUIC packets have varying protections depending on their type:<a href="#section-5-2" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-5-3.1">Version Negotiation packets have no cryptographic protection.<a href="#section-5-3.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-5-3.2">Retry packets use AEAD_AES_128_GCM to provide protection against accidental
+modification and to limit the entities that can produce a valid Retry;
+see <a href="#retry-integrity" class="xref">Section 5.8</a>.<a href="#section-5-3.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-5-3.3">Initial packets use AEAD_AES_128_GCM with keys derived from the Destination
+Connection ID field of the first Initial packet sent by the client; see
+<a href="#initial-secrets" class="xref">Section 5.2</a>.<a href="#section-5-3.3" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-5-3.4">All other packets have strong cryptographic protections for confidentiality
+and integrity, using keys and algorithms negotiated by TLS.<a href="#section-5-3.4" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="section-5-4">This section describes how packet protection is applied to Handshake packets,
+0-RTT packets, and 1-RTT packets. The same packet protection process is applied
+to Initial packets. However, as it is trivial to determine the keys used for
+Initial packets, these packets are not considered to have confidentiality or
+integrity protection. Retry packets use a fixed key and so similarly lack
+confidentiality and integrity protection.<a href="#section-5-4" class="pilcrow">¶</a></p>
+<div id="protection-keys">
+<section id="section-5.1">
+        <h3 id="name-packet-protection-keys">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-packet-protection-keys" class="section-name selfRef">Packet Protection Keys</a>
+        </h3>
+<p id="section-5.1-1">QUIC derives packet protection keys in the same way that TLS derives record
+protection keys.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2">Each encryption level has separate secret values for protection of packets sent
+in each direction. These traffic secrets are derived by TLS (see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-7.1" class="relref">Section 7.1</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>) and are used by QUIC for all encryption levels except the Initial
+encryption level. The secrets for the Initial encryption level are computed
+based on the client's initial Destination Connection ID, as described in
+<a href="#initial-secrets" class="xref">Section 5.2</a>.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.1-3">The keys used for packet protection are computed from the TLS secrets using the
+KDF provided by TLS.  In TLS 1.3, the HKDF-Expand-Label function described in
+<span><a href="https://rfc-editor.org/rfc/rfc8446#section-7.1" class="relref">Section 7.1</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span> is used with the hash function from the negotiated
+cipher suite.  All uses of HKDF-Expand-Label in QUIC use a zero-length Context.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.1-4">Note that labels, which are described using strings, are encoded
+as bytes using ASCII <span>[<a href="#ASCII" class="xref">ASCII</a>]</span> without quotes or any trailing NUL
+byte.<a href="#section-5.1-4" class="pilcrow">¶</a></p>
+<p id="section-5.1-5">Other versions of TLS <span class="bcp14">MUST</span> provide a similar function in order to be
+used with QUIC.<a href="#section-5.1-5" class="pilcrow">¶</a></p>
+<p id="section-5.1-6">The current encryption level secret and the label "quic key" are input to the
+KDF to produce the AEAD key; the label "quic iv" is used to derive the
+Initialization Vector (IV); see <a href="#aead" class="xref">Section 5.3</a>.  The header protection key uses the
+"quic hp" label; see <a href="#header-protect" class="xref">Section 5.4</a>.  Using these labels provides key
+separation between QUIC and TLS; see <a href="#key-diversity" class="xref">Section 9.6</a>.<a href="#section-5.1-6" class="pilcrow">¶</a></p>
+<p id="section-5.1-7">Both "quic key" and "quic hp" are used to produce keys, so the Length provided
+to HKDF-Expand-Label along with these labels is determined by the size of keys
+in the AEAD or header protection algorithm. The Length provided with "quic iv"
+is the minimum length of the AEAD nonce or 8 bytes if that is larger; see
+<span>[<a href="#AEAD" class="xref">AEAD</a>]</span>.<a href="#section-5.1-7" class="pilcrow">¶</a></p>
+<p id="section-5.1-8">The KDF used for initial secrets is always the HKDF-Expand-Label function from
+TLS 1.3; see <a href="#initial-secrets" class="xref">Section 5.2</a>.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="initial-secrets">
+<section id="section-5.2">
+        <h3 id="name-initial-secrets">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-initial-secrets" class="section-name selfRef">Initial Secrets</a>
+        </h3>
+<p id="section-5.2-1">Initial packets apply the packet protection process, but use a secret derived
+from the Destination Connection ID field from the client's first Initial
+packet.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.2-2">This secret is determined by using HKDF-Extract (see <span><a href="https://rfc-editor.org/rfc/rfc5869#section-2.2" class="relref">Section 2.2</a> of [<a href="#HKDF" class="xref">HKDF</a>]</span>)
+with a salt of 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a and the input keying
+material (IKM) of the Destination Connection ID field. This produces an
+intermediate pseudorandom key (PRK) that is used to derive two separate secrets
+for sending and receiving.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
+<p id="section-5.2-3">The secret used by clients to construct Initial packets uses the PRK and the
+label "client in" as input to the HKDF-Expand-Label function from TLS
+<span>[<a href="#TLS13" class="xref">TLS13</a>]</span> to produce a 32-byte secret.  Packets constructed by the server use
+the same process with the label "server in".  The hash function for HKDF when
+deriving initial secrets and keys is SHA-256
+<span>[<a href="#SHA" class="xref">SHA</a>]</span>.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
+<p id="section-5.2-4">This process in pseudocode is:<a href="#section-5.2-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="section-5.2-5">
+<pre>
+initial_salt = 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a
+initial_secret = HKDF-Extract(initial_salt,
+                              client_dst_connection_id)
+
+client_initial_secret = HKDF-Expand-Label(initial_secret,
+                                          "client in", "",
+                                          Hash.length)
+server_initial_secret = HKDF-Expand-Label(initial_secret,
+                                          "server in", "",
+                                          Hash.length)
+</pre><a href="#section-5.2-5" class="pilcrow">¶</a>
+</div>
+<p id="section-5.2-6">The connection ID used with HKDF-Expand-Label is the Destination Connection ID
+in the Initial packet sent by the client.  This will be a randomly selected
+value unless the client creates the Initial packet after receiving a Retry
+packet, where the Destination Connection ID is selected by the server.<a href="#section-5.2-6" class="pilcrow">¶</a></p>
+<p id="section-5.2-7">Future versions of QUIC <span class="bcp14">SHOULD</span> generate a new salt value, thus ensuring that
+the keys are different for each version of QUIC.  This prevents a middlebox that
+recognizes only one version of QUIC from seeing or modifying the contents of
+packets from future versions.<a href="#section-5.2-7" class="pilcrow">¶</a></p>
+<p id="section-5.2-8">The HKDF-Expand-Label function defined in TLS 1.3 <span class="bcp14">MUST</span> be used for Initial
+packets even where the TLS versions offered do not include TLS 1.3.<a href="#section-5.2-8" class="pilcrow">¶</a></p>
+<p id="section-5.2-9">The secrets used for constructing subsequent Initial packets change when a
+server sends a Retry packet to use the connection ID value selected by the
+server.  The secrets do not change when a client changes the Destination
+Connection ID it uses in response to an Initial packet from the server.<a href="#section-5.2-9" class="pilcrow">¶</a></p>
+<aside id="section-5.2-10">
+          <p id="section-5.2-10.1">Note: The Destination Connection ID field could be any length up to 20 bytes,
+  including zero length if the server sends a Retry packet with a zero-length
+  Source Connection ID field. After a Retry, the Initial keys provide the client
+  no assurance that the server received its packet, so the client has to rely on
+  the exchange that included the Retry packet to validate the server address;
+  see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-5.2-10.1" class="pilcrow">¶</a></p>
+</aside>
+<p id="section-5.2-11"><a href="#test-vectors" class="xref">Appendix A</a> contains sample Initial packets.<a href="#section-5.2-11" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="aead">
+<section id="section-5.3">
+        <h3 id="name-aead-usage">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-aead-usage" class="section-name selfRef">AEAD Usage</a>
+        </h3>
+<p id="section-5.3-1">The Authenticated Encryption with Associated Data (AEAD) function (see
+<span>[<a href="#AEAD" class="xref">AEAD</a>]</span>) used for QUIC packet protection is the AEAD that is negotiated for
+use with the TLS connection.  For example, if TLS is using the
+TLS_AES_128_GCM_SHA256 cipher suite, the AEAD_AES_128_GCM function is used.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.3-2">QUIC can use any of the cipher suites defined in <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> with the exception
+of TLS_AES_128_CCM_8_SHA256.  A cipher suite <span class="bcp14">MUST NOT</span> be negotiated unless a
+header protection scheme is defined for the cipher suite.  This document defines
+a header protection scheme for all cipher suites defined in <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> aside
+from TLS_AES_128_CCM_8_SHA256.  These cipher suites have a 16-byte
+authentication tag and produce an output 16 bytes larger than their input.<a href="#section-5.3-2" class="pilcrow">¶</a></p>
+<p id="section-5.3-3">An endpoint <span class="bcp14">MUST NOT</span> reject a ClientHello that offers a cipher suite that it
+does not support, or it would be impossible to deploy a new cipher suite.  This
+also applies to TLS_AES_128_CCM_8_SHA256.<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+<p id="section-5.3-4">When constructing packets, the AEAD function is applied prior to applying
+header protection; see <a href="#header-protect" class="xref">Section 5.4</a>. The unprotected packet header is part
+of the associated data (A). When processing packets, an endpoint first
+removes the header protection.<a href="#section-5.3-4" class="pilcrow">¶</a></p>
+<p id="section-5.3-5">The key and IV for the packet are computed as described in <a href="#protection-keys" class="xref">Section 5.1</a>.
+The nonce, N, is formed by combining the packet protection IV with the packet
+number.  The 62 bits of the reconstructed QUIC packet number in network byte
+order are left-padded with zeros to the size of the IV.  The exclusive OR of the
+padded packet number and the IV forms the AEAD nonce.<a href="#section-5.3-5" class="pilcrow">¶</a></p>
+<p id="section-5.3-6">The associated data, A, for the AEAD is the contents of the QUIC header,
+starting from the first byte of either the short or long header, up to and
+including the unprotected packet number.<a href="#section-5.3-6" class="pilcrow">¶</a></p>
+<p id="section-5.3-7">The input plaintext, P, for the AEAD is the payload of the QUIC packet, as
+described in <span>[<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-5.3-7" class="pilcrow">¶</a></p>
+<p id="section-5.3-8">The output ciphertext, C, of the AEAD is transmitted in place of P.<a href="#section-5.3-8" class="pilcrow">¶</a></p>
+<p id="section-5.3-9">Some AEAD functions have limits for how many packets can be encrypted under the
+same key and IV; see <a href="#aead-limits" class="xref">Section 6.6</a>.  This might be lower than the packet
+number limit.  An endpoint <span class="bcp14">MUST</span> initiate a key update (<a href="#key-update" class="xref">Section 6</a>) prior to
+exceeding any limit set for the AEAD that is in use.<a href="#section-5.3-9" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="header-protect">
+<section id="section-5.4">
+        <h3 id="name-header-protection">
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-header-protection" class="section-name selfRef">Header Protection</a>
+        </h3>
+<p id="section-5.4-1">Parts of QUIC packet headers, in particular the Packet Number field, are
+protected using a key that is derived separately from the packet protection key
+and IV.  The key derived using the "quic hp" label is used to provide
+confidentiality protection for those fields that are not exposed to on-path
+elements.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
+<p id="section-5.4-2">This protection applies to the least significant bits of the first byte, plus
+the Packet Number field.  The four least significant bits of the first byte are
+protected for packets with long headers; the five least significant bits of the
+first byte are protected for packets with short headers.  For both header forms,
+this covers the reserved bits and the Packet Number Length field; the Key Phase
+bit is also protected for packets with a short header.<a href="#section-5.4-2" class="pilcrow">¶</a></p>
+<p id="section-5.4-3">The same header protection key is used for the duration of the connection, with
+the value not changing after a key update (see <a href="#key-update" class="xref">Section 6</a>).  This allows
+header protection to be used to protect the key phase.<a href="#section-5.4-3" class="pilcrow">¶</a></p>
+<p id="section-5.4-4">This process does not apply to Retry or Version Negotiation packets, which do
+not contain a protected payload or any of the fields that are protected by this
+process.<a href="#section-5.4-4" class="pilcrow">¶</a></p>
+<div id="header-protection-application">
+<section id="section-5.4.1">
+          <h4 id="name-header-protection-applicati">
+<a href="#section-5.4.1" class="section-number selfRef">5.4.1. </a><a href="#name-header-protection-applicati" class="section-name selfRef">Header Protection Application</a>
+          </h4>
+<p id="section-5.4.1-1">Header protection is applied after packet protection is applied (see <a href="#aead" class="xref">Section 5.3</a>).
+The ciphertext of the packet is sampled and used as input to an encryption
+algorithm.  The algorithm used depends on the negotiated AEAD.<a href="#section-5.4.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.4.1-2">The output of this algorithm is a 5-byte mask that is applied to the protected
+header fields using exclusive OR.  The least significant bits of the first byte
+of the packet are masked by the least significant bits of the first mask byte,
+and the packet number is masked with the remaining bytes.  Any unused bytes of
+mask that might result from a shorter packet number encoding are unused.<a href="#section-5.4.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.4.1-3"><a href="#pseudo-hp" class="xref">Figure 6</a> shows a sample algorithm for applying header protection. Removing
+header protection only differs in the order in which the packet number length
+(pn_length) is determined (here "^" is used to represent exclusive OR).<a href="#section-5.4.1-3" class="pilcrow">¶</a></p>
+<span id="name-header-protection-pseudocod"></span><div id="pseudo-hp">
+<figure id="figure-6">
+            <div id="section-5.4.1-4.1">
+<pre class="sourcecode lang-pseudocode">
+mask = header_protection(hp_key, sample)
+
+pn_length = (packet[0] &amp; 0x03) + 1
+if (packet[0] &amp; 0x80) == 0x80:
+   # Long header: 4 bits masked
+   packet[0] ^= mask[0] &amp; 0x0f
+else:
+   # Short header: 5 bits masked
+   packet[0] ^= mask[0] &amp; 0x1f
+
+# pn_offset is the start of the Packet Number field.
+packet[pn_offset:pn_offset+pn_length] ^= mask[1:1+pn_length]
+</pre>
+</div>
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<a href="#name-header-protection-pseudocod" class="selfRef">Header Protection Pseudocode</a>
+            </figcaption></figure>
+</div>
+<p id="section-5.4.1-5">Specific header protection functions are defined based on the selected cipher
+suite; see <a href="#hp-aes" class="xref">Section 5.4.3</a> and <a href="#hp-chacha" class="xref">Section 5.4.4</a>.<a href="#section-5.4.1-5" class="pilcrow">¶</a></p>
+<p id="section-5.4.1-6"><a href="#fig-sample" class="xref">Figure 7</a> shows an example long header packet (Initial) and a short header
+packet (1-RTT). <a href="#fig-sample" class="xref">Figure 7</a> shows the fields in each header that are covered
+by header protection and the portion of the protected packet payload that is
+sampled.<a href="#section-5.4.1-6" class="pilcrow">¶</a></p>
+<span id="name-header-protection-and-ciphe"></span><div id="fig-sample">
+<figure id="figure-7">
+            <div class="artwork art-text alignLeft" id="section-5.4.1-7.1">
+<pre>
+Initial Packet {
+  Header Form (1) = 1,
+  Fixed Bit (1) = 1,
+  Long Packet Type (2) = 0,
+  Reserved Bits (2),         # Protected
+  Packet Number Length (2),  # Protected
+  Version (32),
+  DCID Len (8),
+  Destination Connection ID (0..160),
+  SCID Len (8),
+  Source Connection ID (0..160),
+  Token Length (i),
+  Token (..),
+  Length (i),
+  Packet Number (8..32),     # Protected
+  Protected Payload (0..24), # Skipped Part
+  Protected Payload (128),   # Sampled Part
+  Protected Payload (..)     # Remainder
+}
+
+1-RTT Packet {
+  Header Form (1) = 0,
+  Fixed Bit (1) = 1,
+  Spin Bit (1),
+  Reserved Bits (2),         # Protected
+  Key Phase (1),             # Protected
+  Packet Number Length (2),  # Protected
+  Destination Connection ID (0..160),
+  Packet Number (8..32),     # Protected
+  Protected Payload (0..24), # Skipped Part
+  Protected Payload (128),   # Sampled Part
+  Protected Payload (..),    # Remainder
+}
+</pre>
+</div>
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<a href="#name-header-protection-and-ciphe" class="selfRef">Header Protection and Ciphertext Sample</a>
+            </figcaption></figure>
+</div>
+<p id="section-5.4.1-8">Before a TLS cipher suite can be used with QUIC, a header protection algorithm
+<span class="bcp14">MUST</span> be specified for the AEAD used with that cipher suite.  This document
+defines algorithms for AEAD_AES_128_GCM, AEAD_AES_128_CCM, AEAD_AES_256_GCM (all
+these AES AEADs are defined in <span>[<a href="#AEAD" class="xref">AEAD</a>]</span>), and AEAD_CHACHA20_POLY1305
+(defined in <span>[<a href="#CHACHA" class="xref">CHACHA</a>]</span>).  Prior to TLS selecting a cipher suite, AES
+header protection is used (<a href="#hp-aes" class="xref">Section 5.4.3</a>), matching the AEAD_AES_128_GCM packet
+protection.<a href="#section-5.4.1-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="hp-sample">
+<section id="section-5.4.2">
+          <h4 id="name-header-protection-sample">
+<a href="#section-5.4.2" class="section-number selfRef">5.4.2. </a><a href="#name-header-protection-sample" class="section-name selfRef">Header Protection Sample</a>
+          </h4>
+<p id="section-5.4.2-1">The header protection algorithm uses both the header protection key and a sample
+of the ciphertext from the packet Payload field.<a href="#section-5.4.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.4.2-2">The same number of bytes are always sampled, but an allowance needs to be made
+for the removal of protection by a receiving endpoint, which will not know the
+length of the Packet Number field.  The sample of ciphertext is taken starting
+from an offset of 4 bytes after the start of the Packet Number field.  That is,
+in sampling packet ciphertext for header protection, the Packet Number field is
+assumed to be 4 bytes long (its maximum possible encoded length).<a href="#section-5.4.2-2" class="pilcrow">¶</a></p>
+<p id="section-5.4.2-3">An endpoint <span class="bcp14">MUST</span> discard packets that are not long enough to contain a complete
+sample.<a href="#section-5.4.2-3" class="pilcrow">¶</a></p>
+<p id="section-5.4.2-4">To ensure that sufficient data is available for sampling, packets are padded so
+that the combined lengths of the encoded packet number and protected payload is
+at least 4 bytes longer than the sample required for header protection.  The
+cipher suites defined in <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> -- other than TLS_AES_128_CCM_8_SHA256, for
+which a header protection scheme is not defined in this document -- have 16-byte
+expansions and 16-byte header protection samples.  This results in needing at
+least 3 bytes of frames in the unprotected payload if the packet number is
+encoded on a single byte, or 2 bytes of frames for a 2-byte packet number
+encoding.<a href="#section-5.4.2-4" class="pilcrow">¶</a></p>
+<p id="section-5.4.2-5">The sampled ciphertext can be determined by the following pseudocode:<a href="#section-5.4.2-5" class="pilcrow">¶</a></p>
+<div id="section-5.4.2-6">
+<pre class="sourcecode lang-pseudocode">
+# pn_offset is the start of the Packet Number field.
+sample_offset = pn_offset + 4
+
+sample = packet[sample_offset..sample_offset+sample_length]
+</pre><a href="#section-5.4.2-6" class="pilcrow">¶</a>
+</div>
+<p id="section-5.4.2-7">Where the packet number offset of a short header packet can be calculated as:<a href="#section-5.4.2-7" class="pilcrow">¶</a></p>
+<div id="section-5.4.2-8">
+<pre class="sourcecode lang-pseudocode">
+pn_offset = 1 + len(connection_id)
+</pre><a href="#section-5.4.2-8" class="pilcrow">¶</a>
+</div>
+<p id="section-5.4.2-9">And the packet number offset of a long header packet can be calculated as:<a href="#section-5.4.2-9" class="pilcrow">¶</a></p>
+<div id="section-5.4.2-10">
+<pre class="sourcecode lang-pseudocode">
+pn_offset = 7 + len(destination_connection_id) +
+                len(source_connection_id) +
+                len(payload_length)
+if packet_type == Initial:
+    pn_offset += len(token_length) +
+                 len(token)
+</pre><a href="#section-5.4.2-10" class="pilcrow">¶</a>
+</div>
+<p id="section-5.4.2-11">For example, for a packet with a short header, an 8-byte connection ID, and
+protected with AEAD_AES_128_GCM, the sample takes bytes 13 to 28 inclusive
+(using zero-based indexing).<a href="#section-5.4.2-11" class="pilcrow">¶</a></p>
+<p id="section-5.4.2-12">Multiple QUIC packets might be included in the same UDP datagram. Each packet
+is handled separately.<a href="#section-5.4.2-12" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="hp-aes">
+<section id="section-5.4.3">
+          <h4 id="name-aes-based-header-protection">
+<a href="#section-5.4.3" class="section-number selfRef">5.4.3. </a><a href="#name-aes-based-header-protection" class="section-name selfRef">AES-Based Header Protection</a>
+          </h4>
+<p id="section-5.4.3-1">This section defines the packet protection algorithm for AEAD_AES_128_GCM,
+AEAD_AES_128_CCM, and AEAD_AES_256_GCM. AEAD_AES_128_GCM and AEAD_AES_128_CCM
+use 128-bit AES in Electronic Codebook (ECB) mode. AEAD_AES_256_GCM uses
+256-bit AES in ECB mode.  AES is defined in <span>[<a href="#AES" class="xref">AES</a>]</span>.<a href="#section-5.4.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.4.3-2">This algorithm samples 16 bytes from the packet ciphertext. This value is used
+as the input to AES-ECB.  In pseudocode, the header protection function is
+defined as:<a href="#section-5.4.3-2" class="pilcrow">¶</a></p>
+<div id="section-5.4.3-3">
+<pre class="sourcecode lang-pseudocode">
+header_protection(hp_key, sample):
+  mask = AES-ECB(hp_key, sample)
+</pre><a href="#section-5.4.3-3" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="hp-chacha">
+<section id="section-5.4.4">
+          <h4 id="name-chacha20-based-header-prote">
+<a href="#section-5.4.4" class="section-number selfRef">5.4.4. </a><a href="#name-chacha20-based-header-prote" class="section-name selfRef">ChaCha20-Based Header Protection</a>
+          </h4>
+<p id="section-5.4.4-1">When AEAD_CHACHA20_POLY1305 is in use, header protection uses the raw ChaCha20
+function as defined in <span><a href="https://rfc-editor.org/rfc/rfc8439#section-2.4" class="relref">Section 2.4</a> of [<a href="#CHACHA" class="xref">CHACHA</a>]</span>.  This uses a 256-bit key and
+16 bytes sampled from the packet protection output.<a href="#section-5.4.4-1" class="pilcrow">¶</a></p>
+<p id="section-5.4.4-2">The first 4 bytes of the sampled ciphertext are the block counter.  A ChaCha20
+implementation could take a 32-bit integer in place of a byte sequence, in
+which case, the byte sequence is interpreted as a little-endian value.<a href="#section-5.4.4-2" class="pilcrow">¶</a></p>
+<p id="section-5.4.4-3">The remaining 12 bytes are used as the nonce. A ChaCha20 implementation might
+take an array of three 32-bit integers in place of a byte sequence, in which
+case, the nonce bytes are interpreted as a sequence of 32-bit little-endian
+integers.<a href="#section-5.4.4-3" class="pilcrow">¶</a></p>
+<p id="section-5.4.4-4">The encryption mask is produced by invoking ChaCha20 to protect 5 zero bytes. In
+pseudocode, the header protection function is defined as:<a href="#section-5.4.4-4" class="pilcrow">¶</a></p>
+<div id="section-5.4.4-5">
+<pre class="sourcecode lang-pseudocode">
+header_protection(hp_key, sample):
+  counter = sample[0..3]
+  nonce = sample[4..15]
+  mask = ChaCha20(hp_key, counter, nonce, {0,0,0,0,0})
+</pre><a href="#section-5.4.4-5" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="receiving-protected-packets">
+<section id="section-5.5">
+        <h3 id="name-receiving-protected-packets">
+<a href="#section-5.5" class="section-number selfRef">5.5. </a><a href="#name-receiving-protected-packets" class="section-name selfRef">Receiving Protected Packets</a>
+        </h3>
+<p id="section-5.5-1">Once an endpoint successfully receives a packet with a given packet number, it
+<span class="bcp14">MUST</span> discard all packets in the same packet number space with higher packet
+numbers if they cannot be successfully unprotected with either the same key, or
+-- if there is a key update -- a subsequent packet protection key; see
+<a href="#key-update" class="xref">Section 6</a>.  Similarly, a packet that appears to trigger a key update but
+cannot be unprotected successfully <span class="bcp14">MUST</span> be discarded.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
+<p id="section-5.5-2">Failure to unprotect a packet does not necessarily indicate the existence of a
+protocol error in a peer or an attack.  The truncated packet number encoding
+used in QUIC can cause packet numbers to be decoded incorrectly if they are
+delayed significantly.<a href="#section-5.5-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="using-early-data">
+<section id="section-5.6">
+        <h3 id="name-use-of-0-rtt-keys">
+<a href="#section-5.6" class="section-number selfRef">5.6. </a><a href="#name-use-of-0-rtt-keys" class="section-name selfRef">Use of 0-RTT Keys</a>
+        </h3>
+<p id="section-5.6-1">If 0-RTT keys are available (see <a href="#enable-0rtt" class="xref">Section 4.6.1</a>), the lack of replay protection
+means that restrictions on their use are necessary to avoid replay attacks on
+the protocol.<a href="#section-5.6-1" class="pilcrow">¶</a></p>
+<p id="section-5.6-2">Of the frames defined in <span>[<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>, the STREAM, RESET_STREAM,
+STOP_SENDING, and CONNECTION_CLOSE frames are potentially unsafe for use with
+0-RTT as they carry application data. Application data that is received in
+0-RTT could cause an application at the server to process the data multiple
+times rather than just once. Additional actions taken by a server as a result
+of processing replayed application data could have unwanted consequences. A
+client therefore <span class="bcp14">MUST NOT</span> use 0-RTT for application data unless specifically
+requested by the application that is in use.<a href="#section-5.6-2" class="pilcrow">¶</a></p>
+<p id="section-5.6-3">An application protocol that uses QUIC <span class="bcp14">MUST</span> include a profile that defines
+acceptable use of 0-RTT; otherwise, 0-RTT can only be used to carry QUIC frames
+that do not carry application data. For example, a profile for HTTP is
+described in <span>[<a href="#HTTP-REPLAY" class="xref">HTTP-REPLAY</a>]</span> and used for HTTP/3; see
+<span><a href="https://datatracker.ietf.org/doc/html/draft-ietf-quic-http-34#section-10.9" class="relref">Section 10.9</a> of [<a href="#QUIC-HTTP" class="xref">QUIC-HTTP</a>]</span>.<a href="#section-5.6-3" class="pilcrow">¶</a></p>
+<p id="section-5.6-4">Though replaying packets might result in additional connection attempts, the
+effect of processing replayed frames that do not carry application data is
+limited to changing the state of the affected connection. A TLS handshake
+cannot be successfully completed using replayed packets.<a href="#section-5.6-4" class="pilcrow">¶</a></p>
+<p id="section-5.6-5">A client <span class="bcp14">MAY</span> wish to apply additional restrictions on what data it sends prior
+to the completion of the TLS handshake.<a href="#section-5.6-5" class="pilcrow">¶</a></p>
+<p id="section-5.6-6">A client otherwise treats 0-RTT keys as equivalent to 1-RTT keys, except that
+it cannot send certain frames with 0-RTT keys; see
+<span><a href="https://rfc-editor.org/rfc/rfc9000#section-12.5" class="relref">Section 12.5</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-5.6-6" class="pilcrow">¶</a></p>
+<p id="section-5.6-7">A client that receives an indication that its 0-RTT data has been accepted by a
+server can send 0-RTT data until it receives all of the server's handshake
+messages.  A client <span class="bcp14">SHOULD</span> stop sending 0-RTT data if it receives an indication
+that 0-RTT data has been rejected.<a href="#section-5.6-7" class="pilcrow">¶</a></p>
+<p id="section-5.6-8">A server <span class="bcp14">MUST NOT</span> use 0-RTT keys to protect packets; it uses 1-RTT keys to
+protect acknowledgments of 0-RTT packets.  A client <span class="bcp14">MUST NOT</span> attempt to
+decrypt 0-RTT packets it receives and instead <span class="bcp14">MUST</span> discard them.<a href="#section-5.6-8" class="pilcrow">¶</a></p>
+<p id="section-5.6-9">Once a client has installed 1-RTT keys, it <span class="bcp14">MUST NOT</span> send any more 0-RTT
+packets.<a href="#section-5.6-9" class="pilcrow">¶</a></p>
+<aside id="section-5.6-10">
+          <p id="section-5.6-10.1">Note: 0-RTT data can be acknowledged by the server as it receives it, but any
+  packets containing acknowledgments of 0-RTT data cannot have packet protection
+  removed by the client until the TLS handshake is complete.  The 1-RTT keys
+  necessary to remove packet protection cannot be derived until the client
+  receives all server handshake messages.<a href="#section-5.6-10.1" class="pilcrow">¶</a></p>
+</aside>
+</section>
+</div>
+<div id="pre-hs-protected">
+<section id="section-5.7">
+        <h3 id="name-receiving-out-of-order-prot">
+<a href="#section-5.7" class="section-number selfRef">5.7. </a><a href="#name-receiving-out-of-order-prot" class="section-name selfRef">Receiving Out-of-Order Protected Packets</a>
+        </h3>
+<p id="section-5.7-1">Due to reordering and loss, protected packets might be received by an endpoint
+before the final TLS handshake messages are received.  A client will be unable
+to decrypt 1-RTT packets from the server, whereas a server will be able to
+decrypt 1-RTT packets from the client.  Endpoints in either role <span class="bcp14">MUST NOT</span>
+decrypt 1-RTT packets from their peer prior to completing the handshake.<a href="#section-5.7-1" class="pilcrow">¶</a></p>
+<p id="section-5.7-2">Even though 1-RTT keys are available to a server after receiving the first
+handshake messages from a client, it is missing assurances on the client state:<a href="#section-5.7-2" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-5.7-3.1">The client is not authenticated, unless the server has chosen to use a
+pre-shared key and validated the client's pre-shared key binder; see <span><a href="https://rfc-editor.org/rfc/rfc8446#section-4.2.11" class="relref">Section 4.2.11</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>.<a href="#section-5.7-3.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-5.7-3.2">The client has not demonstrated liveness, unless the server has validated the
+client's address with a Retry packet or other means; see
+<span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>.<a href="#section-5.7-3.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-5.7-3.3">Any received 0-RTT data that the server responds to might be due to a replay
+attack.<a href="#section-5.7-3.3" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-5.7-4">Therefore, the server's use of 1-RTT keys before the handshake is complete is
+limited to sending data.  A server <span class="bcp14">MUST NOT</span> process incoming 1-RTT protected
+packets before the TLS handshake is complete.  Because sending acknowledgments
+indicates that all frames in a packet have been processed, a server cannot send
+acknowledgments for 1-RTT packets until the TLS handshake is complete.  Received
+packets protected with 1-RTT keys <span class="bcp14">MAY</span> be stored and later decrypted and used
+once the handshake is complete.<a href="#section-5.7-4" class="pilcrow">¶</a></p>
+<aside id="section-5.7-5">
+          <p id="section-5.7-5.1">Note: TLS implementations might provide all 1-RTT secrets prior to handshake
+  completion.  Even where QUIC implementations have 1-RTT read keys, those keys
+  are not to be used prior to completing the handshake.<a href="#section-5.7-5.1" class="pilcrow">¶</a></p>
+</aside>
+<p id="section-5.7-6">The requirement for the server to wait for the client Finished message creates
+a dependency on that message being delivered.  A client can avoid the
+potential for head-of-line blocking that this implies by sending its 1-RTT
+packets coalesced with a Handshake packet containing a copy of the CRYPTO frame
+that carries the Finished message, until one of the Handshake packets is
+acknowledged.  This enables immediate server processing for those packets.<a href="#section-5.7-6" class="pilcrow">¶</a></p>
+<p id="section-5.7-7">A server could receive packets protected with 0-RTT keys prior to receiving a
+TLS ClientHello.  The server <span class="bcp14">MAY</span> retain these packets for later decryption in
+anticipation of receiving a ClientHello.<a href="#section-5.7-7" class="pilcrow">¶</a></p>
+<p id="section-5.7-8">A client generally receives 1-RTT keys at the same time as the handshake
+completes.  Even if it has 1-RTT secrets, a client <span class="bcp14">MUST NOT</span> process
+incoming 1-RTT protected packets before the TLS handshake is complete.<a href="#section-5.7-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="retry-integrity">
+<section id="section-5.8">
+        <h3 id="name-retry-packet-integrity">
+<a href="#section-5.8" class="section-number selfRef">5.8. </a><a href="#name-retry-packet-integrity" class="section-name selfRef">Retry Packet Integrity</a>
+        </h3>
+<p id="section-5.8-1">Retry packets (see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-17.2.5" class="relref">Section 17.2.5</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>) carry a Retry Integrity
+Tag that provides two properties: it allows the discarding of packets that have
+accidentally been corrupted by the network, and only an entity that observes an
+Initial packet can send a valid Retry packet.<a href="#section-5.8-1" class="pilcrow">¶</a></p>
+<p id="section-5.8-2">The Retry Integrity Tag is a 128-bit field that is computed as the output of
+AEAD_AES_128_GCM <span>[<a href="#AEAD" class="xref">AEAD</a>]</span> used with the following inputs:<a href="#section-5.8-2" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-5.8-3.1">The secret key, K, is 128 bits equal to 0xbe0c690b9f66575a1d766b54e368c84e.<a href="#section-5.8-3.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-5.8-3.2">The nonce, N, is 96 bits equal to 0x461599d35d632bf2239825bb.<a href="#section-5.8-3.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-5.8-3.3">The plaintext, P, is empty.<a href="#section-5.8-3.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-5.8-3.4">The associated data, A, is the contents of the Retry Pseudo-Packet, as
+illustrated in <a href="#retry-pseudo" class="xref">Figure 8</a>:<a href="#section-5.8-3.4" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-5.8-4">The secret key and the nonce are values derived by calling HKDF-Expand-Label
+using 0xd9c9943e6101fd200021506bcc02814c73030f25c79d71ce876eca876e6fca8e as the
+secret, with labels being "quic key" and "quic iv" (<a href="#protection-keys" class="xref">Section 5.1</a>).<a href="#section-5.8-4" class="pilcrow">¶</a></p>
+<span id="name-retry-pseudo-packet"></span><div id="retry-pseudo">
+<figure id="figure-8">
+          <div class="artwork art-text alignLeft" id="section-5.8-5.1">
+<pre>
+Retry Pseudo-Packet {
+  ODCID Length (8),
+  Original Destination Connection ID (0..160),
+  Header Form (1) = 1,
+  Fixed Bit (1) = 1,
+  Long Packet Type (2) = 3,
+  Unused (4),
+  Version (32),
+  DCID Len (8),
+  Destination Connection ID (0..160),
+  SCID Len (8),
+  Source Connection ID (0..160),
+  Retry Token (..),
+}
+</pre>
+</div>
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<a href="#name-retry-pseudo-packet" class="selfRef">Retry Pseudo-Packet</a>
+          </figcaption></figure>
+</div>
+<p id="section-5.8-6">The Retry Pseudo-Packet is not sent over the wire. It is computed by taking
+the transmitted Retry packet, removing the Retry Integrity Tag, and prepending
+the two following fields:<a href="#section-5.8-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-5.8-7">
+          <dt id="section-5.8-7.1">ODCID Length:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.8-7.2">
+            <p id="section-5.8-7.2.1">The ODCID Length field contains the length in bytes of the Original
+Destination Connection ID field that follows it, encoded as an 8-bit unsigned
+integer.<a href="#section-5.8-7.2.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.8-7.3">Original Destination Connection ID:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.8-7.4">
+            <p id="section-5.8-7.4.1">The Original Destination Connection ID contains the value of the Destination
+Connection ID from the Initial packet that this Retry is in response to. The
+length of this field is given in ODCID Length. The presence of this field
+ensures that a valid Retry packet can only be sent by an entity that
+observes the Initial packet.<a href="#section-5.8-7.4.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+</div>
+<div id="key-update">
+<section id="section-6">
+      <h2 id="name-key-update">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-key-update" class="section-name selfRef">Key Update</a>
+      </h2>
+<p id="section-6-1">Once the handshake is confirmed (see <a href="#handshake-confirmed" class="xref">Section 4.1.2</a>), an endpoint <span class="bcp14">MAY</span>
+initiate a key update.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-6-2">The Key Phase bit indicates which packet protection keys are used to protect the
+packet.  The Key Phase bit is initially set to 0 for the first set of 1-RTT
+packets and toggled to signal each subsequent key update.<a href="#section-6-2" class="pilcrow">¶</a></p>
+<p id="section-6-3">The Key Phase bit allows a recipient to detect a change in keying material
+without needing to receive the first packet that triggered the change.  An
+endpoint that notices a changed Key Phase bit updates keys and decrypts the
+packet that contains the changed value.<a href="#section-6-3" class="pilcrow">¶</a></p>
+<p id="section-6-4">Initiating a key update results in both endpoints updating keys.  This differs
+from TLS where endpoints can update keys independently.<a href="#section-6-4" class="pilcrow">¶</a></p>
+<p id="section-6-5">This mechanism replaces the key update mechanism of TLS, which relies on
+KeyUpdate messages sent using 1-RTT encryption keys.  Endpoints <span class="bcp14">MUST NOT</span> send a
+TLS KeyUpdate message.  Endpoints <span class="bcp14">MUST</span> treat the receipt of a TLS KeyUpdate
+message as a connection error of type 0x010a, equivalent to a
+fatal TLS alert of unexpected_message; see <a href="#tls-errors" class="xref">Section 4.8</a>.<a href="#section-6-5" class="pilcrow">¶</a></p>
+<p id="section-6-6"><a href="#ex-key-update" class="xref">Figure 9</a> shows a key update process, where the initial set of keys used
+(identified with @M) are replaced by updated keys (identified with @N).  The
+value of the Key Phase bit is indicated in brackets [].<a href="#section-6-6" class="pilcrow">¶</a></p>
+<span id="name-key-update-2"></span><div id="ex-key-update">
+<figure id="figure-9">
+        <div class="artwork art-text alignLeft" id="section-6-7.1">
+<pre>
+   Initiating Peer                    Responding Peer
+
+@M [0] QUIC Packets
+
+... Update to @N
+@N [1] QUIC Packets
+                      --------&gt;
+                                         Update to @N ...
+                                      QUIC Packets [1] @N
+                      &lt;--------
+                                      QUIC Packets [1] @N
+                                    containing ACK
+                      &lt;--------
+... Key Update Permitted
+
+@N [1] QUIC Packets
+         containing ACK for @N packets
+                      --------&gt;
+                                 Key Update Permitted ...
+</pre>
+</div>
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<a href="#name-key-update-2" class="selfRef">Key Update</a>
+        </figcaption></figure>
+</div>
+<div id="key-update-initiate">
+<section id="section-6.1">
+        <h3 id="name-initiating-a-key-update">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-initiating-a-key-update" class="section-name selfRef">Initiating a Key Update</a>
+        </h3>
+<p id="section-6.1-1">Endpoints maintain separate read and write secrets for packet protection.  An
+endpoint initiates a key update by updating its packet protection write secret
+and using that to protect new packets.  The endpoint creates a new write secret
+from the existing write secret as performed in <span><a href="https://rfc-editor.org/rfc/rfc8446#section-7.2" class="relref">Section 7.2</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>.  This
+uses the KDF function provided by TLS with a label of "quic ku".  The
+corresponding key and IV are created from that secret as defined in
+<a href="#protection-keys" class="xref">Section 5.1</a>.  The header protection key is not updated.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2">For example, to update write keys with TLS 1.3, HKDF-Expand-Label is used as:<a href="#section-6.1-2" class="pilcrow">¶</a></p>
+<div id="section-6.1-3">
+<pre class="sourcecode lang-pseudocode">
+secret_&lt;n+1&gt; = HKDF-Expand-Label(secret_&lt;n&gt;, "quic ku",
+                                 "", Hash.length)
+</pre><a href="#section-6.1-3" class="pilcrow">¶</a>
+</div>
+<p id="section-6.1-4">The endpoint toggles the value of the Key Phase bit and uses the updated key and
+IV to protect all subsequent packets.<a href="#section-6.1-4" class="pilcrow">¶</a></p>
+<p id="section-6.1-5">An endpoint <span class="bcp14">MUST NOT</span> initiate a key update prior to having confirmed the
+handshake (<a href="#handshake-confirmed" class="xref">Section 4.1.2</a>).  An endpoint <span class="bcp14">MUST NOT</span> initiate a subsequent
+key update unless it has received an acknowledgment for a packet that was sent
+protected with keys from the current key phase.  This ensures that keys are
+available to both peers before another key update can be initiated.  This can be
+implemented by tracking the lowest packet number sent with each key phase and
+the highest acknowledged packet number in the 1-RTT space: once the latter is
+higher than or equal to the former, another key update can be initiated.<a href="#section-6.1-5" class="pilcrow">¶</a></p>
+<aside id="section-6.1-6">
+          <p id="section-6.1-6.1">Note: Keys of packets other than the 1-RTT packets are never updated; their keys
+  are derived solely from the TLS handshake state.<a href="#section-6.1-6.1" class="pilcrow">¶</a></p>
+</aside>
+<p id="section-6.1-7">The endpoint that initiates a key update also updates the keys that it uses for
+receiving packets.  These keys will be needed to process packets the peer sends
+after updating.<a href="#section-6.1-7" class="pilcrow">¶</a></p>
+<p id="section-6.1-8">An endpoint <span class="bcp14">MUST</span> retain old keys until it has successfully unprotected a packet
+sent using the new keys.  An endpoint <span class="bcp14">SHOULD</span> retain old keys for some time
+after unprotecting a packet sent using the new keys.  Discarding old keys too
+early can cause delayed packets to be discarded.  Discarding packets will be
+interpreted as packet loss by the peer and could adversely affect performance.<a href="#section-6.1-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="responding-to-a-key-update">
+<section id="section-6.2">
+        <h3 id="name-responding-to-a-key-update">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-responding-to-a-key-update" class="section-name selfRef">Responding to a Key Update</a>
+        </h3>
+<p id="section-6.2-1">A peer is permitted to initiate a key update after receiving an acknowledgment
+of a packet in the current key phase.  An endpoint detects a key update when
+processing a packet with a key phase that differs from the value used to protect
+the last packet it sent.  To process this packet, the endpoint uses the next
+packet protection key and IV.  See <a href="#receive-key-generation" class="xref">Section 6.3</a> for considerations
+about generating these keys.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">If a packet is successfully processed using the next key and IV, then the peer
+has initiated a key update.  The endpoint <span class="bcp14">MUST</span> update its send keys to the
+corresponding key phase in response, as described in <a href="#key-update-initiate" class="xref">Section 6.1</a>.
+Sending keys <span class="bcp14">MUST</span> be updated before sending an acknowledgment for the packet
+that was received with updated keys.  By acknowledging the packet that triggered
+the key update in a packet protected with the updated keys, the endpoint signals
+that the key update is complete.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2-3">An endpoint can defer sending the packet or acknowledgment according to its
+normal packet sending behavior; it is not necessary to immediately generate a
+packet in response to a key update.  The next packet sent by the endpoint will
+use the updated keys.  The next packet that contains an acknowledgment will
+cause the key update to be completed.  If an endpoint detects a second update
+before it has sent any packets with updated keys containing an
+acknowledgment for the packet that initiated the key update, it indicates that
+its peer has updated keys twice without awaiting confirmation.  An endpoint <span class="bcp14">MAY</span>
+treat such consecutive key updates as a connection error of type
+KEY_UPDATE_ERROR.<a href="#section-6.2-3" class="pilcrow">¶</a></p>
+<p id="section-6.2-4">An endpoint that receives an acknowledgment that is carried in a packet
+protected with old keys where any acknowledged packet was protected with newer
+keys <span class="bcp14">MAY</span> treat that as a connection error of type KEY_UPDATE_ERROR.  This
+indicates that a peer has received and acknowledged a packet that initiates a
+key update, but has not updated keys in response.<a href="#section-6.2-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="receive-key-generation">
+<section id="section-6.3">
+        <h3 id="name-timing-of-receive-key-gener">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-timing-of-receive-key-gener" class="section-name selfRef">Timing of Receive Key Generation</a>
+        </h3>
+<p id="section-6.3-1">Endpoints responding to an apparent key update <span class="bcp14">MUST NOT</span> generate a timing
+side-channel signal that might indicate that the Key Phase bit was invalid (see
+<a href="#hp-side-channel" class="xref">Section 9.5</a>).  Endpoints can use randomized packet protection keys in
+place of discarded keys when key updates are not yet permitted.  Using
+randomized keys ensures that attempting to remove packet protection does not
+result in timing variations, and results in packets with an invalid Key Phase
+bit being rejected.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<p id="section-6.3-2">The process of creating new packet protection keys for receiving packets could
+reveal that a key update has occurred. An endpoint <span class="bcp14">MAY</span> generate new keys as
+part of packet processing, but this creates a timing signal that could be used
+by an attacker to learn when key updates happen and thus leak the value of the
+Key Phase bit.<a href="#section-6.3-2" class="pilcrow">¶</a></p>
+<p id="section-6.3-3">Endpoints are generally expected to have current and next receive packet
+protection keys available. For a short period after a key update completes, up
+to the PTO, endpoints <span class="bcp14">MAY</span> defer generation of the next set of
+receive packet protection keys. This allows endpoints
+to retain only two sets of receive keys; see <a href="#old-keys-recv" class="xref">Section 6.5</a>.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
+<p id="section-6.3-4">Once generated, the next set of packet protection keys <span class="bcp14">SHOULD</span> be retained, even
+if the packet that was received was subsequently discarded.  Packets containing
+apparent key updates are easy to forge, and while the process of key update does
+not require significant effort, triggering this process could be used by an
+attacker for DoS.<a href="#section-6.3-4" class="pilcrow">¶</a></p>
+<p id="section-6.3-5">For this reason, endpoints <span class="bcp14">MUST</span> be able to retain two sets of packet protection
+keys for receiving packets: the current and the next.  Retaining the previous
+keys in addition to these might improve performance, but this is not essential.<a href="#section-6.3-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="old-keys-send">
+<section id="section-6.4">
+        <h3 id="name-sending-with-updated-keys">
+<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-sending-with-updated-keys" class="section-name selfRef">Sending with Updated Keys</a>
+        </h3>
+<p id="section-6.4-1">An endpoint never sends packets that are protected with old keys.  Only the
+current keys are used.  Keys used for protecting packets can be discarded
+immediately after switching to newer keys.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
+<p id="section-6.4-2">Packets with higher packet numbers <span class="bcp14">MUST</span> be protected with either the same or
+newer packet protection keys than packets with lower packet numbers.  An
+endpoint that successfully removes protection with old keys when newer keys were
+used for packets with lower packet numbers <span class="bcp14">MUST</span> treat this as a connection error
+of type KEY_UPDATE_ERROR.<a href="#section-6.4-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="old-keys-recv">
+<section id="section-6.5">
+        <h3 id="name-receiving-with-different-ke">
+<a href="#section-6.5" class="section-number selfRef">6.5. </a><a href="#name-receiving-with-different-ke" class="section-name selfRef">Receiving with Different Keys</a>
+        </h3>
+<p id="section-6.5-1">For receiving packets during a key update, packets protected with older keys
+might arrive if they were delayed by the network.  Retaining old packet
+protection keys allows these packets to be successfully processed.<a href="#section-6.5-1" class="pilcrow">¶</a></p>
+<p id="section-6.5-2">As packets protected with keys from the next key phase use the same Key Phase
+value as those protected with keys from the previous key phase, it is necessary
+to distinguish between the two if packets protected with old keys are to be
+processed.  This can be done using packet numbers.  A recovered packet number
+that is lower than any packet number from the current key phase uses the
+previous packet protection keys; a recovered packet number that is higher than
+any packet number from the current key phase requires the use of the next packet
+protection keys.<a href="#section-6.5-2" class="pilcrow">¶</a></p>
+<p id="section-6.5-3">Some care is necessary to ensure that any process for selecting between
+previous, current, and next packet protection keys does not expose a timing side
+channel that might reveal which keys were used to remove packet protection.  See
+<a href="#hp-side-channel" class="xref">Section 9.5</a> for more information.<a href="#section-6.5-3" class="pilcrow">¶</a></p>
+<p id="section-6.5-4">Alternatively, endpoints can retain only two sets of packet protection keys,
+swapping previous for next after enough time has passed to allow for reordering
+in the network.  In this case, the Key Phase bit alone can be used to select
+keys.<a href="#section-6.5-4" class="pilcrow">¶</a></p>
+<p id="section-6.5-5">An endpoint <span class="bcp14">MAY</span> allow a period of approximately the Probe Timeout (PTO; see
+<span>[<a href="#QUIC-RECOVERY" class="xref">QUIC-RECOVERY</a>]</span>) after promoting the next set of receive keys to be current
+before it creates the subsequent set of packet protection keys. These updated
+keys <span class="bcp14">MAY</span> replace the previous keys at that time. With the caveat that PTO is a
+subjective measure -- that is, a peer could have a different view of the RTT --
+this time is expected to be long enough that any reordered packets would be
+declared lost by a peer even if they were acknowledged and short enough to allow
+a peer to initiate further key updates.<a href="#section-6.5-5" class="pilcrow">¶</a></p>
+<p id="section-6.5-6">Endpoints need to allow for the possibility that a peer might not be able to
+decrypt packets that initiate a key update during the period when the peer
+retains old keys.  Endpoints <span class="bcp14">SHOULD</span> wait three times the PTO before initiating a
+key update after receiving an acknowledgment that confirms that the previous key
+update was received.  Failing to allow sufficient time could lead to packets
+being discarded.<a href="#section-6.5-6" class="pilcrow">¶</a></p>
+<p id="section-6.5-7">An endpoint <span class="bcp14">SHOULD</span> retain old read keys for no more than three times the PTO
+after having received a packet protected using the new keys. After this period,
+old read keys and their corresponding secrets <span class="bcp14">SHOULD</span> be discarded.<a href="#section-6.5-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="aead-limits">
+<section id="section-6.6">
+        <h3 id="name-limits-on-aead-usage">
+<a href="#section-6.6" class="section-number selfRef">6.6. </a><a href="#name-limits-on-aead-usage" class="section-name selfRef">Limits on AEAD Usage</a>
+        </h3>
+<p id="section-6.6-1">This document sets usage limits for AEAD algorithms to ensure that overuse does
+not give an adversary a disproportionate advantage in attacking the
+confidentiality and integrity of communications when using QUIC.<a href="#section-6.6-1" class="pilcrow">¶</a></p>
+<p id="section-6.6-2">The usage limits defined in TLS 1.3 exist for protection against attacks
+on confidentiality and apply to successful applications of AEAD protection. The
+integrity protections in authenticated encryption also depend on limiting the
+number of attempts to forge packets. TLS achieves this by closing connections
+after any record fails an authentication check. In comparison, QUIC ignores any
+packet that cannot be authenticated, allowing multiple forgery attempts.<a href="#section-6.6-2" class="pilcrow">¶</a></p>
+<p id="section-6.6-3">QUIC accounts for AEAD confidentiality and integrity limits separately. The
+confidentiality limit applies to the number of packets encrypted with a given
+key. The integrity limit applies to the number of packets decrypted within a
+given connection. Details on enforcing these limits for each AEAD algorithm
+follow below.<a href="#section-6.6-3" class="pilcrow">¶</a></p>
+<p id="section-6.6-4">Endpoints <span class="bcp14">MUST</span> count the number of encrypted packets for each set of keys. If
+the total number of encrypted packets with the same key exceeds the
+confidentiality limit for the selected AEAD, the endpoint <span class="bcp14">MUST</span> stop using those
+keys. Endpoints <span class="bcp14">MUST</span> initiate a key update before sending more protected packets
+than the confidentiality limit for the selected AEAD permits. If a key update
+is not possible or integrity limits are reached, the endpoint <span class="bcp14">MUST</span> stop using
+the connection and only send stateless resets in response to receiving packets.
+It is <span class="bcp14">RECOMMENDED</span> that endpoints immediately close the connection with a
+connection error of type AEAD_LIMIT_REACHED before reaching a state where key
+updates are not possible.<a href="#section-6.6-4" class="pilcrow">¶</a></p>
+<p id="section-6.6-5">For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the confidentiality limit is
+2<sup>23</sup> encrypted packets; see <a href="#gcm-bounds" class="xref">Appendix B.1</a>. For
+AEAD_CHACHA20_POLY1305, the confidentiality limit is greater than the number of
+possible packets (2<sup>62</sup>) and so can be disregarded. For
+AEAD_AES_128_CCM, the confidentiality limit is 2<sup>21.5</sup> encrypted
+packets; see <a href="#ccm-bounds" class="xref">Appendix B.2</a>. Applying a limit reduces the probability that an
+attacker can distinguish the AEAD in use from a random permutation; see
+<span>[<a href="#AEBounds" class="xref">AEBounds</a>]</span>, <span>[<a href="#ROBUST" class="xref">ROBUST</a>]</span>, and <span>[<a href="#GCM-MU" class="xref">GCM-MU</a>]</span>.<a href="#section-6.6-5" class="pilcrow">¶</a></p>
+<p id="section-6.6-6">In addition to counting packets sent, endpoints <span class="bcp14">MUST</span> count the number of
+received packets that fail authentication during the lifetime of a connection.
+If the total number of received packets that fail authentication within the
+connection, across all keys, exceeds the integrity limit for the selected AEAD,
+the endpoint <span class="bcp14">MUST</span> immediately close the connection with a connection error of
+type AEAD_LIMIT_REACHED and not process any more packets.<a href="#section-6.6-6" class="pilcrow">¶</a></p>
+<p id="section-6.6-7">For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the integrity limit is 2<sup>52</sup>
+invalid packets; see <a href="#gcm-bounds" class="xref">Appendix B.1</a>. For AEAD_CHACHA20_POLY1305, the integrity
+limit is 2<sup>36</sup> invalid packets; see <span>[<a href="#AEBounds" class="xref">AEBounds</a>]</span>. For AEAD_AES_128_CCM,
+the integrity limit is 2<sup>21.5</sup> invalid packets; see
+<a href="#ccm-bounds" class="xref">Appendix B.2</a>. Applying this limit reduces the probability that an attacker can
+successfully forge a packet; see <span>[<a href="#AEBounds" class="xref">AEBounds</a>]</span>, <span>[<a href="#ROBUST" class="xref">ROBUST</a>]</span>, and <span>[<a href="#GCM-MU" class="xref">GCM-MU</a>]</span>.<a href="#section-6.6-7" class="pilcrow">¶</a></p>
+<p id="section-6.6-8">Endpoints that limit the size of packets <span class="bcp14">MAY</span> use higher confidentiality and
+integrity limits; see <a href="#aead-analysis" class="xref">Appendix B</a> for details.<a href="#section-6.6-8" class="pilcrow">¶</a></p>
+<p id="section-6.6-9">Future analyses and specifications <span class="bcp14">MAY</span> relax confidentiality or integrity limits
+for an AEAD.<a href="#section-6.6-9" class="pilcrow">¶</a></p>
+<p id="section-6.6-10">Any TLS cipher suite that is specified for use with QUIC <span class="bcp14">MUST</span> define limits on
+the use of the associated AEAD function that preserves margins for
+confidentiality and integrity. That is, limits <span class="bcp14">MUST</span> be specified for the number
+of packets that can be authenticated and for the number of packets that can fail
+authentication.  Providing a reference to any analysis upon which values are
+based -- and any assumptions used in that analysis -- allows limits to be
+adapted to varying usage conditions.<a href="#section-6.6-10" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="key-update-error">
+<section id="section-6.7">
+        <h3 id="name-key-update-error-code">
+<a href="#section-6.7" class="section-number selfRef">6.7. </a><a href="#name-key-update-error-code" class="section-name selfRef">Key Update Error Code</a>
+        </h3>
+<p id="section-6.7-1">The KEY_UPDATE_ERROR error code (0x0e) is used to signal errors related to key
+updates.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="security-of-initial-messages">
+<section id="section-7">
+      <h2 id="name-security-of-initial-message">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-security-of-initial-message" class="section-name selfRef">Security of Initial Messages</a>
+      </h2>
+<p id="section-7-1">Initial packets are not protected with a secret key, so they are subject to
+potential tampering by an attacker.  QUIC provides protection against attackers
+that cannot read packets but does not attempt to provide additional protection
+against attacks where the attacker can observe and inject packets.  Some forms
+of tampering -- such as modifying the TLS messages themselves -- are detectable,
+but some -- such as modifying ACKs -- are not.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">For example, an attacker could inject a packet containing an ACK frame to
+make it appear that a packet had not been received or to create a false
+impression of the state of the connection (e.g., by modifying the ACK Delay).
+Note that such a packet could cause a legitimate packet to be dropped as a
+duplicate.  Implementations <span class="bcp14">SHOULD</span> use caution in relying on any data that is
+contained in Initial packets that is not otherwise authenticated.<a href="#section-7-2" class="pilcrow">¶</a></p>
+<p id="section-7-3">It is also possible for the attacker to tamper with data that is carried in
+Handshake packets, but because that sort of tampering requires modifying TLS
+handshake messages, any such tampering will cause the TLS handshake to fail.<a href="#section-7-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="quic-specific-adjustments-to-the-tls-handshake">
+<section id="section-8">
+      <h2 id="name-quic-specific-adjustments-t">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-quic-specific-adjustments-t" class="section-name selfRef">QUIC-Specific Adjustments to the TLS Handshake</a>
+      </h2>
+<p id="section-8-1">Certain aspects of the TLS handshake are different when used with QUIC.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<p id="section-8-2">QUIC also requires additional features from TLS.  In addition to negotiation of
+cryptographic parameters, the TLS handshake carries and authenticates values for
+QUIC transport parameters.<a href="#section-8-2" class="pilcrow">¶</a></p>
+<div id="protocol-negotiation">
+<section id="section-8.1">
+        <h3 id="name-protocol-negotiation">
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-protocol-negotiation" class="section-name selfRef">Protocol Negotiation</a>
+        </h3>
+<p id="section-8.1-1">QUIC requires that the cryptographic handshake provide authenticated protocol
+negotiation.  TLS uses Application-Layer Protocol Negotiation
+<span>[<a href="#ALPN" class="xref">ALPN</a>]</span> to select an application protocol.  Unless another mechanism
+is used for agreeing on an application protocol, endpoints <span class="bcp14">MUST</span> use ALPN for
+this purpose.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
+<p id="section-8.1-2">When using ALPN, endpoints <span class="bcp14">MUST</span> immediately close a connection (see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-10.2" class="relref">Section 10.2</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>) with a no_application_protocol TLS alert (QUIC error
+code 0x0178; see <a href="#tls-errors" class="xref">Section 4.8</a>) if an application protocol is not negotiated.
+While <span>[<a href="#ALPN" class="xref">ALPN</a>]</span> only specifies that servers use this alert, QUIC clients <span class="bcp14">MUST</span>
+use error 0x0178 to terminate a connection when ALPN negotiation fails.<a href="#section-8.1-2" class="pilcrow">¶</a></p>
+<p id="section-8.1-3">An application protocol <span class="bcp14">MAY</span> restrict the QUIC versions that it can operate over.
+Servers <span class="bcp14">MUST</span> select an application protocol compatible with the QUIC version
+that the client has selected.  The server <span class="bcp14">MUST</span> treat the inability to select a
+compatible application protocol as a connection error of type 0x0178
+(no_application_protocol).  Similarly, a client <span class="bcp14">MUST</span> treat the selection of an
+incompatible application protocol by a server as a connection error of type
+0x0178.<a href="#section-8.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="quic_parameters">
+<section id="section-8.2">
+        <h3 id="name-quic-transport-parameters-e">
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-quic-transport-parameters-e" class="section-name selfRef">QUIC Transport Parameters Extension</a>
+        </h3>
+<p id="section-8.2-1">QUIC transport parameters are carried in a TLS extension. Different versions of
+QUIC might define a different method for negotiating transport configuration.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
+<p id="section-8.2-2">Including transport parameters in the TLS handshake provides integrity
+protection for these values.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
+<div id="section-8.2-3">
+<pre class="sourcecode lang-tls-presentation">
+   enum {
+      quic_transport_parameters(0x39), (65535)
+   } ExtensionType;
+</pre><a href="#section-8.2-3" class="pilcrow">¶</a>
+</div>
+<p id="section-8.2-4">The extension_data field of the quic_transport_parameters extension contains a
+value that is defined by the version of QUIC that is in use.<a href="#section-8.2-4" class="pilcrow">¶</a></p>
+<p id="section-8.2-5">The quic_transport_parameters extension is carried in the ClientHello and the
+EncryptedExtensions messages during the handshake. Endpoints <span class="bcp14">MUST</span> send the
+quic_transport_parameters extension; endpoints that receive ClientHello or
+EncryptedExtensions messages without the quic_transport_parameters extension
+<span class="bcp14">MUST</span> close the connection with an error of type 0x016d (equivalent to a fatal
+TLS missing_extension alert, see <a href="#tls-errors" class="xref">Section 4.8</a>).<a href="#section-8.2-5" class="pilcrow">¶</a></p>
+<p id="section-8.2-6">Transport parameters become available prior to the completion of the handshake.
+A server might use these values earlier than handshake completion. However, the
+value of transport parameters is not authenticated until the handshake
+completes, so any use of these parameters cannot depend on their authenticity.
+Any tampering with transport parameters will cause the handshake to fail.<a href="#section-8.2-6" class="pilcrow">¶</a></p>
+<p id="section-8.2-7">Endpoints <span class="bcp14">MUST NOT</span> send this extension in a TLS connection that does not use
+QUIC (such as the use of TLS with TCP defined in <span>[<a href="#TLS13" class="xref">TLS13</a>]</span>).  A fatal
+unsupported_extension alert <span class="bcp14">MUST</span> be sent by an implementation that supports this
+extension if the extension is received when the transport is not QUIC.<a href="#section-8.2-7" class="pilcrow">¶</a></p>
+<p id="section-8.2-8">Negotiating the quic_transport_parameters extension causes the EndOfEarlyData to
+be removed; see <a href="#remove-eoed" class="xref">Section 8.3</a>.<a href="#section-8.2-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="remove-eoed">
+<section id="section-8.3">
+        <h3 id="name-removing-the-endofearlydata">
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-removing-the-endofearlydata" class="section-name selfRef">Removing the EndOfEarlyData Message</a>
+        </h3>
+<p id="section-8.3-1">The TLS EndOfEarlyData message is not used with QUIC.  QUIC does not rely on
+this message to mark the end of 0-RTT data or to signal the change to Handshake
+keys.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
+<p id="section-8.3-2">Clients <span class="bcp14">MUST NOT</span> send the EndOfEarlyData message.  A server <span class="bcp14">MUST</span> treat receipt
+of a CRYPTO frame in a 0-RTT packet as a connection error of type
+PROTOCOL_VIOLATION.<a href="#section-8.3-2" class="pilcrow">¶</a></p>
+<p id="section-8.3-3">As a result, EndOfEarlyData does not appear in the TLS handshake transcript.<a href="#section-8.3-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="compat-mode">
+<section id="section-8.4">
+        <h3 id="name-prohibit-tls-middlebox-comp">
+<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-prohibit-tls-middlebox-comp" class="section-name selfRef">Prohibit TLS Middlebox Compatibility Mode</a>
+        </h3>
+<p id="section-8.4-1">Appendix D.4 of <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> describes an alteration to the TLS 1.3 handshake as
+a workaround for bugs in some middleboxes. The TLS 1.3 middlebox compatibility
+mode involves setting the legacy_session_id field to a 32-byte value in the
+ClientHello and ServerHello, then sending a change_cipher_spec record. Both
+field and record carry no semantic content and are ignored.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
+<p id="section-8.4-2">This mode has no use in QUIC as it only applies to middleboxes that interfere
+with TLS over TCP. QUIC also provides no means to carry a change_cipher_spec
+record. A client <span class="bcp14">MUST NOT</span> request the use of the TLS 1.3 compatibility mode. A
+server <span class="bcp14">SHOULD</span> treat the receipt of a TLS ClientHello with a non-empty
+legacy_session_id field as a connection error of type PROTOCOL_VIOLATION.<a href="#section-8.4-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="security-considerations">
+<section id="section-9">
+      <h2 id="name-security-considerations">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-9-1">All of the security considerations that apply to TLS also apply to the use of
+TLS in QUIC. Reading all of <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> and its appendices is the best way to
+gain an understanding of the security properties of QUIC.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<p id="section-9-2">This section summarizes some of the more important security aspects specific to
+the TLS integration, though there are many security-relevant details in the
+remainder of the document.<a href="#section-9-2" class="pilcrow">¶</a></p>
+<div id="session-linkability">
+<section id="section-9.1">
+        <h3 id="name-session-linkability">
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-session-linkability" class="section-name selfRef">Session Linkability</a>
+        </h3>
+<p id="section-9.1-1">Use of TLS session tickets allows servers and possibly other entities to
+correlate connections made by the same client; see <a href="#resumption" class="xref">Section 4.5</a> for details.<a href="#section-9.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="replay">
+<section id="section-9.2">
+        <h3 id="name-replay-attacks-with-0-rtt">
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-replay-attacks-with-0-rtt" class="section-name selfRef">Replay Attacks with 0-RTT</a>
+        </h3>
+<p id="section-9.2-1">As described in <span><a href="https://rfc-editor.org/rfc/rfc8446#section-8" class="relref">Section 8</a> of [<a href="#TLS13" class="xref">TLS13</a>]</span>, use of TLS early data comes with an
+exposure to replay attack.  The use of 0-RTT in QUIC is similarly vulnerable to
+replay attack.<a href="#section-9.2-1" class="pilcrow">¶</a></p>
+<p id="section-9.2-2">Endpoints <span class="bcp14">MUST</span> implement and use the replay protections described in <span>[<a href="#TLS13" class="xref">TLS13</a>]</span>,
+however it is recognized that these protections are imperfect.  Therefore,
+additional consideration of the risk of replay is needed.<a href="#section-9.2-2" class="pilcrow">¶</a></p>
+<p id="section-9.2-3">QUIC is not vulnerable to replay attack, except via the application protocol
+information it might carry.  The management of QUIC protocol state based on the
+frame types defined in <span>[<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span> is not vulnerable to replay.
+Processing of QUIC frames is idempotent and cannot result in invalid connection
+states if frames are replayed, reordered, or lost.  QUIC connections do not
+produce effects that last beyond the lifetime of the connection, except for
+those produced by the application protocol that QUIC serves.<a href="#section-9.2-3" class="pilcrow">¶</a></p>
+<p id="section-9.2-4">TLS session tickets and address validation tokens are used to carry QUIC
+configuration information between connections, specifically, to enable a server
+to efficiently recover state that is used in connection establishment and
+address validation.  These <span class="bcp14">MUST NOT</span> be used to communicate application semantics
+between endpoints; clients <span class="bcp14">MUST</span> treat them as opaque values.  The potential for
+reuse of these tokens means that they require stronger protections against
+replay.<a href="#section-9.2-4" class="pilcrow">¶</a></p>
+<p id="section-9.2-5">A server that accepts 0-RTT on a connection incurs a higher cost than accepting
+a connection without 0-RTT.  This includes higher processing and computation
+costs.  Servers need to consider the probability of replay and all associated
+costs when accepting 0-RTT.<a href="#section-9.2-5" class="pilcrow">¶</a></p>
+<p id="section-9.2-6">Ultimately, the responsibility for managing the risks of replay attacks with
+0-RTT lies with an application protocol.  An application protocol that uses QUIC
+<span class="bcp14">MUST</span> describe how the protocol uses 0-RTT and the measures that are employed to
+protect against replay attack.  An analysis of replay risk needs to consider
+all QUIC protocol features that carry application semantics.<a href="#section-9.2-6" class="pilcrow">¶</a></p>
+<p id="section-9.2-7">Disabling 0-RTT entirely is the most effective defense against replay attack.<a href="#section-9.2-7" class="pilcrow">¶</a></p>
+<p id="section-9.2-8">QUIC extensions <span class="bcp14">MUST</span> either describe how replay attacks affect their operation
+or prohibit the use of the extension in 0-RTT.  Application protocols <span class="bcp14">MUST</span>
+either prohibit the use of extensions that carry application semantics in 0-RTT
+or provide replay mitigation strategies.<a href="#section-9.2-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="reflection">
+<section id="section-9.3">
+        <h3 id="name-packet-reflection-attack-mi">
+<a href="#section-9.3" class="section-number selfRef">9.3. </a><a href="#name-packet-reflection-attack-mi" class="section-name selfRef">Packet Reflection Attack Mitigation</a>
+        </h3>
+<p id="section-9.3-1">A small ClientHello that results in a large block of handshake messages from a
+server can be used in packet reflection attacks to amplify the traffic generated
+by an attacker.<a href="#section-9.3-1" class="pilcrow">¶</a></p>
+<p id="section-9.3-2">QUIC includes three defenses against this attack. First, the packet containing
+a ClientHello <span class="bcp14">MUST</span> be padded to a minimum size. Second, if responding to an
+unverified source address, the server is forbidden to send more than three
+times as many bytes as the number of bytes it has received (see <span><a href="https://rfc-editor.org/rfc/rfc9000#section-8.1" class="relref">Section 8.1</a> of [<a href="#QUIC-TRANSPORT" class="xref">QUIC-TRANSPORT</a>]</span>). Finally, because acknowledgments of Handshake packets are
+authenticated, a blind attacker cannot forge them. Put together, these defenses
+limit the level of amplification.<a href="#section-9.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="header-protect-analysis">
+<section id="section-9.4">
+        <h3 id="name-header-protection-analysis">
+<a href="#section-9.4" class="section-number selfRef">9.4. </a><a href="#name-header-protection-analysis" class="section-name selfRef">Header Protection Analysis</a>
+        </h3>
+<p id="section-9.4-1"><span>[<a href="#NAN" class="xref">NAN</a>]</span> analyzes authenticated encryption
+algorithms that provide nonce privacy, referred to as "Hide Nonce" (HN)
+transforms. The general header protection construction in this document is
+one of those algorithms (HN1). Header protection is applied after the packet
+protection AEAD, sampling a set of bytes (<code>sample</code>) from the AEAD output and
+encrypting the header field using a pseudorandom function (PRF) as follows:<a href="#section-9.4-1" class="pilcrow">¶</a></p>
+<div id="section-9.4-2">
+<pre class="sourcecode lang-pseudocode">
+protected_field = field XOR PRF(hp_key, sample)
+</pre><a href="#section-9.4-2" class="pilcrow">¶</a>
+</div>
+<p id="section-9.4-3">The header protection variants in this document use a pseudorandom permutation
+(PRP) in place of a generic PRF. However, since all PRPs are also PRFs <span>[<a href="#IMC" class="xref">IMC</a>]</span>,
+these variants do not deviate from the HN1 construction.<a href="#section-9.4-3" class="pilcrow">¶</a></p>
+<p id="section-9.4-4">As <code>hp_key</code> is distinct from the packet protection key, it follows that header
+protection achieves AE2 security as defined in <span>[<a href="#NAN" class="xref">NAN</a>]</span> and therefore guarantees
+privacy of <code>field</code>, the protected packet header. Future header protection
+variants based on this construction <span class="bcp14">MUST</span> use a PRF to ensure equivalent
+security guarantees.<a href="#section-9.4-4" class="pilcrow">¶</a></p>
+<p id="section-9.4-5">Use of the same key and ciphertext sample more than once risks compromising
+header protection. Protecting two different headers with the same key and
+ciphertext sample reveals the exclusive OR of the protected fields.  Assuming
+that the AEAD acts as a PRF, if L bits are sampled, the odds of two ciphertext
+samples being identical approach 2<sup>-L/2</sup>, that is, the birthday bound.
+For the algorithms described in this document, that probability is one in
+2<sup>64</sup>.<a href="#section-9.4-5" class="pilcrow">¶</a></p>
+<p id="section-9.4-6">To prevent an attacker from modifying packet headers, the header is transitively
+authenticated using packet protection; the entire packet header is part of the
+authenticated additional data.  Protected fields that are falsified or modified
+can only be detected once the packet protection is removed.<a href="#section-9.4-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="hp-side-channel">
+<section id="section-9.5">
+        <h3 id="name-header-protection-timing-si">
+<a href="#section-9.5" class="section-number selfRef">9.5. </a><a href="#name-header-protection-timing-si" class="section-name selfRef">Header Protection Timing Side Channels</a>
+        </h3>
+<p id="section-9.5-1">An attacker could guess values for packet numbers or Key Phase and have an
+endpoint confirm guesses through timing side channels.  Similarly, guesses for
+the packet number length can be tried and exposed.  If the recipient of a packet
+discards packets with duplicate packet numbers without attempting to remove
+packet protection, they could reveal through timing side channels that the
+packet number matches a received packet.  For authentication to be free from
+side channels, the entire process of header protection removal, packet number
+recovery, and packet protection removal <span class="bcp14">MUST</span> be applied together without timing
+and other side channels.<a href="#section-9.5-1" class="pilcrow">¶</a></p>
+<p id="section-9.5-2">For the sending of packets, construction and protection of packet payloads and
+packet numbers <span class="bcp14">MUST</span> be free from side channels that would reveal the packet
+number or its encoded size.<a href="#section-9.5-2" class="pilcrow">¶</a></p>
+<p id="section-9.5-3">During a key update, the time taken to generate new keys could reveal through
+timing side channels that a key update has occurred.  Alternatively, where an
+attacker injects packets, this side channel could reveal the value of the Key
+Phase on injected packets.  After receiving a key update, an endpoint <span class="bcp14">SHOULD</span>
+generate and save the next set of receive packet protection keys, as described
+in <a href="#receive-key-generation" class="xref">Section 6.3</a>.  By generating new keys before a key update is
+received, receipt of packets will not create timing signals that leak the value
+of the Key Phase.<a href="#section-9.5-3" class="pilcrow">¶</a></p>
+<p id="section-9.5-4">This depends on not doing this key generation during packet processing, and it
+can require that endpoints maintain three sets of packet protection keys for
+receiving: for the previous key phase, for the current key phase, and for the
+next key phase.  Endpoints can instead choose to defer generation of the next
+receive packet protection keys until they discard old keys so that only two sets
+of receive keys need to be retained at any point in time.<a href="#section-9.5-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="key-diversity">
+<section id="section-9.6">
+        <h3 id="name-key-diversity">
+<a href="#section-9.6" class="section-number selfRef">9.6. </a><a href="#name-key-diversity" class="section-name selfRef">Key Diversity</a>
+        </h3>
+<p id="section-9.6-1">In using TLS, the central key schedule of TLS is used.  As a result of the TLS
+handshake messages being integrated into the calculation of secrets, the
+inclusion of the QUIC transport parameters extension ensures that the handshake
+and 1-RTT keys are not the same as those that might be produced by a server
+running TLS over TCP.  To avoid the possibility of cross-protocol key
+synchronization, additional measures are provided to improve key separation.<a href="#section-9.6-1" class="pilcrow">¶</a></p>
+<p id="section-9.6-2">The QUIC packet protection keys and IVs are derived using a different label than
+the equivalent keys in TLS.<a href="#section-9.6-2" class="pilcrow">¶</a></p>
+<p id="section-9.6-3">To preserve this separation, a new version of QUIC <span class="bcp14">SHOULD</span> define new labels for
+key derivation for packet protection key and IV, plus the header protection
+keys.  This version of QUIC uses the string "quic".  Other versions can use a
+version-specific label in place of that string.<a href="#section-9.6-3" class="pilcrow">¶</a></p>
+<p id="section-9.6-4">The initial secrets use a key that is specific to the negotiated QUIC version.
+New QUIC versions <span class="bcp14">SHOULD</span> define a new salt value used in calculating initial
+secrets.<a href="#section-9.6-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="randomness">
+<section id="section-9.7">
+        <h3 id="name-randomness">
+<a href="#section-9.7" class="section-number selfRef">9.7. </a><a href="#name-randomness" class="section-name selfRef">Randomness</a>
+        </h3>
+<p id="section-9.7-1">QUIC depends on endpoints being able to generate secure random numbers, both
+directly for protocol values such as the connection ID, and transitively via
+TLS. See <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span> for guidance on secure random number generation.<a href="#section-9.7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="iana-considerations">
+<section id="section-10">
+      <h2 id="name-iana-considerations">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-10-1">IANA has registered a codepoint of 57 (or 0x39) for the
+quic_transport_parameters extension (defined in <a href="#quic_parameters" class="xref">Section 8.2</a>) in the "TLS
+ExtensionType Values" registry <span>[<a href="#TLS-REGISTRIES" class="xref">TLS-REGISTRIES</a>]</span>.<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-10-2">The Recommended column for this extension is marked Yes. The TLS 1.3 Column
+includes CH (ClientHello) and EE (EncryptedExtensions).<a href="#section-10-2" class="pilcrow">¶</a></p>
+<span id="name-tls-extensiontype-values-re"></span><div id="iana-tls-ext">
+<table class="center" id="table-2">
+        <caption>
+<a href="#table-2" class="selfRef">Table 2</a>:
+<a href="#name-tls-extensiontype-values-re" class="selfRef">TLS ExtensionType Values Registry Entry</a>
+        </caption>
+<thead>
+          <tr>
+            <th class="text-right" rowspan="1" colspan="1">Value</th>
+            <th class="text-left" rowspan="1" colspan="1">Extension Name</th>
+            <th class="text-left" rowspan="1" colspan="1">TLS 1.3</th>
+            <th class="text-left" rowspan="1" colspan="1">Recommended</th>
+            <th class="text-left" rowspan="1" colspan="1">Reference</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-right" rowspan="1" colspan="1">57</td>
+            <td class="text-left" rowspan="1" colspan="1">quic_transport_parameters</td>
+            <td class="text-left" rowspan="1" colspan="1">CH, EE</td>
+            <td class="text-left" rowspan="1" colspan="1">Y</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+        </tbody>
+      </table>
+</div>
+</section>
+</div>
+<section id="section-11">
+      <h2 id="name-references">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-references" class="section-name selfRef">References</a>
+      </h2>
+<section id="section-11.1">
+        <h3 id="name-normative-references">
+<a href="#section-11.1" class="section-number selfRef">11.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+        </h3>
+<dl class="references">
+<dt id="AEAD">[AEAD]</dt>
+        <dd>
+<span class="refAuthor">McGrew, D.</span>, <span class="refTitle">"An Interface and Algorithms for Authenticated Encryption"</span>, <span class="seriesInfo">RFC 5116</span>, <span class="seriesInfo">DOI 10.17487/RFC5116</span>, <time datetime="2008-01" class="refDate">January 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5116">https://www.rfc-editor.org/info/rfc5116</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="AES">[AES]</dt>
+        <dd>
+<span class="refTitle">"Advanced encryption standard (AES)"</span>, <span class="seriesInfo">National Institute of Standards and Technology report</span>, <span class="seriesInfo">DOI 10.6028/nist.fips.197</span>, <time datetime="2001-11" class="refDate">November 2001</time>, <span>&lt;<a href="https://doi.org/10.6028/nist.fips.197">https://doi.org/10.6028/nist.fips.197</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="ALPN">[ALPN]</dt>
+        <dd>
+<span class="refAuthor">Friedl, S.</span>, <span class="refAuthor">Popov, A.</span>, <span class="refAuthor">Langley, A.</span>, and <span class="refAuthor">E. Stephan</span>, <span class="refTitle">"Transport Layer Security (TLS) Application-Layer Protocol Negotiation Extension"</span>, <span class="seriesInfo">RFC 7301</span>, <span class="seriesInfo">DOI 10.17487/RFC7301</span>, <time datetime="2014-07" class="refDate">July 2014</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7301">https://www.rfc-editor.org/info/rfc7301</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="CHACHA">[CHACHA]</dt>
+        <dd>
+<span class="refAuthor">Nir, Y.</span> and <span class="refAuthor">A. Langley</span>, <span class="refTitle">"ChaCha20 and Poly1305 for IETF Protocols"</span>, <span class="seriesInfo">RFC 8439</span>, <span class="seriesInfo">DOI 10.17487/RFC8439</span>, <time datetime="2018-06" class="refDate">June 2018</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8439">https://www.rfc-editor.org/info/rfc8439</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="HKDF">[HKDF]</dt>
+        <dd>
+<span class="refAuthor">Krawczyk, H.</span> and <span class="refAuthor">P. Eronen</span>, <span class="refTitle">"HMAC-based Extract-and-Expand Key Derivation Function (HKDF)"</span>, <span class="seriesInfo">RFC 5869</span>, <span class="seriesInfo">DOI 10.17487/RFC5869</span>, <time datetime="2010-05" class="refDate">May 2010</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5869">https://www.rfc-editor.org/info/rfc5869</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="QUIC-RECOVERY">[QUIC-RECOVERY]</dt>
+        <dd>
+<span class="refAuthor">Iyengar, J., Ed.</span> and <span class="refAuthor">I. Swett, Ed.</span>, <span class="refTitle">"QUIC Loss Detection and Congestion Control"</span>, <span class="seriesInfo">RFC 9002</span>, <span class="seriesInfo">DOI 10.17487/RFC9002</span>, <time datetime="2021-05" class="refDate">May 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9002">https://www.rfc-editor.org/info/rfc9002</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="QUIC-TRANSPORT">[QUIC-TRANSPORT]</dt>
+        <dd>
+<span class="refAuthor">Iyengar, J., Ed.</span> and <span class="refAuthor">M. Thomson, Ed.</span>, <span class="refTitle">"QUIC: A UDP-Based Multiplexed and Secure Transport"</span>, <span class="seriesInfo">RFC 9000</span>, <span class="seriesInfo">DOI 10.17487/RFC9000</span>, <time datetime="2021-05" class="refDate">May 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9000">https://www.rfc-editor.org/info/rfc9000</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2119">[RFC2119]</dt>
+        <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4086">[RFC4086]</dt>
+        <dd>
+<span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">BCP 106</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4086">https://www.rfc-editor.org/info/rfc4086</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+        <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="SHA">[SHA]</dt>
+        <dd>
+<span class="refAuthor">Dang, Q.</span>, <span class="refTitle">"Secure Hash Standard"</span>, <span class="seriesInfo">National Institute of Standards and Technology report</span>, <span class="seriesInfo">DOI 10.6028/nist.fips.180-4</span>, <time datetime="2015-07" class="refDate">July 2015</time>, <span>&lt;<a href="https://doi.org/10.6028/nist.fips.180-4">https://doi.org/10.6028/nist.fips.180-4</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="TLS-REGISTRIES">[TLS-REGISTRIES]</dt>
+        <dd>
+<span class="refAuthor">Salowey, J.</span> and <span class="refAuthor">S. Turner</span>, <span class="refTitle">"IANA Registry Updates for TLS and DTLS"</span>, <span class="seriesInfo">RFC 8447</span>, <span class="seriesInfo">DOI 10.17487/RFC8447</span>, <time datetime="2018-08" class="refDate">August 2018</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8447">https://www.rfc-editor.org/info/rfc8447</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="TLS13">[TLS13]</dt>
+      <dd>
+<span class="refAuthor">Rescorla, E.</span>, <span class="refTitle">"The Transport Layer Security (TLS) Protocol Version 1.3"</span>, <span class="seriesInfo">RFC 8446</span>, <span class="seriesInfo">DOI 10.17487/RFC8446</span>, <time datetime="2018-08" class="refDate">August 2018</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8446">https://www.rfc-editor.org/info/rfc8446</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-11.2">
+        <h3 id="name-informative-references">
+<a href="#section-11.2" class="section-number selfRef">11.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+        </h3>
+<dl class="references">
+<dt id="AEBounds">[AEBounds]</dt>
+        <dd>
+<span class="refAuthor">Luykx, A.</span> and <span class="refAuthor">K. Paterson</span>, <span class="refTitle">"Limits on Authenticated Encryption Use in TLS"</span>, <time datetime="2017-08-28" class="refDate">August 28, 2017</time>, <span>&lt;<a href="https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf">https://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="ASCII">[ASCII]</dt>
+        <dd>
+<span class="refAuthor">Cerf, V.</span>, <span class="refTitle">"ASCII format for network interchange"</span>, <span class="seriesInfo">STD 80</span>, <span class="seriesInfo">RFC 20</span>, <span class="seriesInfo">DOI 10.17487/RFC0020</span>, <time datetime="1969-10" class="refDate">October 1969</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc20">https://www.rfc-editor.org/info/rfc20</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="CCM-ANALYSIS">[CCM-ANALYSIS]</dt>
+        <dd>
+<span class="refAuthor">Jonsson, J.</span>, <span class="refTitle">"On the Security of CTR + CBC-MAC"</span>, <span class="refContent">Selected Areas in Cryptography</span>, <span class="refContent">SAC 2002</span>, <span class="refContent">Lecture Notes in Computer Science, vol 2595</span>, <span class="refContent">pp. 76-93</span>, <span class="seriesInfo">DOI 10.1007/3-540-36492-7_7</span>, <time datetime="2003" class="refDate">2003</time>, <span>&lt;<a href="https://doi.org/10.1007/3-540-36492-7_7">https://doi.org/10.1007/3-540-36492-7_7</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="COMPRESS">[COMPRESS]</dt>
+        <dd>
+<span class="refAuthor">Ghedini, A.</span> and <span class="refAuthor">V. Vasiliev</span>, <span class="refTitle">"TLS Certificate Compression"</span>, <span class="seriesInfo">RFC 8879</span>, <span class="seriesInfo">DOI 10.17487/RFC8879</span>, <time datetime="2020-12" class="refDate">December 2020</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8879">https://www.rfc-editor.org/info/rfc8879</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="GCM-MU">[GCM-MU]</dt>
+        <dd>
+<span class="refAuthor">Hoang, V.</span>, <span class="refAuthor">Tessaro, S.</span>, and <span class="refAuthor">A. Thiruvengadam</span>, <span class="refTitle">"The Multi-user Security of GCM, Revisited: Tight Bounds for Nonce Randomization"</span>, <span class="refContent">CCS '18: Proceedings of the 2018 ACM SIGSAC Conference on Computer and Communications Security</span>, <span class="refContent">pp. 1429-1440</span>, <span class="seriesInfo">DOI 10.1145/3243734.3243816</span>, <time datetime="2018" class="refDate">2018</time>, <span>&lt;<a href="https://doi.org/10.1145/3243734.3243816">https://doi.org/10.1145/3243734.3243816</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="HTTP-REPLAY">[HTTP-REPLAY]</dt>
+        <dd>
+<span class="refAuthor">Thomson, M.</span>, <span class="refAuthor">Nottingham, M.</span>, and <span class="refAuthor">W. Tarreau</span>, <span class="refTitle">"Using Early Data in HTTP"</span>, <span class="seriesInfo">RFC 8470</span>, <span class="seriesInfo">DOI 10.17487/RFC8470</span>, <time datetime="2018-09" class="refDate">September 2018</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8470">https://www.rfc-editor.org/info/rfc8470</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="HTTP2-TLS13">[HTTP2-TLS13]</dt>
+        <dd>
+<span class="refAuthor">Benjamin, D.</span>, <span class="refTitle">"Using TLS 1.3 with HTTP/2"</span>, <span class="seriesInfo">RFC 8740</span>, <span class="seriesInfo">DOI 10.17487/RFC8740</span>, <time datetime="2020-02" class="refDate">February 2020</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8740">https://www.rfc-editor.org/info/rfc8740</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="IMC">[IMC]</dt>
+        <dd>
+<span class="refAuthor">Katz, J.</span> and <span class="refAuthor">Y. Lindell</span>, <span class="refTitle">"Introduction to Modern Cryptography, Second Edition"</span>, <span class="seriesInfo">ISBN 978-1466570269</span>, <time datetime="2014-11-06" class="refDate">November 6, 2014</time>. </dd>
+<dd class="break"></dd>
+<dt id="NAN">[NAN]</dt>
+        <dd>
+<span class="refAuthor">Bellare, M.</span>, <span class="refAuthor">Ng, R.</span>, and <span class="refAuthor">B. Tackmann</span>, <span class="refTitle">"Nonces Are Noticed: AEAD Revisited"</span>, <span class="refContent">Advances in Cryptology - CRYPTO 2019</span>, <span class="refContent">Lecture Notes in Computer Science, vol 11692</span>, <span class="refContent">pp. 235-265</span>, <span class="seriesInfo">DOI 10.1007/978-3-030-26948-7_9</span>, <time datetime="2019" class="refDate">2019</time>, <span>&lt;<a href="https://doi.org/10.1007/978-3-030-26948-7_9">https://doi.org/10.1007/978-3-030-26948-7_9</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="QUIC-HTTP">[QUIC-HTTP]</dt>
+        <dd>
+<span class="refAuthor">Bishop, M., Ed.</span>, <span class="refTitle">"Hypertext Transfer Protocol Version 3 (HTTP/3)"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-quic-http-34</span>, <time datetime="2021-02-02" class="refDate">February 2, 2021</time>, <span>&lt;<a href="https://tools.ietf.org/html/draft-ietf-quic-http-34">https://tools.ietf.org/html/draft-ietf-quic-http-34</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2818">[RFC2818]</dt>
+        <dd>
+<span class="refAuthor">Rescorla, E.</span>, <span class="refTitle">"HTTP Over TLS"</span>, <span class="seriesInfo">RFC 2818</span>, <span class="seriesInfo">DOI 10.17487/RFC2818</span>, <time datetime="2000-05" class="refDate">May 2000</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2818">https://www.rfc-editor.org/info/rfc2818</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5280">[RFC5280]</dt>
+        <dd>
+<span class="refAuthor">Cooper, D.</span>, <span class="refAuthor">Santesson, S.</span>, <span class="refAuthor">Farrell, S.</span>, <span class="refAuthor">Boeyen, S.</span>, <span class="refAuthor">Housley, R.</span>, and <span class="refAuthor">W. Polk</span>, <span class="refTitle">"Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile"</span>, <span class="seriesInfo">RFC 5280</span>, <span class="seriesInfo">DOI 10.17487/RFC5280</span>, <time datetime="2008-05" class="refDate">May 2008</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5280">https://www.rfc-editor.org/info/rfc5280</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="ROBUST">[ROBUST]</dt>
+      <dd>
+<span class="refAuthor">Fischlin, M.</span>, <span class="refAuthor">Günther, F.</span>, and <span class="refAuthor">C. Janson</span>, <span class="refTitle">"Robust Channels: Handling Unreliable Networks in the Record Layers of QUIC and DTLS 1.3"</span>, <time datetime="2020-05-16" class="refDate">May 16, 2020</time>, <span>&lt;<a href="https://eprint.iacr.org/2020/718">https://eprint.iacr.org/2020/718</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+</section>
+<div id="test-vectors">
+<section id="appendix-A">
+      <h2 id="name-sample-packet-protection">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-sample-packet-protection" class="section-name selfRef">Sample Packet Protection</a>
+      </h2>
+<p id="appendix-A-1">This section shows examples of packet protection so that implementations can be
+verified incrementally. Samples of Initial packets from both client and server
+plus a Retry packet are defined. These packets use an 8-byte client-chosen
+Destination Connection ID of 0x8394c8f03e515708. Some intermediate values are
+included. All values are shown in hexadecimal.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<div id="keys">
+<section id="appendix-A.1">
+        <h3 id="name-keys">
+<a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-keys" class="section-name selfRef">Keys</a>
+        </h3>
+<p id="appendix-A.1-1">The labels generated during the execution of the HKDF-Expand-Label function
+(that is, HkdfLabel.label) and part of the value given to the HKDF-Expand
+function in order to produce its output are:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-A.1-2">
+          <dt id="appendix-A.1-2.1">client in:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.1-2.2">
+            <p id="appendix-A.1-2.2.1">00200f746c73313320636c69656e7420696e00<a href="#appendix-A.1-2.2.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="appendix-A.1-2.3">server in:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.1-2.4">
+            <p id="appendix-A.1-2.4.1">00200f746c7331332073657276657220696e00<a href="#appendix-A.1-2.4.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="appendix-A.1-2.5">quic key:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.1-2.6">
+            <p id="appendix-A.1-2.6.1">00100e746c7331332071756963206b657900<a href="#appendix-A.1-2.6.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="appendix-A.1-2.7">quic iv:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.1-2.8">
+            <p id="appendix-A.1-2.8.1">000c0d746c733133207175696320697600<a href="#appendix-A.1-2.8.1" class="pilcrow">¶</a></p>
+</dd>
+          <dd class="break"></dd>
+<dt id="appendix-A.1-2.9">quic hp:</dt>
+          <dd style="margin-left: 1.5em" id="appendix-A.1-2.10">
+            <p id="appendix-A.1-2.10.1">00100d746c733133207175696320687000<a href="#appendix-A.1-2.10.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="appendix-A.1-3">The initial secret is common:<a href="#appendix-A.1-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.1-4">
+<pre>
+initial_secret = HKDF-Extract(initial_salt, cid)
+    = 7db5df06e7a69e432496adedb0085192
+      3595221596ae2ae9fb8115c1e9ed0a44
+</pre><a href="#appendix-A.1-4" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.1-5">The secrets for protecting client packets are:<a href="#appendix-A.1-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.1-6">
+<pre>
+client_initial_secret
+    = HKDF-Expand-Label(initial_secret, "client in", "", 32)
+    = c00cf151ca5be075ed0ebfb5c80323c4
+      2d6b7db67881289af4008f1f6c357aea
+
+key = HKDF-Expand-Label(client_initial_secret, "quic key", "", 16)
+    = 1f369613dd76d5467730efcbe3b1a22d
+
+iv  = HKDF-Expand-Label(client_initial_secret, "quic iv", "", 12)
+    = fa044b2f42a3fd3b46fb255c
+
+hp  = HKDF-Expand-Label(client_initial_secret, "quic hp", "", 16)
+    = 9f50449e04a0e810283a1e9933adedd2
+</pre><a href="#appendix-A.1-6" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.1-7">The secrets for protecting server packets are:<a href="#appendix-A.1-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.1-8">
+<pre>
+server_initial_secret
+    = HKDF-Expand-Label(initial_secret, "server in", "", 32)
+    = 3c199828fd139efd216c155ad844cc81
+      fb82fa8d7446fa7d78be803acdda951b
+
+key = HKDF-Expand-Label(server_initial_secret, "quic key", "", 16)
+    = cf3a5331653c364c88f0f379b6067e37
+
+iv  = HKDF-Expand-Label(server_initial_secret, "quic iv", "", 12)
+    = 0ac1493ca1905853b0bba03e
+
+hp  = HKDF-Expand-Label(server_initial_secret, "quic hp", "", 16)
+    = c206b8d9b9f0f37644430b490eeaa314
+</pre><a href="#appendix-A.1-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="sample-client-initial">
+<section id="appendix-A.2">
+        <h3 id="name-client-initial">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-client-initial" class="section-name selfRef">Client Initial</a>
+        </h3>
+<p id="appendix-A.2-1">The client sends an Initial packet.  The unprotected payload of this packet
+contains the following CRYPTO frame, plus enough PADDING frames to make a
+1162-byte payload:<a href="#appendix-A.2-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.2-2">
+<pre>
+060040f1010000ed0303ebf8fa56f129 39b9584a3896472ec40bb863cfd3e868
+04fe3a47f06a2b69484c000004130113 02010000c000000010000e00000b6578
+616d706c652e636f6dff01000100000a 00080006001d00170018001000070005
+04616c706e0005000501000000000033 00260024001d00209370b2c9caa47fba
+baf4559fedba753de171fa71f50f1ce1 5d43e994ec74d748002b000302030400
+0d0010000e0403050306030203080408 050806002d00020101001c0002400100
+3900320408ffffffffffffffff050480 00ffff07048000ffff08011001048000
+75300901100f088394c8f03e51570806 048000ffff
+</pre><a href="#appendix-A.2-2" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.2-3">The unprotected header indicates a length of 1182 bytes: the 4-byte packet
+number, 1162 bytes of frames, and the 16-byte authentication tag.  The header
+includes the connection ID and a packet number of 2:<a href="#appendix-A.2-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.2-4">
+<pre>
+c300000001088394c8f03e5157080000449e00000002
+</pre><a href="#appendix-A.2-4" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.2-5">Protecting the payload produces output that is sampled for header protection.
+Because the header uses a 4-byte packet number encoding, the first 16 bytes of
+the protected payload is sampled and then applied to the header as follows:<a href="#appendix-A.2-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.2-6">
+<pre>
+sample = d1b1c98dd7689fb8ec11d242b123dc9b
+
+mask = AES-ECB(hp, sample)[0..4]
+     = 437b9aec36
+
+header[0] ^= mask[0] &amp; 0x0f
+     = c0
+header[18..21] ^= mask[1..4]
+     = 7b9aec34
+header = c000000001088394c8f03e5157080000449e7b9aec34
+</pre><a href="#appendix-A.2-6" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.2-7">The resulting protected packet is:<a href="#appendix-A.2-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.2-8">
+<pre>
+c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11
+d242b123dc9bd8bab936b47d92ec356c 0bab7df5976d27cd449f63300099f399
+1c260ec4c60d17b31f8429157bb35a12 82a643a8d2262cad67500cadb8e7378c
+8eb7539ec4d4905fed1bee1fc8aafba1 7c750e2c7ace01e6005f80fcb7df6212
+30c83711b39343fa028cea7f7fb5ff89 eac2308249a02252155e2347b63d58c5
+457afd84d05dfffdb20392844ae81215 4682e9cf012f9021a6f0be17ddd0c208
+4dce25ff9b06cde535d0f920a2db1bf3 62c23e596d11a4f5a6cf3948838a3aec
+4e15daf8500a6ef69ec4e3feb6b1d98e 610ac8b7ec3faf6ad760b7bad1db4ba3
+485e8a94dc250ae3fdb41ed15fb6a8e5 eba0fc3dd60bc8e30c5c4287e53805db
+059ae0648db2f64264ed5e39be2e20d8 2df566da8dd5998ccabdae053060ae6c
+7b4378e846d29f37ed7b4ea9ec5d82e7 961b7f25a9323851f681d582363aa5f8
+9937f5a67258bf63ad6f1a0b1d96dbd4 faddfcefc5266ba6611722395c906556
+be52afe3f565636ad1b17d508b73d874 3eeb524be22b3dcbc2c7468d54119c74
+68449a13d8e3b95811a198f3491de3e7 fe942b330407abf82a4ed7c1b311663a
+c69890f4157015853d91e923037c227a 33cdd5ec281ca3f79c44546b9d90ca00
+f064c99e3dd97911d39fe9c5d0b23a22 9a234cb36186c4819e8b9c5927726632
+291d6a418211cc2962e20fe47feb3edf 330f2c603a9d48c0fcb5699dbfe58964
+25c5bac4aee82e57a85aaf4e2513e4f0 5796b07ba2ee47d80506f8d2c25e50fd
+14de71e6c418559302f939b0e1abd576 f279c4b2e0feb85c1f28ff18f58891ff
+ef132eef2fa09346aee33c28eb130ff2 8f5b766953334113211996d20011a198
+e3fc433f9f2541010ae17c1bf202580f 6047472fb36857fe843b19f5984009dd
+c324044e847a4f4a0ab34f719595de37 252d6235365e9b84392b061085349d73
+203a4a13e96f5432ec0fd4a1ee65accd d5e3904df54c1da510b0ff20dcc0c77f
+cb2c0e0eb605cb0504db87632cf3d8b4 dae6e705769d1de354270123cb11450e
+fc60ac47683d7b8d0f811365565fd98c 4c8eb936bcab8d069fc33bd801b03ade
+a2e1fbc5aa463d08ca19896d2bf59a07 1b851e6c239052172f296bfb5e724047
+90a2181014f3b94a4e97d117b4381303 68cc39dbb2d198065ae3986547926cd2
+162f40a29f0c3c8745c0f50fba3852e5 66d44575c29d39a03f0cda721984b6f4
+40591f355e12d439ff150aab7613499d bd49adabc8676eef023b15b65bfc5ca0
+6948109f23f350db82123535eb8a7433 bdabcb909271a6ecbcb58b936a88cd4e
+8f2e6ff5800175f113253d8fa9ca8885 c2f552e657dc603f252e1a8e308f76f0
+be79e2fb8f5d5fbbe2e30ecadd220723 c8c0aea8078cdfcb3868263ff8f09400
+54da48781893a7e49ad5aff4af300cd8 04a6b6279ab3ff3afb64491c85194aab
+760d58a606654f9f4400e8b38591356f bf6425aca26dc85244259ff2b19c41b9
+f96f3ca9ec1dde434da7d2d392b905dd f3d1f9af93d1af5950bd493f5aa731b4
+056df31bd267b6b90a079831aaf579be 0a39013137aac6d404f518cfd4684064
+7e78bfe706ca4cf5e9c5453e9f7cfd2b 8b4c8d169a44e55c88d4a9a7f9474241
+e221af44860018ab0856972e194cd934
+</pre><a href="#appendix-A.2-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="server-initial">
+<section id="appendix-A.3">
+        <h3 id="name-server-initial">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-server-initial" class="section-name selfRef">Server Initial</a>
+        </h3>
+<p id="appendix-A.3-1">The server sends the following payload in response, including an ACK frame, a
+CRYPTO frame, and no PADDING frames:<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.3-2">
+<pre>
+02000000000600405a020000560303ee fce7f7b37ba1d1632e96677825ddf739
+88cfc79825df566dc5430b9a045a1200 130100002e00330024001d00209d3c94
+0d89690b84d08a60993c144eca684d10 81287c834d5311bcf32bb9da1a002b00
+020304
+</pre><a href="#appendix-A.3-2" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.3-3">The header from the server includes a new connection ID and a 2-byte packet
+number encoding for a packet number of 1:<a href="#appendix-A.3-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.3-4">
+<pre>
+c1000000010008f067a5502a4262b50040750001
+</pre><a href="#appendix-A.3-4" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.3-5">As a result, after protection, the header protection sample is taken starting
+from the third protected byte:<a href="#appendix-A.3-5" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.3-6">
+<pre>
+sample = 2cd0991cd25b0aac406a5816b6394100
+mask   = 2ec0d8356a
+header = cf000000010008f067a5502a4262b5004075c0d9
+</pre><a href="#appendix-A.3-6" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.3-7">The final protected packet is then:<a href="#appendix-A.3-7" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.3-8">
+<pre>
+cf000000010008f067a5502a4262b500 4075c0d95a482cd0991cd25b0aac406a
+5816b6394100f37a1c69797554780bb3 8cc5a99f5ede4cf73c3ec2493a1839b3
+dbcba3f6ea46c5b7684df3548e7ddeb9 c3bf9c73cc3f3bded74b562bfb19fb84
+022f8ef4cdd93795d77d06edbb7aaf2f 58891850abbdca3d20398c276456cbc4
+2158407dd074ee
+</pre><a href="#appendix-A.3-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="retry">
+<section id="appendix-A.4">
+        <h3 id="name-retry">
+<a href="#appendix-A.4" class="section-number selfRef">A.4. </a><a href="#name-retry" class="section-name selfRef">Retry</a>
+        </h3>
+<p id="appendix-A.4-1">This shows a Retry packet that might be sent in response to the Initial packet
+in <a href="#sample-client-initial" class="xref">Appendix A.2</a>. The integrity check includes the client-chosen
+connection ID value of 0x8394c8f03e515708, but that value is not
+included in the final Retry packet:<a href="#appendix-A.4-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.4-2">
+<pre>
+ff000000010008f067a5502a4262b574 6f6b656e04a265ba2eff4d829058fb3f
+0f2496ba
+</pre><a href="#appendix-A.4-2" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="chacha20-poly1305-short-header-packet">
+<section id="appendix-A.5">
+        <h3 id="name-chacha20-poly1305-short-hea">
+<a href="#appendix-A.5" class="section-number selfRef">A.5. </a><a href="#name-chacha20-poly1305-short-hea" class="section-name selfRef">ChaCha20-Poly1305 Short Header Packet</a>
+        </h3>
+<p id="appendix-A.5-1">This example shows some of the steps required to protect a packet with
+a short header.  This example uses AEAD_CHACHA20_POLY1305.<a href="#appendix-A.5-1" class="pilcrow">¶</a></p>
+<p id="appendix-A.5-2">In this example, TLS produces an application write secret from which a server
+uses HKDF-Expand-Label to produce four values: a key, an IV, a header
+protection key, and the secret that will be used after keys are updated (this
+last value is not used further in this example).<a href="#appendix-A.5-2" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.5-3">
+<pre>
+secret
+    = 9ac312a7f877468ebe69422748ad00a1
+      5443f18203a07d6060f688f30f21632b
+
+key = HKDF-Expand-Label(secret, "quic key", "", 32)
+    = c6d98ff3441c3fe1b2182094f69caa2e
+      d4b716b65488960a7a984979fb23e1c8
+
+iv  = HKDF-Expand-Label(secret, "quic iv", "", 12)
+    = e0459b3474bdd0e44a41c144
+
+hp  = HKDF-Expand-Label(secret, "quic hp", "", 32)
+    = 25a282b9e82f06f21f488917a4fc8f1b
+      73573685608597d0efcb076b0ab7a7a4
+
+ku  = HKDF-Expand-Label(secret, "quic ku", "", 32)
+    = 1223504755036d556342ee9361d25342
+      1a826c9ecdf3c7148684b36b714881f9
+</pre><a href="#appendix-A.5-3" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.5-4">The following shows the steps involved in protecting a minimal packet with an
+empty Destination Connection ID. This packet contains a single PING frame (that
+is, a payload of just 0x01) and has a packet number of 654360564. In this
+example, using a packet number of length 3 (that is, 49140 is encoded) avoids
+having to pad the payload of the packet; PADDING frames would be needed if the
+packet number is encoded on fewer bytes.<a href="#appendix-A.5-4" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.5-5">
+<pre>
+pn                 = 654360564 (decimal)
+nonce              = e0459b3474bdd0e46d417eb0
+unprotected header = 4200bff4
+payload plaintext  = 01
+payload ciphertext = 655e5cd55c41f69080575d7999c25a5bfb
+</pre><a href="#appendix-A.5-5" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.5-6">The resulting ciphertext is the minimum size possible. One byte is skipped to
+produce the sample for header protection.<a href="#appendix-A.5-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.5-7">
+<pre>
+sample = 5e5cd55c41f69080575d7999c25a5bfb
+mask   = aefefe7d03
+header = 4cfe4189
+</pre><a href="#appendix-A.5-7" class="pilcrow">¶</a>
+</div>
+<p id="appendix-A.5-8">The protected packet is the smallest possible packet size of 21 bytes.<a href="#appendix-A.5-8" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-A.5-9">
+<pre>
+packet = 4cfe4189655e5cd55c41f69080575d7999c25a5bfb
+</pre><a href="#appendix-A.5-9" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="aead-analysis">
+<section id="appendix-B">
+      <h2 id="name-aead-algorithm-analysis">
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-aead-algorithm-analysis" class="section-name selfRef">AEAD Algorithm Analysis</a>
+      </h2>
+<p id="appendix-B-1">This section documents analyses used in deriving AEAD algorithm limits for
+AEAD_AES_128_GCM, AEAD_AES_128_CCM, and AEAD_AES_256_GCM. The analyses that
+follow use symbols for multiplication (*), division (/), and exponentiation (^),
+plus parentheses for establishing precedence. The following symbols are also
+used:<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="appendix-B-2">
+        <dt id="appendix-B-2.1">t:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.2">
+          <p id="appendix-B-2.2.1">The size of the authentication tag in bits. For these ciphers, t is 128.<a href="#appendix-B-2.2.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-B-2.3">n:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.4">
+          <p id="appendix-B-2.4.1">The size of the block function in bits. For these ciphers, n is 128.<a href="#appendix-B-2.4.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-B-2.5">k:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.6">
+          <p id="appendix-B-2.6.1">The size of the key in bits. This is 128 for AEAD_AES_128_GCM and
+AEAD_AES_128_CCM; 256 for AEAD_AES_256_GCM.<a href="#appendix-B-2.6.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-B-2.7">l:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.8">
+          <p id="appendix-B-2.8.1">The number of blocks in each packet (see below).<a href="#appendix-B-2.8.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-B-2.9">q:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.10">
+          <p id="appendix-B-2.10.1">The number of genuine packets created and protected by endpoints. This value
+is the bound on the number of packets that can be protected before updating
+keys.<a href="#appendix-B-2.10.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-B-2.11">v:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.12">
+          <p id="appendix-B-2.12.1">The number of forged packets that endpoints will accept. This value is the
+bound on the number of forged packets that an endpoint can reject before
+updating keys.<a href="#appendix-B-2.12.1" class="pilcrow">¶</a></p>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-B-2.13">o:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-B-2.14">
+          <p id="appendix-B-2.14.1">The amount of offline ideal cipher queries made by an adversary.<a href="#appendix-B-2.14.1" class="pilcrow">¶</a></p>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="appendix-B-3">The analyses that follow rely on a count of the number of block operations
+involved in producing each message. This analysis is performed for packets of
+size up to 2<sup>11</sup> (l = 2<sup>7</sup>) and 2<sup>16</sup> (l =
+2<sup>12</sup>). A size of 2<sup>11</sup> is expected to be a limit that matches
+common deployment patterns, whereas the 2<sup>16</sup> is the maximum possible
+size of a QUIC packet. Only endpoints that strictly limit packet size can use
+the larger confidentiality and integrity limits that are derived using the
+smaller packet size.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
+<p id="appendix-B-4">For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the message length (l) is the length
+of the associated data in blocks plus the length of the plaintext in blocks.<a href="#appendix-B-4" class="pilcrow">¶</a></p>
+<p id="appendix-B-5">For AEAD_AES_128_CCM, the total number of block cipher operations is the sum of
+the following: the length of the associated data in blocks, the length of the
+ciphertext in blocks, the length of the plaintext in blocks, plus 1. In this
+analysis, this is simplified to a value of twice the length of the packet in
+blocks (that is, <code>2l = 2<sup>8</sup></code> for packets that are limited to
+2<sup>11</sup> bytes, or <code>2l = 2<sup>13</sup></code> otherwise). This
+simplification is based on the packet containing all of the associated data and
+ciphertext. This results in a one to three block overestimation of the number of
+operations per packet.<a href="#appendix-B-5" class="pilcrow">¶</a></p>
+<div id="gcm-bounds">
+<section id="appendix-B.1">
+        <h3 id="name-analysis-of-aead_aes_128_gc">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-analysis-of-aead_aes_128_gc" class="section-name selfRef">Analysis of AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits</a>
+        </h3>
+<p id="appendix-B.1-1"><span>[<a href="#GCM-MU" class="xref">GCM-MU</a>]</span> specifies concrete bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM
+as used in TLS 1.3 and QUIC. This section documents this analysis using several
+simplifying assumptions:<a href="#appendix-B.1-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="appendix-B.1-2.1">The number of ciphertext blocks an attacker uses in forgery attempts is
+bounded by v * l, which is the number of forgery attempts multiplied by the
+size of each packet (in blocks).<a href="#appendix-B.1-2.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="appendix-B.1-2.2">The amount of offline work done by an attacker does not dominate other factors
+in the analysis.<a href="#appendix-B.1-2.2" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="appendix-B.1-3">The bounds in <span>[<a href="#GCM-MU" class="xref">GCM-MU</a>]</span> are tighter and more complete than those used in
+<span>[<a href="#AEBounds" class="xref">AEBounds</a>]</span>, which allows for larger limits than those described in
+<span>[<a href="#TLS13" class="xref">TLS13</a>]</span>.<a href="#appendix-B.1-3" class="pilcrow">¶</a></p>
+<div id="confidentiality-limit">
+<section id="appendix-B.1.1">
+          <h4 id="name-confidentiality-limit">
+<a href="#appendix-B.1.1" class="section-number selfRef">B.1.1. </a><a href="#name-confidentiality-limit" class="section-name selfRef">Confidentiality Limit</a>
+          </h4>
+<p id="appendix-B.1.1-1">For confidentiality, Theorem (4.3) in <span>[<a href="#GCM-MU" class="xref">GCM-MU</a>]</span> establishes that, for a single
+user that does not repeat nonces, the dominant term in determining the
+distinguishing advantage between a real and random AEAD algorithm gained by an
+attacker is:<a href="#appendix-B.1.1-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.1.1-2">
+<pre>
+2 * (q * l)^2 / 2^n
+</pre><a href="#appendix-B.1.1-2" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.1.1-3">For a target advantage of 2<sup>-57</sup>, this results in the relation:<a href="#appendix-B.1.1-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.1.1-4">
+<pre>
+q &lt;= 2^35 / l
+</pre><a href="#appendix-B.1.1-4" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.1.1-5">Thus, endpoints that do not send packets larger than 2<sup>11</sup> bytes cannot
+protect more than 2<sup>28</sup> packets in a single connection without causing
+an attacker to gain a more significant advantage than the target of
+2<sup>-57</sup>. The limit for endpoints that allow for the packet size to be as
+large as 2<sup>16</sup> is instead 2<sup>23</sup>.<a href="#appendix-B.1.1-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="integrity-limit">
+<section id="appendix-B.1.2">
+          <h4 id="name-integrity-limit">
+<a href="#appendix-B.1.2" class="section-number selfRef">B.1.2. </a><a href="#name-integrity-limit" class="section-name selfRef">Integrity Limit</a>
+          </h4>
+<p id="appendix-B.1.2-1">For integrity, Theorem (4.3) in <span>[<a href="#GCM-MU" class="xref">GCM-MU</a>]</span> establishes that an attacker gains
+an advantage in successfully forging a packet of no more than the following:<a href="#appendix-B.1.2-1" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.1.2-2">
+<pre>
+(1 / 2^(8 * n)) + ((2 * v) / 2^(2 * n))
+        + ((2 * o * v) / 2^(k + n)) + (n * (v + (v * l)) / 2^k)
+</pre><a href="#appendix-B.1.2-2" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.1.2-3">The goal is to limit this advantage to 2<sup>-57</sup>.  For AEAD_AES_128_GCM,
+the fourth term in this inequality dominates the rest, so the others can be
+removed without significant effect on the result. This produces the following
+approximation:<a href="#appendix-B.1.2-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.1.2-4">
+<pre>
+v &lt;= 2^64 / l
+</pre><a href="#appendix-B.1.2-4" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.1.2-5">Endpoints that do not attempt to remove protection from packets larger than
+2<sup>11</sup> bytes can attempt to remove protection from at most
+2<sup>57</sup> packets. Endpoints that do not restrict the size of processed
+packets can attempt to remove protection from at most 2<sup>52</sup> packets.<a href="#appendix-B.1.2-5" class="pilcrow">¶</a></p>
+<p id="appendix-B.1.2-6">For AEAD_AES_256_GCM, the same term dominates, but the larger value of k
+produces the following approximation:<a href="#appendix-B.1.2-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.1.2-7">
+<pre>
+v &lt;= 2^192 / l
+</pre><a href="#appendix-B.1.2-7" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.1.2-8">This is substantially larger than the limit for AEAD_AES_128_GCM.  However, this
+document recommends that the same limit be applied to both functions as either
+limit is acceptably large.<a href="#appendix-B.1.2-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="ccm-bounds">
+<section id="appendix-B.2">
+        <h3 id="name-analysis-of-aead_aes_128_cc">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-analysis-of-aead_aes_128_cc" class="section-name selfRef">Analysis of AEAD_AES_128_CCM Usage Limits</a>
+        </h3>
+<p id="appendix-B.2-1">TLS <span>[<a href="#TLS13" class="xref">TLS13</a>]</span> and <span>[<a href="#AEBounds" class="xref">AEBounds</a>]</span> do not specify limits on usage
+for AEAD_AES_128_CCM. However, any AEAD that is used with QUIC requires limits
+on use that ensure that both confidentiality and integrity are preserved. This
+section documents that analysis.<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-2"><span>[<a href="#CCM-ANALYSIS" class="xref">CCM-ANALYSIS</a>]</span> is used as the basis of this
+analysis. The results of that analysis are used to derive usage limits that are
+based on those chosen in <span>[<a href="#TLS13" class="xref">TLS13</a>]</span>.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-3">For confidentiality, Theorem 2 in <span>[<a href="#CCM-ANALYSIS" class="xref">CCM-ANALYSIS</a>]</span> establishes that an attacker
+gains a distinguishing advantage over an ideal pseudorandom permutation (PRP) of
+no more than the following:<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.2-4">
+<pre>
+(2l * q)^2 / 2^n
+</pre><a href="#appendix-B.2-4" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.2-5">The integrity limit in Theorem 1 in <span>[<a href="#CCM-ANALYSIS" class="xref">CCM-ANALYSIS</a>]</span> provides an attacker a
+strictly higher advantage for the same number of messages. As the targets for
+the confidentiality advantage and the integrity advantage are the same, only
+Theorem 1 needs to be considered.<a href="#appendix-B.2-5" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-6">Theorem 1 establishes that an attacker gains an advantage over an
+ideal PRP of no more than the following:<a href="#appendix-B.2-6" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.2-7">
+<pre>
+v / 2^t + (2l * (v + q))^2 / 2^n
+</pre><a href="#appendix-B.2-7" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.2-8">As <code>t</code> and <code>n</code> are both 128, the first term is negligible relative to the
+second, so that term can be removed without a significant effect on the result.<a href="#appendix-B.2-8" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-9">This produces a relation that combines both encryption and decryption attempts
+with the same limit as that produced by the theorem for confidentiality alone.
+For a target advantage of 2<sup>-57</sup>, this results in the following:<a href="#appendix-B.2-9" class="pilcrow">¶</a></p>
+<div class="artwork art-text alignLeft" id="appendix-B.2-10">
+<pre>
+v + q &lt;= 2^34.5 / l
+</pre><a href="#appendix-B.2-10" class="pilcrow">¶</a>
+</div>
+<p id="appendix-B.2-11">By setting <code>q = v</code>, values for both confidentiality and integrity limits can be
+produced. Endpoints that limit packets to 2<sup>11</sup> bytes therefore have
+both confidentiality and integrity limits of 2<sup>26.5</sup> packets. Endpoints
+that do not restrict packet size have a limit of 2<sup>21.5</sup>.<a href="#appendix-B.2-11" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="contributors">
+<section id="appendix-C">
+      <h2 id="name-contributors">
+<a href="#name-contributors" class="section-name selfRef">Contributors</a>
+      </h2>
+<p id="appendix-C-1">The IETF QUIC Working Group received an enormous amount of support from many
+people. The following people provided substantive contributions to this
+document:<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="appendix-C-2.1">
+          <p id="appendix-C-2.1.1"><span class="contact-name">Adam Langley</span><a href="#appendix-C-2.1.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.2">
+          <p id="appendix-C-2.2.1"><span class="contact-name">Alessandro Ghedini</span><a href="#appendix-C-2.2.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.3">
+          <p id="appendix-C-2.3.1"><span class="contact-name">Christian Huitema</span><a href="#appendix-C-2.3.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.4">
+          <p id="appendix-C-2.4.1"><span class="contact-name">Christopher Wood</span><a href="#appendix-C-2.4.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.5">
+          <p id="appendix-C-2.5.1"><span class="contact-name">David Schinazi</span><a href="#appendix-C-2.5.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.6">
+          <p id="appendix-C-2.6.1"><span class="contact-name">Dragana Damjanovic</span><a href="#appendix-C-2.6.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.7">
+          <p id="appendix-C-2.7.1"><span class="contact-name">Eric Rescorla</span><a href="#appendix-C-2.7.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.8">
+          <p id="appendix-C-2.8.1"><span class="contact-name">Felix Günther</span><a href="#appendix-C-2.8.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.9">
+          <p id="appendix-C-2.9.1"><span class="contact-name">Ian Swett</span><a href="#appendix-C-2.9.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.10">
+          <p id="appendix-C-2.10.1"><span class="contact-name">Jana Iyengar</span><a href="#appendix-C-2.10.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.11">
+          <p id="appendix-C-2.11.1"><span class="contact-name"><span class="non-ascii">奥 一穂</span> (<span class="ascii">Kazuho Oku</span>)</span><a href="#appendix-C-2.11.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.12">
+          <p id="appendix-C-2.12.1"><span class="contact-name">Marten Seemann</span><a href="#appendix-C-2.12.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.13">
+          <p id="appendix-C-2.13.1"><span class="contact-name">Martin Duke</span><a href="#appendix-C-2.13.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.14">
+          <p id="appendix-C-2.14.1"><span class="contact-name">Mike Bishop</span><a href="#appendix-C-2.14.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.15">
+          <p id="appendix-C-2.15.1"><span class="contact-name">Mikkel Fahnøe Jørgensen</span><a href="#appendix-C-2.15.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.16">
+          <p id="appendix-C-2.16.1"><span class="contact-name">Nick Banks</span><a href="#appendix-C-2.16.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.17">
+          <p id="appendix-C-2.17.1"><span class="contact-name">Nick Harper</span><a href="#appendix-C-2.17.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.18">
+          <p id="appendix-C-2.18.1"><span class="contact-name">Roberto Peon</span><a href="#appendix-C-2.18.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.19">
+          <p id="appendix-C-2.19.1"><span class="contact-name">Rui Paulo</span><a href="#appendix-C-2.19.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.20">
+          <p id="appendix-C-2.20.1"><span class="contact-name">Ryan Hamilton</span><a href="#appendix-C-2.20.1" class="pilcrow">¶</a></p>
+</li>
+        <li class="compact" id="appendix-C-2.21">
+          <p id="appendix-C-2.21.1"><span class="contact-name">Victor Vasiliev</span><a href="#appendix-C-2.21.1" class="pilcrow">¶</a></p>
+</li>
+      </ul>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-D">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Martin Thomson (<span class="role">editor</span>)</span></div>
+<div dir="auto" class="left"><span class="org">Mozilla</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:mt@lowentropy.net" class="email">mt@lowentropy.net</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Sean Turner (<span class="role">editor</span>)</span></div>
+<div dir="auto" class="left"><span class="org">sn3rd</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:sean@sn3rd.com" class="email">sean@sn3rd.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/cli/xml2rfc/writers/base.py
+++ b/cli/xml2rfc/writers/base.py
@@ -2250,7 +2250,8 @@ class BaseV3Writer(object):
     def is_top_level_section(cls, num):
         return cls.level_of_section_num(num) == 1
 
-    @staticmethod
-    def is_appendix(pn):
+    appendix_pn_re = re.compile(r'^section-[a-z]\.|^section-appendix\.')
+    @classmethod
+    def is_appendix(cls, pn):
         """Is a section with this number an appendix?"""
-        return pn.startswith('section-appendix.')
+        return cls.appendix_pn_re.match(pn) is not None

--- a/cli/xml2rfc/writers/html.py
+++ b/cli/xml2rfc/writers/html.py
@@ -1173,7 +1173,7 @@ class HtmlWriter(BaseV3Writer):
             next  = x.getnext()
             if next is not None and next.tag == 'author':
                 after_next = next.getnext()
-                if after_next.tag != 'author':
+                if after_next is not None and after_next.tag != 'author':
                     after_next = None
             else:
                 next = None

--- a/cli/xml2rfc/writers/preptool.py
+++ b/cli/xml2rfc/writers/preptool.py
@@ -146,6 +146,15 @@ class PrepToolWriter(BaseV3Writer):
             self.attribute_defaults[tag] = sdict(dict( (k, defaults[k]) for k in keys if defaults[k] ))
         return copy.copy(self.attribute_defaults[tag])
 
+    def set_element_pn(self, elt, value):
+        existing_value = elt.get('pn', None)
+        if existing_value is None:
+            if self.prepped:
+                self.warn(elt, 'pn not set on element in prepped input, setting to {}'.format(value))
+            elt.set('pn', value)
+        elif existing_value != value:
+            self.warn(elt, 'using existing pn ({}) instead of generated pn ({})'.format(existing_value, value))
+
     def element(self, tag, line=None, **kwargs):
         attrib = self.get_attribute_defaults(tag)
         attrib.update(kwargs)
@@ -1282,18 +1291,18 @@ class PrepToolWriter(BaseV3Writer):
     #       pn='p-[section]-[counter]'
     def boilerplate_section_add_number(self, e, p):
         self.boilerplate_section_number += 1
-        e.set('pn', '%s-boilerplate.%s' % (pnprefix[e.tag], self.boilerplate_section_number, ))
+        self.set_element_pn(e, '%s-boilerplate.%s' % (pnprefix[e.tag], self.boilerplate_section_number, ))
 
     def toc_section_add_number(self, e, p):
         self.toc_section_number += 1
-        e.set('pn', '%s-toc.%s' % (pnprefix[e.tag], self.toc_section_number, ))
+        self.set_element_pn(e, '%s-toc.%s' % (pnprefix[e.tag], self.toc_section_number, ))
 
     def front_abstract_add_number(self, e, p):
-        e.set('pn', '%s-abstract' % pnprefix[e.tag])
+        self.set_element_pn(e, '%s-abstract' % pnprefix[e.tag])
 
     def front_note_add_number(self, e, p):
         self.note_number += 1
-        e.set('pn', '%s-note.%s' % (pnprefix[e.tag], self.note_number, ))
+        self.set_element_pn(e, '%s-note.%s' % (pnprefix[e.tag], self.note_number, ))
 
     def middle_section_add_number(self, e, p):
         level = len(list(e.iterancestors('section')))
@@ -1302,21 +1311,21 @@ class PrepToolWriter(BaseV3Writer):
         self.middle_section_number[level] += 1
         if level < self.prev_section_level:
             self.middle_section_number = self.middle_section_number[:level+1]
-        e.set('pn', '%s-%s' % (pnprefix[e.tag], '.'.join([ str(n) for n in self.middle_section_number ]), ))
+        self.set_element_pn(e, '%s-%s' % (pnprefix[e.tag], '.'.join([ str(n) for n in self.middle_section_number ]), ))
         self.prev_section_level = level
         self.references_number[0] = self.middle_section_number[0]
 
     def table_add_number(self, e, p):
         self.table_number += 1
-        e.set('pn', '%s-%s' % (pnprefix[e.tag], self.table_number, ))
+        self.set_element_pn(e, '%s-%s' % (pnprefix[e.tag], self.table_number, ))
 
     def figure_add_number(self, e, p):
         self.figure_number += 1
-        e.set('pn', '%s-%s' % (pnprefix[e.tag], self.figure_number, ))
+        self.set_element_pn(e, '%s-%s' % (pnprefix[e.tag], self.figure_number, ))
 
     def u_add_number(self, e, p):
         self.unicode_number += 1
-        e.set('pn', '%s-%s' % (pnprefix[e.tag], self.unicode_number, ))
+        self.set_element_pn(e, '%s-%s' % (pnprefix[e.tag], self.unicode_number, ))
 
     def references_add_number(self, e, p):
         level = len(list(e.iterancestors('references')))
@@ -1325,7 +1334,7 @@ class PrepToolWriter(BaseV3Writer):
         self.references_number[level] += 1
         if level < self.prev_references_level:
             self.references_number = self.references_number[:level+1]
-        e.set('pn', '%s-%s' % (pnprefix[e.tag], '.'.join([ str(n) for n in self.references_number ]), ))
+        self.set_element_pn(e, '%s-%s' % (pnprefix[e.tag], '.'.join([ str(n) for n in self.references_number ]), ))
         self.prev_references_level = level
 
     def back_section_add_number(self, e, p):
@@ -1340,7 +1349,7 @@ class PrepToolWriter(BaseV3Writer):
             # avoid running off the end of the alphabet when assigning appendix letters
             self.err(e, '<back> has at least %s sections, only 26 supported' % section_number[0])
         section_number[0] = chr(0x60+section_number[0])
-        e.set('pn', '%s-appendix.%s' % (pnprefix[e.tag], '.'.join([ str(n) for n in section_number ]), ))
+        self.set_element_pn(e, '%s-appendix.%s' % (pnprefix[e.tag], '.'.join([ str(n) for n in section_number ]), ))
         self.prev_section_level = level
 
     def paragraph_add_numbers(self, e, p):
@@ -1369,7 +1378,7 @@ class PrepToolWriter(BaseV3Writer):
                         debug.show('c.items()')
                     num[-1] += 1
                     if c.tag not in ['figure', 'table']:
-                        c.set('pn', prefix+num2str(num))
+                        self.set_element_pn(c, prefix+num2str(num))
                 elif c.tag in bloc_tags:
                     num[-1] += 1
                 if c.tag in sect_tags:
@@ -1417,7 +1426,7 @@ class PrepToolWriter(BaseV3Writer):
                 pn = slugify_name('%s-%s-%s-%s' % (pnprefix[e.tag], item, sub, self.iref_number))
             else:
                 pn = slugify_name('%s-%s-%s' % (pnprefix[e.tag], item, self.iref_number))
-            e.set('pn', pn)
+            self.set_element_pn(e, pn)
             anchor, anchor_tag = get_anchor(p)
             if not anchor:
                 self.err(e, "Did not find an anchor to use for <iref item='%s'> in <%s>" % (item, p.tag))

--- a/cli/xml2rfc/writers/preptool.py
+++ b/cli/xml2rfc/writers/preptool.py
@@ -1289,6 +1289,9 @@ class PrepToolWriter(BaseV3Writer):
     # 
     #    o  <artwork>, <aside>, <blockquote>, <dt>, <li>, <sourcecode>, <t>:
     #       pn='p-[section]-[counter]'
+    #
+    # N.B., the pn formats have changed from the above comment.
+    #
     def boilerplate_section_add_number(self, e, p):
         self.boilerplate_section_number += 1
         self.set_element_pn(e, '%s-boilerplate.%s' % (pnprefix[e.tag], self.boilerplate_section_number, ))


### PR DESCRIPTION
This addresses [ticket 664](https://trac.ietf.org/trac/xml2rfc/ticket/664).

Prepped XML files should already have pn attributes for all the relevant elements. These will match any references in xref elements that were, e.g., in a precomputed index or table of contents. When we changed the format of the pns we generate, this broke those precomputed xrefs.

This leaves any incoming pn values alone. These should ordinarily be present for every element on a prepped XML, so warnings are emitted if one is missing, and the value we would have assigned is given to it. (This may result in bad linking in some pathological cases, but the input really is not valid if this arises - and the user got a warning.) When passing through an existing pn, a warning is also emitted if the old value is different from the current value, as a hint that the prepped XML is out of date.

The HTML writer is updated to catch both old and new appendix pns when generating IDs for section elements.

This also fixes a corner case in the author list handling that broke several existing rfc documents.

You will note that there are no new tests. I plan to add one of the RFCs that was failing, but after beating my head against the tests for a few hours already, I still am not able to run them. When I get that sorted out, I will add a prepped rfc to tests/input and its expected output to the tests/valid and add it to the list run by the Makefile.